### PR TITLE
Add Korean i18n support with full UI localization (phases 1-3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,72 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build & Run
+
+```bash
+# One-command launch (recommended for development)
+chmod +x run.sh && ./run.sh
+
+# Build the main server binary
+go build -o cyberstrike-ai cmd/server/main.go
+
+# Run directly
+go run cmd/server/main.go
+# With explicit config path
+go run cmd/server/main.go --config config.yaml
+
+# Build MCP stdio binary (for Cursor/CLI integration)
+go build -o cyberstrike-ai-mcp cmd/mcp-stdio/main.go
+
+# Run tests
+go test ./...
+# Run a single package's tests
+go test ./internal/agent/...
+go test ./internal/security/...
+```
+
+## Architecture Overview
+
+CyberStrikeAI is a Go web server (`github.com/gin-gonic/gin`) exposing an AI-driven security testing platform. The entry point is `cmd/server/main.go`, which loads `config.yaml`, then delegates to `internal/app/app.go` which wires all subsystems together.
+
+### Core Data Flow
+
+```
+User/Web UI → Gin HTTP router → handler/* → agent.Agent → MCP Server → security.Executor → Tool execution
+```
+
+1. **`internal/agent/agent.go`** — The AI agent loop. Sends user messages to an OpenAI-compatible LLM, receives tool-call responses, executes them via the MCP server, and iterates until completion. Manages conversation history and memory compression (`memory_compressor.go`).
+
+2. **`internal/mcp/`** — MCP (Model Context Protocol) server implementation. `server.go` registers tools and dispatches calls; `external_manager.go` manages federated external MCP servers (HTTP/stdio/SSE transports). Tools exposed to the AI are registered here.
+
+3. **`internal/security/executor.go`** — Executes security tool commands from YAML definitions in `tools/*.yaml`. Handles large-result pagination (>200KB stored as artifacts in `tmp/`), result compression, and timeouts. Tools are registered into the MCP server.
+
+4. **`internal/handler/`** — Gin HTTP handlers, one file per domain: `agent.go` (AI loop + batch tasks), `conversation.go`, `monitor.go` (tool execution logs), `vulnerability.go`, `role.go`, `skills.go`, `knowledge.go`, `external_mcp.go`, `attackchain.go`, `robot.go` (DingTalk/Lark/WeCom), `config.go` (live config apply), etc.
+
+5. **`internal/database/`** — SQLite persistence via `mattn/go-sqlite3`. Stores conversations, tool executions, vulnerabilities, batch task queues, and optionally a separate `knowledge.db`.
+
+6. **`internal/knowledge/`** — Vector search knowledge base. `manager.go` scans `knowledge_base/` Markdown files, `indexer.go` builds embeddings (OpenAI API), `retriever.go` does hybrid vector+keyword search. Registered as `search_knowledge_base` MCP tool.
+
+7. **`internal/skills/`** — Loads `skills/*/SKILL.md` files. Registered as `list_skills` / `read_skill` MCP tools so the AI can access skill content on-demand.
+
+8. **`internal/robot/`** — Long-lived streaming connections for DingTalk and Lark (Feishu) chatbots. Started/restarted without server restart via `app.RestartRobotConnections()`.
+
+9. **`internal/app/app.go`** — The composition root. Initializes all subsystems, wires dependencies, registers MCP tools (including the built-in `record_vulnerability` tool inline), and sets up Gin routes via `setupRoutes()`.
+
+### Key Configuration
+
+`config.yaml` controls everything: OpenAI API credentials (`openai.*`), server/MCP ports, tool directory (`security.tools_dir`), roles directory (`roles_dir`), skills directory (`skills_dir`), knowledge base (`knowledge.*`), and chatbot credentials (`robots.*`).
+
+### Extension Points
+
+- **Add a tool**: Create `tools/<name>.yaml` with `name`, `command`, `args`, `parameters[]`, and `description`. No code changes needed.
+- **Add a role**: Create `roles/<name>.yaml` with `name`, `description`, `user_prompt`, `tools[]`, `skills[]`, `enabled`. No code changes needed.
+- **Add a skill**: Create `skills/<name>/SKILL.md`. Attach to roles via their YAML `skills` field.
+- **Add a knowledge item**: Place `.md` files in `knowledge_base/<category>/`. Scan and index via web UI or API (`POST /api/knowledge/scan`).
+
+### MCP Transports
+
+- **HTTP MCP**: Auto-started on `mcp.port` (default 8081) when `mcp.enabled: true`
+- **stdio MCP**: `cmd/mcp-stdio/main.go` for Cursor/CLI integration
+- **External MCP federation**: Managed via `internal/mcp/external_manager.go`, configured through `/api/external-mcp` endpoints

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -9,28 +9,28 @@ import (
 )
 
 func main() {
-	var configPath = flag.String("config", "config.yaml", "配置文件路径")
+	var configPath = flag.String("config", "config.yaml", "설정 파일 경로")
 	flag.Parse()
 
-	// 加载配置
+	// 설정 로드
 	cfg, err := config.Load(*configPath)
 	if err != nil {
-		fmt.Printf("加载配置失败: %v\n", err)
+		fmt.Printf("설정 로드 실패: %v\n", err)
 		return
 	}
 
-	// 初始化日志
+	// 로그 초기화
 	log := logger.New(cfg.Log.Level, cfg.Log.Output)
 
-	// 创建应用
+	// 애플리케이션 생성
 	application, err := app.New(cfg, log)
 	if err != nil {
-		log.Fatal("应用初始化失败", "error", err)
+		log.Fatal("애플리케이션 초기화 실패", "error", err)
 	}
 
-	// 启动服务器
+	// 서버 시작
 	if err := application.Run(); err != nil {
-		log.Fatal("服务器启动失败", "error", err)
+		log.Fatal("서버 시작 실패", "error", err)
 	}
 }
 

--- a/config.yaml
+++ b/config.yaml
@@ -1,173 +1,176 @@
 # ============================================
-# CyberStrikeAI 配置文件
+# CyberStrikeAI 설정 파일
 # ============================================
-# 本配置文件支持通过 Web 界面进行可视化配置
-# 点击右上角"设置"按钮即可修改配置
-# ============================================
-
-# ============================================
-# 系统设置
+# 이 설정 파일은 웹 인터페이스에서 시각적으로 수정할 수 있습니다
+# 우측 상단 "설정" 버튼을 클릭하여 변경하세요
 # ============================================
 
-# 前端显示的版本号（可选，不填则显示默认版本）
+# ============================================
+# 시스템 설정
+# ============================================
+
+# 프론트엔드에 표시할 버전 번호 (선택, 비워두면 기본 버전 표시)
 version: "v1.3.19"
 
-# 服务器配置
+# UI 언어 설정: cn (중국어) | ko (한국어)
+language: "ko"
+
+# 서버 설정
 server:
-  host: 0.0.0.0 # 监听地址，0.0.0.0 表示监听所有网络接口
-  port: 8080     # HTTP 服务端口，可通过浏览器访问 http://localhost:8080
+  host: 0.0.0.0 # 수신 주소, 0.0.0.0은 모든 네트워크 인터페이스에서 수신
+  port: 8080     # HTTP 서비스 포트, 브라우저에서 http://localhost:8080 으로 접속
 
-# 认证配置
+# 인증 설정
 auth:
-  password:  # Web 登录密码，请修改为强密码
-  session_duration_hours: 12          # 登录有效期（小时），超时后需重新登录
+  password: OUKK_dByUKWPkdhgu9ZeQfWk # 웹 로그인 비밀번호, 강력한 비밀번호로 변경하세요
+  session_duration_hours: 12          # 로그인 유효 시간 (시간 단위), 만료 후 재로그인 필요
 
-# 日志配置
+# 로그 설정
 log:
-  level: info   # 日志级别: debug(调试), info(信息), warn(警告), error(错误)
-  output: stdout # 日志输出位置: stdout(标准输出), stderr(标准错误), 或文件路径
+  level: info   # 로그 수준: debug(디버그), info(정보), warn(경고), error(오류)
+  output: stdout # 로그 출력 위치: stdout(표준 출력), stderr(표준 오류), 또는 파일 경로
 
 # ============================================
-# 对话相关配置
+# 대화 관련 설정
 # ============================================
 
-# AI 模型配置（支持 OpenAI 兼容 API）
-# 必填项：api_key, base_url, model 必须填写才能正常运行
-# 支持的 API 服务商：
+# AI 모델 설정 (OpenAI 호환 API 지원)
+# 필수 항목: api_key, base_url, model 을 반드시 입력해야 정상 작동합니다
+# 지원 API 서비스:
 #   - OpenAI: https://api.openai.com/v1
 #   - DeepSeek: https://api.deepseek.com/v1
-#   - 其他兼容 OpenAI 协议的 API
-# 常用模型: gpt-4, gpt-3.5-turbo, deepseek-chat, claude-3-opus 等
+#   - 기타 OpenAI 프로토콜 호환 API
+# 주요 모델: gpt-4, gpt-3.5-turbo, deepseek-chat, claude-3-opus 등
 openai:
-  base_url: https://api.deepseek.com/v1 # API 基础 URL（必填）
-  api_key: sk-xxxx                       # API 密钥（必填）
-  model: deepseek-chat                   # 模型名称（必填）
-  max_total_tokens: 120000              # LLM 相关上下文的最大 Token 数限制（内存压缩和攻击链构建会共用此配置）
+  base_url: https://api.deepseek.com/v1 # API 기본 URL (필수)
+  api_key: sk-xxxx                       # API 키 (필수)
+  model: deepseek-chat                   # 모델 이름 (필수)
+  max_total_tokens: 120000              # LLM 관련 컨텍스트 최대 토큰 수 (메모리 압축 및 공격 체인 구성에 공유 사용)
 
 # ============================================
-# 信息收集（FOFA）配置（可选）
+# 정보 수집 (FOFA) 설정 (선택)
 # ============================================
-# 用于「信息收集」页面调用 FOFA API（后端代理，避免前端暴露 key）
-# 也可通过环境变量配置：FOFA_EMAIL / FOFA_API_KEY（优先级更高）
+# 「정보 수집」 페이지에서 FOFA API 호출에 사용 (백엔드 프록시로 프론트엔드 key 노출 방지)
+# 환경 변수로도 설정 가능: FOFA_EMAIL / FOFA_API_KEY (우선순위 높음)
 fofa:
-  base_url: "https://fofa.info/api/v1/search/all" # 可选，留空则使用默认
-  email: ""   # FOFA 账号邮箱（可选，建议在系统设置中填写）
-  api_key: "" # FOFA API Key（可选，建议在系统设置中填写）
+  base_url: "https://fofa.info/api/v1/search/all" # 선택, 비워두면 기본값 사용
+  email: ""   # FOFA 계정 이메일 (선택, 시스템 설정에서 입력 권장)
+  api_key: "" # FOFA API Key (선택, 시스템 설정에서 입력 권장)
 
-# Agent 配置
-# 达到最大迭代次数时，AI 会自动总结测试结果
+# Agent 설정
+# 최대 반복 횟수에 도달하면 AI가 테스트 결과를 자동으로 요약합니다
 agent:
-  max_iterations: 120           # 最大迭代次数，AI 代理最多执行多少轮工具调用
-  large_result_threshold: 102400 # 大结果阈值（字节），默认50KB，超过此大小会自动保存到存储
-  result_storage_dir: tmp        # 结果存储目录，大结果会保存在此目录下
+  max_iterations: 120           # 최대 반복 횟수, AI 에이전트가 최대 몇 번의 도구 호출을 수행할지
+  large_result_threshold: 102400 # 대용량 결과 임계값 (바이트), 기본 100KB, 초과 시 스토리지에 자동 저장
+  result_storage_dir: tmp        # 결과 저장 디렉토리, 대용량 결과가 이 디렉토리에 저장됨
 
-# 数据库配置
+# 데이터베이스 설정
 database:
-  path: data/conversations.db    # SQLite 数据库文件路径，用于存储对话历史和消息
-  knowledge_db_path: data/knowledge.db # 知识库数据库文件路径（可选，为空则使用会话数据库），用于存储知识库项和向量嵌入，可独立复制和复用
+  path: data/conversations.db    # SQLite 데이터베이스 파일 경로, 대화 기록 및 메시지 저장용
+  knowledge_db_path: data/knowledge.db # 지식 베이스 데이터베이스 파일 경로 (선택, 비워두면 세션 데이터베이스 사용), 지식 항목 및 벡터 임베딩 저장, 독립적으로 복사 및 재사용 가능
 
 # ============================================
-# 任务管理相关配置
+# 작업 관리 관련 설정
 # ============================================
-# （配置项已包含在对话相关配置中）
+# (설정 항목은 대화 관련 설정에 포함됨)
 
 # ============================================
-# 漏洞管理相关配置
+# 취약점 관리 관련 설정
 # ============================================
 
-# 安全工具配置
-# 系统会从该目录加载所有 .yaml 格式的工具配置文件
-# 推荐方式：在 tools/ 目录下为每个工具创建独立的配置文件
+# 보안 도구 설정
+# 시스템은 해당 디렉토리에서 모든 .yaml 형식의 도구 설정 파일을 로드합니다
+# 권장 방식: tools/ 디렉토리 아래 각 도구별로 독립적인 설정 파일 생성
 security:
-  tools_dir: tools # 工具配置文件目录（相对于配置文件所在目录）
-  # 工具描述模式：加载 tools 下工具时，暴露给 AI/API 使用的描述来源
-  #   short - 优先使用 short_description（简短描述，省 token），为空时用 description
-  #   full  - 使用 description（详细描述）
+  tools_dir: tools # 도구 설정 파일 디렉토리 (설정 파일 위치 기준 상대 경로)
+  # 도구 설명 모드: tools 아래 도구 로드 시 AI/API에 노출할 설명 출처
+  #   short - short_description 우선 사용 (간략한 설명, 토큰 절약), 비어 있으면 description 사용
+  #   full  - description 사용 (상세 설명)
   tool_description_mode: full
 
 # ============================================
-# MCP 相关配置
+# MCP 관련 설정
 # ============================================
 
-# MCP 协议配置
-# MCP (Model Context Protocol) 用于工具注册和调用
+# MCP 프로토콜 설정
+# MCP (Model Context Protocol)는 도구 등록 및 호출에 사용됩니다
 mcp:
-  enabled: false # 是否启用 MCP 服务器（http模式）
-  host: 0.0.0.0  # MCP 服务器监听地址
-  port: 8081     # MCP 服务器端口
+  enabled: false # MCP 서버 활성화 여부 (http 모드)
+  host: 0.0.0.0  # MCP 서버 수신 주소
+  port: 8081     # MCP 서버 포트
 
-# 外部 MCP 配置
+# 외부 MCP 설정
 external_mcp:
   servers: {}
 
 # ============================================
-# 知识库相关配置
+# 지식 베이스 관련 설정
 # ============================================
 
 knowledge:
-  enabled: false                    # 是否启用知识检索功能
-  base_path: knowledge_base         # 知识库目录路径（相对于配置文件所在目录）
+  enabled: false                    # 지식 검색 기능 활성화 여부
+  base_path: knowledge_base         # 지식 베이스 디렉토리 경로 (설정 파일 위치 기준 상대 경로)
   embedding:
-    provider: openai                # 嵌入模型提供商（目前仅支持openai）
-    model: text-embedding-v4        # 嵌入模型名称
-    base_url: https://api.deepseek.com/v1 # 留空则使用OpenAI配置的base_url
-    api_key: sk-xxxxxx              # 留空则使用OpenAI配置的api_key
+    provider: openai                # 임베딩 모델 제공자 (현재 openai만 지원)
+    model: text-embedding-v4        # 임베딩 모델 이름
+    base_url: https://api.deepseek.com/v1 # 비워두면 OpenAI 설정의 base_url 사용
+    api_key: sk-xxxxxx              # 비워두면 OpenAI 설정의 api_key 사용
   retrieval:
-    top_k: 5                        # 检索返回的Top-K结果数量
-    similarity_threshold: 0.7       # 相似度阈值（0-1），低于此值的结果将被过滤
-    hybrid_weight: 0.7              # 混合检索权重（0-1），向量检索的权重，1.0表示纯向量检索，0.0表示纯关键词检索
+    top_k: 5                        # 검색 결과 Top-K 반환 수
+    similarity_threshold: 0.7       # 유사도 임계값 (0-1), 이 값 미만의 결과는 필터링
+    hybrid_weight: 0.7              # 혼합 검색 가중치 (0-1), 벡터 검색 가중치. 1.0=순수 벡터 검색, 0.0=순수 키워드 검색
   # ============================================
-  # 索引配置（用于解决 API 限制问题）
+  # 인덱싱 설정 (API 제한 문제 해결용)
   # ============================================
   indexing:
-    # 分块配置
-    chunk_size: 512 # 每个块的最大 token 数（默认 512），长文本会被分割成多个块
-    chunk_overlap: 50 # 块之间的重叠 token 数（默认 50），保持上下文连贯性
-    max_chunks_per_item: 0 # 单个知识项的最大块数量（0 表示不限制），防止单个文件消耗过多 API 配额
-    # 速率限制配置（解决 429 错误）
-    max_rpm: 0 # 每分钟最大请求数（默认 0 表示不限制），如 OpenAI 默认 200 RPM
-    rate_limit_delay_ms: 300 # 请求间隔毫秒数（默认 300），用于避免 API 速率限制，设为 0 不限制
-    # 建议值：200 次/分钟≈300ms, 100 次/分钟≈600ms
+    # 청크 설정
+    chunk_size: 512 # 청크당 최대 토큰 수 (기본 512), 긴 텍스트는 여러 청크로 분할
+    chunk_overlap: 50 # 청크 간 겹치는 토큰 수 (기본 50), 컨텍스트 연속성 유지
+    max_chunks_per_item: 0 # 지식 항목당 최대 청크 수 (0=제한 없음), 단일 파일의 과도한 API 할당량 소비 방지
+    # 속도 제한 설정 (429 오류 해결)
+    max_rpm: 0 # 분당 최대 요청 수 (기본 0=제한 없음), 예: OpenAI 기본 200 RPM
+    rate_limit_delay_ms: 300 # 요청 간격 밀리초 (기본 300), API 속도 제한 방지용. 0=제한 없음
+    # 권장값: 200회/분≈300ms, 100회/분≈600ms
 
-    # 重试配置
-    max_retries: 3 # 最大重试次数（默认 3），遇到速率限制或服务器错误时自动重试
-    retry_delay_ms: 1000 # 重试间隔毫秒数（默认 1000），每次重试会递增延迟
+    # 재시도 설정
+    max_retries: 3 # 최대 재시도 횟수 (기본 3), 속도 제한 또는 서버 오류 시 자동 재시도
+    retry_delay_ms: 1000 # 재시도 간격 밀리초 (기본 1000), 재시도마다 지연 시간 증가
 
 # ============================================
-# 机器人配置（企业微信、钉钉、飞书）
+# 봇 설정 (WeCom, DingTalk, Lark)
 # ============================================
-# 用于在手机端通过企业微信/钉钉/飞书与 CyberStrikeAI 对话，无需部署在服务器上也可使用
-# 在系统设置 -> 机器人设置 中可配置
+# 스마트폰에서 WeCom/DingTalk/Lark를 통해 CyberStrikeAI와 대화 가능, 서버 배포 불필요
+# 시스템 설정 → 봇 설정 에서 구성 가능
 robots:
-  wecom: # 企业微信
+  wecom: # 기업 WeChat (WeCom)
     enabled: false
     token: ""
     encoding_aes_key: ""
     corp_id: ""
     secret: ""
     agent_id: 0
-  dingtalk: # 钉钉
+  dingtalk: # DingTalk
     enabled: false
-    client_id: 
-    client_secret: 
-  lark: # 飞书
+    client_id:
+    client_secret:
+  lark: # Lark (Feishu)
     enabled: false
     app_id: ""
     app_secret: ""
     verify_token: ""
 
 # ============================================
-# Skills 相关配置
+# Skills 관련 설정
 # ============================================
 
-# 系统会从该目录加载所有skills，每个skill应是一个目录，包含SKILL.md文件
-# 例如：skills/sql-injection-testing/SKILL.md
-skills_dir: skills # Skills配置文件目录（相对于配置文件所在目录）
+# 시스템은 해당 디렉토리에서 모든 스킬을 로드합니다. 각 스킬은 SKILL.md 파일을 포함하는 디렉토리여야 합니다
+# 예시: skills/sql-injection-testing/SKILL.md
+skills_dir: skills # Skills 설정 파일 디렉토리 (설정 파일 위치 기준 상대 경로)
 
 # ============================================
-# 角色相关配置
+# 역할 관련 설정
 # ============================================
 
-# 系统会从该目录加载所有 .yaml 格式的角色配置文件
-# 每个角色应创建独立的配置文件，例如：roles/CTF.yaml, roles/默认.yaml 等
-roles_dir: roles # 角色配置文件目录（相对于配置文件所在目录）
+# 시스템은 해당 디렉토리에서 모든 .yaml 형식의 역할 설정 파일을 로드합니다
+# 각 역할은 독립적인 설정 파일로 생성 권장, 예: roles/CTF.yaml, roles/기본.yaml 등
+roles_dir: roles # 역할 설정 파일 디렉토리 (설정 파일 위치 기준 상대 경로)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -3,7 +3,9 @@ package app
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
+	"html/template"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -14,6 +16,7 @@ import (
 	"cyberstrike-ai/internal/config"
 	"cyberstrike-ai/internal/database"
 	"cyberstrike-ai/internal/handler"
+	"cyberstrike-ai/internal/i18n"
 	"cyberstrike-ai/internal/knowledge"
 	"cyberstrike-ai/internal/robot"
 	"cyberstrike-ai/internal/logger"
@@ -53,6 +56,24 @@ type App struct {
 
 // New 创建新应用
 func New(cfg *config.Config, log *logger.Logger) (*App, error) {
+	// 初始化 i18n（在所有组件之前）
+	messagesDir := filepath.Join(filepath.Dir(cfg.Database.Path), "..", "messages")
+	// 使用可执行文件所在目录的相对路径
+	if exePath, err := os.Executable(); err == nil {
+		messagesDir = filepath.Join(filepath.Dir(exePath), "messages")
+	}
+	// 如果 messages 目录不存在，尝试当前目录
+	if _, err := os.Stat(messagesDir); os.IsNotExist(err) {
+		messagesDir = "messages"
+	}
+	lang := cfg.Language
+	if lang == "" {
+		lang = "cn"
+	}
+	if err := i18n.Init(messagesDir, lang); err != nil {
+		log.Logger.Warn("i18n 初始化失败，使用默认语言", zap.Error(err))
+	}
+
 	gin.SetMode(gin.ReleaseMode)
 	router := gin.Default()
 
@@ -840,6 +861,7 @@ func setupRoutes(
 
 	// 静态文件
 	router.Static("/static", "./web/static")
+	router.SetFuncMap(template.FuncMap{"t": i18n.T})
 	router.LoadHTMLGlob("web/templates/*")
 
 	// 前端页面
@@ -848,7 +870,11 @@ func setupRoutes(
 		if version == "" {
 			version = "v1.0.0"
 		}
-		c.HTML(http.StatusOK, "index.html", gin.H{"Version": version})
+		i18nJSON, _ := json.Marshal(i18n.TemplateMap())
+		c.HTML(http.StatusOK, "index.html", gin.H{
+			"Version":  version,
+			"I18NJson": template.JS(i18nJSON),
+		})
 	})
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,6 +14,7 @@ import (
 
 type Config struct {
 	Version     string                `yaml:"version,omitempty" json:"version,omitempty"` // 前端显示的版本号，如 v1.3.3
+	Language    string                `yaml:"language,omitempty" json:"language,omitempty"` // UI 语言: cn (中文) | ko (한국어)
 	Server      ServerConfig          `yaml:"server"`
 	Log         LogConfig             `yaml:"log"`
 	MCP         MCPConfig             `yaml:"mcp"`
@@ -364,23 +365,21 @@ func PrintGeneratedPasswordWarning(password string, persisted bool, persistErr s
 	}
 
 	if persisted {
-		fmt.Println("[CyberStrikeAI] ✅ 已为您自动生成并写入 Web 登录密码。")
+		fmt.Println("[CyberStrikeAI] ✅ 웹 로그인 비밀번호가 자동 생성되어 config.yaml에 저장되었습니다.")
 	} else {
 		if persistErr != "" {
-			fmt.Printf("[CyberStrikeAI] ⚠️ 无法自动写入配置文件中的密码: %s\n", persistErr)
+			fmt.Printf("[CyberStrikeAI] ⚠️ 비밀번호를 설정 파일에 자동 저장하지 못했습니다: %s\n", persistErr)
 		} else {
-			fmt.Println("[CyberStrikeAI] ⚠️ 无法自动写入配置文件中的密码。")
+			fmt.Println("[CyberStrikeAI] ⚠️ 비밀번호를 설정 파일에 자동 저장하지 못했습니다.")
 		}
-		fmt.Println("请手动将以下随机密码写入 config.yaml 的 auth.password：")
+		fmt.Println("아래 자동 생성된 비밀번호를 config.yaml 의 auth.password 에 직접 입력해주세요:")
 	}
 
 	fmt.Println("----------------------------------------------------------------")
-	fmt.Println("CyberStrikeAI Auto-Generated Web Password")
-	fmt.Printf("Password: %s\n", password)
-	fmt.Println("WARNING: Anyone with this password can fully control CyberStrikeAI.")
-	fmt.Println("Please store it securely and change it in config.yaml as soon as possible.")
-	fmt.Println("警告：持有此密码的人将拥有对 CyberStrikeAI 的完全控制权限。")
-	fmt.Println("请妥善保管，并尽快在 config.yaml 中修改 auth.password！")
+	fmt.Println("CyberStrikeAI 자동 생성 웹 비밀번호")
+	fmt.Printf("비밀번호: %s\n", password)
+	fmt.Println("경고: 이 비밀번호를 가진 사람은 CyberStrikeAI를 완전히 제어할 수 있습니다.")
+	fmt.Println("안전하게 보관하고 가능한 빨리 config.yaml 에서 auth.password 를 변경하세요.")
 	fmt.Println("----------------------------------------------------------------")
 }
 
@@ -413,7 +412,7 @@ func LoadToolsFromDir(dir string) ([]ToolConfig, error) {
 		tool, err := LoadToolFromFile(filePath)
 		if err != nil {
 			// 记录错误但继续加载其他文件
-			fmt.Printf("警告: 加载工具配置文件 %s 失败: %v\n", filePath, err)
+			fmt.Printf("경고: 도구 설정 파일 로드 실패 %s: %v\n", filePath, err)
 			continue
 		}
 
@@ -475,7 +474,7 @@ func LoadRolesFromDir(dir string) (map[string]RoleConfig, error) {
 		role, err := LoadRoleFromFile(filePath)
 		if err != nil {
 			// 记录错误但继续加载其他文件
-			fmt.Printf("警告: 加载角色配置文件 %s 失败: %v\n", filePath, err)
+			fmt.Printf("경고: 역할 설정 파일 로드 실패 %s: %v\n", filePath, err)
 			continue
 		}
 

--- a/internal/handler/auth.go
+++ b/internal/handler/auth.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"cyberstrike-ai/internal/config"
+	"cyberstrike-ai/internal/i18n"
 	"cyberstrike-ai/internal/security"
 
 	"github.com/gin-gonic/gin"
@@ -43,13 +44,13 @@ type changePasswordRequest struct {
 func (h *AuthHandler) Login(c *gin.Context) {
 	var req loginRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "密码不能为空"})
+		c.JSON(http.StatusBadRequest, gin.H{"error": i18n.T("auth.error.password_empty")})
 		return
 	}
 
 	token, expiresAt, err := h.manager.Authenticate(req.Password)
 	if err != nil {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "密码错误"})
+		c.JSON(http.StatusUnauthorized, gin.H{"error": i18n.T("auth.error.password_wrong")})
 		return
 	}
 
@@ -73,14 +74,14 @@ func (h *AuthHandler) Logout(c *gin.Context) {
 	}
 
 	h.manager.RevokeToken(token)
-	c.JSON(http.StatusOK, gin.H{"message": "已退出登录"})
+	c.JSON(http.StatusOK, gin.H{"message": i18n.T("auth.message.logout")})
 }
 
 // ChangePassword updates the login password.
 func (h *AuthHandler) ChangePassword(c *gin.Context) {
 	var req changePasswordRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "参数无效"})
+		c.JSON(http.StatusBadRequest, gin.H{"error": i18n.T("auth.error.invalid_params")})
 		return
 	}
 
@@ -88,22 +89,22 @@ func (h *AuthHandler) ChangePassword(c *gin.Context) {
 	newPassword := strings.TrimSpace(req.NewPassword)
 
 	if oldPassword == "" || newPassword == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "当前密码和新密码均不能为空"})
+		c.JSON(http.StatusBadRequest, gin.H{"error": i18n.T("auth.error.passwords_required")})
 		return
 	}
 
 	if len(newPassword) < 8 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "新密码长度至少需要 8 位"})
+		c.JSON(http.StatusBadRequest, gin.H{"error": i18n.T("auth.error.password_too_short")})
 		return
 	}
 
 	if oldPassword == newPassword {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "新密码不能与旧密码相同"})
+		c.JSON(http.StatusBadRequest, gin.H{"error": i18n.T("auth.error.password_same")})
 		return
 	}
 
 	if !h.manager.CheckPassword(oldPassword) {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "当前密码不正确"})
+		c.JSON(http.StatusBadRequest, gin.H{"error": i18n.T("auth.error.password_incorrect")})
 		return
 	}
 
@@ -111,7 +112,7 @@ func (h *AuthHandler) ChangePassword(c *gin.Context) {
 		if h.logger != nil {
 			h.logger.Error("保存新密码失败", zap.Error(err))
 		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "保存新密码失败，请重试"})
+		c.JSON(http.StatusInternalServerError, gin.H{"error": i18n.T("auth.error.save_password_failed")})
 		return
 	}
 
@@ -119,7 +120,7 @@ func (h *AuthHandler) ChangePassword(c *gin.Context) {
 		if h.logger != nil {
 			h.logger.Error("更新认证配置失败", zap.Error(err))
 		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "更新认证配置失败"})
+		c.JSON(http.StatusInternalServerError, gin.H{"error": i18n.T("auth.error.update_config_failed")})
 		return
 	}
 
@@ -132,20 +133,20 @@ func (h *AuthHandler) ChangePassword(c *gin.Context) {
 		h.logger.Info("登录密码已更新，所有会话已失效")
 	}
 
-	c.JSON(http.StatusOK, gin.H{"message": "密码已更新，请使用新密码重新登录"})
+	c.JSON(http.StatusOK, gin.H{"message": i18n.T("auth.message.password_updated")})
 }
 
 // Validate returns the current session status.
 func (h *AuthHandler) Validate(c *gin.Context) {
 	token := c.GetString(security.ContextAuthTokenKey)
 	if token == "" {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "会话无效"})
+		c.JSON(http.StatusUnauthorized, gin.H{"error": i18n.T("auth.error.session_invalid")})
 		return
 	}
 
 	session, ok := h.manager.ValidateToken(token)
 	if !ok {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "会话已过期"})
+		c.JSON(http.StatusUnauthorized, gin.H{"error": i18n.T("auth.error.session_expired")})
 		return
 	}
 

--- a/internal/handler/config.go
+++ b/internal/handler/config.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"cyberstrike-ai/internal/config"
+	"cyberstrike-ai/internal/i18n"
 	"cyberstrike-ai/internal/knowledge"
 	"cyberstrike-ai/internal/mcp"
 	"cyberstrike-ai/internal/security"
@@ -697,7 +698,7 @@ func (h *ConfigHandler) UpdateConfig(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"message": "配置已更新"})
+	c.JSON(http.StatusOK, gin.H{"message": i18n.T("config.message.updated")})
 }
 
 // ApplyConfig 应用配置（重新加载并重启相关服务）
@@ -861,7 +862,7 @@ func (h *ConfigHandler) ApplyConfig(c *gin.Context) {
 	)
 
 	c.JSON(http.StatusOK, gin.H{
-		"message":     "配置已应用",
+		"message":     i18n.T("config.message.applied"),
 		"tools_count": len(h.config.Security.Tools),
 	})
 }

--- a/internal/handler/conversation.go
+++ b/internal/handler/conversation.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	"cyberstrike-ai/internal/database"
+	"cyberstrike-ai/internal/i18n"
 	"github.com/gin-gonic/gin"
 	"go.uber.org/zap"
 )
@@ -81,7 +82,7 @@ func (h *ConversationHandler) GetConversation(c *gin.Context) {
 	conv, err := h.db.GetConversation(id)
 	if err != nil {
 		h.logger.Error("获取对话失败", zap.Error(err))
-		c.JSON(http.StatusNotFound, gin.H{"error": "对话不存在"})
+		c.JSON(http.StatusNotFound, gin.H{"error": i18n.T("conversation.error.not_found")})
 		return
 	}
 
@@ -104,7 +105,7 @@ func (h *ConversationHandler) UpdateConversation(c *gin.Context) {
 	}
 
 	if req.Title == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "标题不能为空"})
+		c.JSON(http.StatusBadRequest, gin.H{"error": i18n.T("conversation.error.title_empty")})
 		return
 	}
 
@@ -135,6 +136,6 @@ func (h *ConversationHandler) DeleteConversation(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"message": "删除成功"})
+	c.JSON(http.StatusOK, gin.H{"message": i18n.T("common.message.deleted")})
 }
 

--- a/internal/handler/external_mcp.go
+++ b/internal/handler/external_mcp.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"cyberstrike-ai/internal/config"
+	"cyberstrike-ai/internal/i18n"
 	"cyberstrike-ai/internal/mcp"
 
 	"github.com/gin-gonic/gin"
@@ -86,7 +87,7 @@ func (h *ExternalMCPHandler) GetExternalMCP(c *gin.Context) {
 	configs := h.manager.GetConfigs()
 	cfg, exists := configs[name]
 	if !exists {
-		c.JSON(http.StatusNotFound, gin.H{"error": "外部MCP配置不存在"})
+		c.JSON(http.StatusNotFound, gin.H{"error": i18n.T("mcp.error.not_found")})
 		return
 	}
 
@@ -132,7 +133,7 @@ func (h *ExternalMCPHandler) AddOrUpdateExternalMCP(c *gin.Context) {
 
 	name := c.Param("name")
 	if name == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "名称不能为空"})
+		c.JSON(http.StatusBadRequest, gin.H{"error": i18n.T("mcp.error.name_empty")})
 		return
 	}
 
@@ -197,7 +198,7 @@ func (h *ExternalMCPHandler) AddOrUpdateExternalMCP(c *gin.Context) {
 	}
 
 	h.logger.Info("外部MCP配置已更新", zap.String("name", name))
-	c.JSON(http.StatusOK, gin.H{"message": "配置已更新"})
+	c.JSON(http.StatusOK, gin.H{"message": i18n.T("mcp.message.updated")})
 }
 
 // DeleteExternalMCP 删除外部MCP配置
@@ -209,7 +210,7 @@ func (h *ExternalMCPHandler) DeleteExternalMCP(c *gin.Context) {
 
 	// 移除配置
 	if err := h.manager.RemoveConfig(name); err != nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "配置不存在"})
+		c.JSON(http.StatusNotFound, gin.H{"error": i18n.T("mcp.error.config_not_found")})
 		return
 	}
 
@@ -226,7 +227,7 @@ func (h *ExternalMCPHandler) DeleteExternalMCP(c *gin.Context) {
 	}
 
 	h.logger.Info("外部MCP配置已删除", zap.String("name", name))
-	c.JSON(http.StatusOK, gin.H{"message": "配置已删除"})
+	c.JSON(http.StatusOK, gin.H{"message": i18n.T("mcp.message.deleted")})
 }
 
 // StartExternalMCP 启动外部MCP
@@ -272,7 +273,7 @@ func (h *ExternalMCPHandler) StartExternalMCP(c *gin.Context) {
 	// 立即返回，不等待连接完成
 	// 客户端会在后台异步连接，用户可以通过状态查询接口查看连接状态
 	c.JSON(http.StatusOK, gin.H{
-		"message": "外部MCP启动请求已提交，正在后台连接中",
+		"message": i18n.T("mcp.message.connecting"),
 		"status":  status,
 	})
 }
@@ -306,7 +307,7 @@ func (h *ExternalMCPHandler) StopExternalMCP(c *gin.Context) {
 	}
 
 	h.logger.Info("外部MCP已停止", zap.String("name", name))
-	c.JSON(http.StatusOK, gin.H{"message": "外部MCP已停止"})
+	c.JSON(http.StatusOK, gin.H{"message": i18n.T("mcp.message.stopped")})
 }
 
 // GetExternalMCPStats 获取统计信息

--- a/internal/handler/fofa.go
+++ b/internal/handler/fofa.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"cyberstrike-ai/internal/config"
+	"cyberstrike-ai/internal/i18n"
 	openaiClient "cyberstrike-ai/internal/openai"
 
 	"github.com/gin-gonic/gin"
@@ -116,23 +117,23 @@ func (h *FofaHandler) ParseNaturalLanguage(c *gin.Context) {
 	}
 	req.Text = strings.TrimSpace(req.Text)
 	if req.Text == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "text 不能为空"})
+		c.JSON(http.StatusBadRequest, gin.H{"error": i18n.T("fofa.error.text_empty")})
 		return
 	}
 
 	if h.cfg == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "系统配置未初始化"})
+		c.JSON(http.StatusInternalServerError, gin.H{"error": i18n.T("fofa.error.config_not_init")})
 		return
 	}
 	if strings.TrimSpace(h.cfg.OpenAI.APIKey) == "" || strings.TrimSpace(h.cfg.OpenAI.Model) == "" {
 		c.JSON(http.StatusBadRequest, gin.H{
-			"error": "未配置 AI 模型：请在系统设置中填写 openai.api_key 与 openai.model（支持 OpenAI 兼容 API，如 DeepSeek）",
+			"error": i18n.T("fofa.error.ai_not_configured"),
 			"need":  []string{"openai.api_key", "openai.model"},
 		})
 		return
 	}
 	if h.openAIClient == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "AI 客户端未初始化"})
+		c.JSON(http.StatusInternalServerError, gin.H{"error": i18n.T("fofa.error.ai_client_not_init")})
 		return
 	}
 
@@ -288,14 +289,14 @@ func (h *FofaHandler) ParseNaturalLanguage(c *gin.Context) {
 		var apiErr *openaiClient.APIError
 		if errors.As(err, &apiErr) {
 			h.logger.Warn("FOFA自然语言解析：LLM返回错误", zap.Int("status", apiErr.StatusCode))
-			c.JSON(http.StatusBadGateway, gin.H{"error": "AI 解析失败（上游返回非 200），请检查模型配置或稍后重试"})
+			c.JSON(http.StatusBadGateway, gin.H{"error": i18n.T("fofa.error.ai_parse_failed")})
 			return
 		}
 		c.JSON(http.StatusBadGateway, gin.H{"error": "AI 解析失败: " + err.Error()})
 		return
 	}
 	if len(apiResponse.Choices) == 0 {
-		c.JSON(http.StatusBadGateway, gin.H{"error": "AI 未返回有效结果"})
+		c.JSON(http.StatusBadGateway, gin.H{"error": i18n.T("fofa.error.ai_no_result")})
 		return
 	}
 
@@ -314,7 +315,7 @@ func (h *FofaHandler) ParseNaturalLanguage(c *gin.Context) {
 			snippet = snippet[:1200]
 		}
 		c.JSON(http.StatusBadGateway, gin.H{
-			"error":   "AI 返回内容无法解析为 JSON，请稍后重试或换个描述方式",
+			"error":   i18n.T("fofa.error.ai_json_parse_failed"),
 			"snippet": snippet,
 		})
 		return
@@ -340,7 +341,7 @@ func (h *FofaHandler) Search(c *gin.Context) {
 
 	req.Query = strings.TrimSpace(req.Query)
 	if req.Query == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "query 不能为空"})
+		c.JSON(http.StatusBadRequest, gin.H{"error": i18n.T("fofa.error.query_empty")})
 		return
 	}
 	if req.Size <= 0 {
@@ -360,7 +361,7 @@ func (h *FofaHandler) Search(c *gin.Context) {
 	email, apiKey := h.resolveCredentials()
 	if email == "" || apiKey == "" {
 		c.JSON(http.StatusBadRequest, gin.H{
-			"error":   "FOFA 未配置：请在系统设置中填写 FOFA Email/API Key，或设置环境变量 FOFA_EMAIL/FOFA_API_KEY",
+			"error":   i18n.T("fofa.error.fofa_not_configured"),
 			"need":    []string{"fofa.email", "fofa.api_key"},
 			"env_key": []string{"FOFA_EMAIL", "FOFA_API_KEY"},
 		})
@@ -405,7 +406,7 @@ func (h *FofaHandler) Search(c *gin.Context) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		c.JSON(http.StatusBadGateway, gin.H{"error": fmt.Sprintf("FOFA 返回非 2xx: %d", resp.StatusCode)})
+		c.JSON(http.StatusBadGateway, gin.H{"error": i18n.T("fofa.error.fofa_non_2xx", resp.StatusCode)})
 		return
 	}
 

--- a/internal/handler/monitor.go
+++ b/internal/handler/monitor.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"cyberstrike-ai/internal/database"
+	"cyberstrike-ai/internal/i18n"
 	"cyberstrike-ai/internal/mcp"
 	"cyberstrike-ai/internal/security"
 	"github.com/gin-gonic/gin"
@@ -243,7 +244,7 @@ func (h *MonitorHandler) GetExecution(c *gin.Context) {
 		}
 	}
 
-	c.JSON(http.StatusNotFound, gin.H{"error": "执行记录未找到"})
+	c.JSON(http.StatusNotFound, gin.H{"error": i18n.T("monitor.error.not_found")})
 }
 
 // GetStats 获取统计信息
@@ -256,7 +257,7 @@ func (h *MonitorHandler) GetStats(c *gin.Context) {
 func (h *MonitorHandler) DeleteExecution(c *gin.Context) {
 	id := c.Param("id")
 	if id == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "执行记录ID不能为空"})
+		c.JSON(http.StatusBadRequest, gin.H{"error": i18n.T("monitor.error.id_empty")})
 		return
 	}
 
@@ -267,7 +268,7 @@ func (h *MonitorHandler) DeleteExecution(c *gin.Context) {
 		if err != nil {
 			// 如果找不到记录，可能已经被删除，直接返回成功
 			h.logger.Warn("执行记录不存在，可能已被删除", zap.String("executionId", id), zap.Error(err))
-			c.JSON(http.StatusOK, gin.H{"message": "执行记录不存在或已被删除"})
+			c.JSON(http.StatusOK, gin.H{"message": i18n.T("monitor.message.already_deleted")})
 			return
 		}
 
@@ -297,14 +298,14 @@ func (h *MonitorHandler) DeleteExecution(c *gin.Context) {
 		}
 
 		h.logger.Info("执行记录已从数据库删除", zap.String("executionId", id), zap.String("toolName", exec.ToolName))
-		c.JSON(http.StatusOK, gin.H{"message": "执行记录已删除"})
+		c.JSON(http.StatusOK, gin.H{"message": i18n.T("monitor.message.deleted")})
 		return
 	}
 
 	// 如果不使用数据库，尝试从内存中删除（内部MCP服务器）
 	// 注意：内存中的记录可能已经被清理，所以这里只记录日志
 	h.logger.Info("尝试删除内存中的执行记录", zap.String("executionId", id))
-	c.JSON(http.StatusOK, gin.H{"message": "执行记录已删除（如果存在）"})
+	c.JSON(http.StatusOK, gin.H{"message": i18n.T("monitor.message.deleted_if_exists")})
 }
 
 // DeleteExecutions 批量删除执行记录
@@ -319,7 +320,7 @@ func (h *MonitorHandler) DeleteExecutions(c *gin.Context) {
 	}
 
 	if len(request.IDs) == 0 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "执行记录ID列表不能为空"})
+		c.JSON(http.StatusBadRequest, gin.H{"error": i18n.T("monitor.error.ids_empty")})
 		return
 	}
 
@@ -372,14 +373,14 @@ func (h *MonitorHandler) DeleteExecutions(c *gin.Context) {
 		}
 
 		h.logger.Info("批量删除执行记录成功", zap.Int("count", len(request.IDs)))
-		c.JSON(http.StatusOK, gin.H{"message": "成功删除执行记录", "deleted": len(executions)})
+		c.JSON(http.StatusOK, gin.H{"message": i18n.T("monitor.message.batch_deleted"), "deleted": len(executions)})
 		return
 	}
 
 	// 如果不使用数据库，尝试从内存中删除（内部MCP服务器）
 	// 注意：内存中的记录可能已经被清理，所以这里只记录日志
 	h.logger.Info("尝试批量删除内存中的执行记录", zap.Int("count", len(request.IDs)))
-	c.JSON(http.StatusOK, gin.H{"message": "执行记录已删除（如果存在）"})
+	c.JSON(http.StatusOK, gin.H{"message": i18n.T("monitor.message.deleted_if_exists")})
 }
 
 

--- a/internal/handler/role.go
+++ b/internal/handler/role.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"cyberstrike-ai/internal/config"
+	"cyberstrike-ai/internal/i18n"
 
 	"gopkg.in/yaml.v3"
 
@@ -90,18 +91,18 @@ func (h *RoleHandler) GetRoles(c *gin.Context) {
 func (h *RoleHandler) GetRole(c *gin.Context) {
 	roleName := c.Param("name")
 	if roleName == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "角色名称不能为空"})
+		c.JSON(http.StatusBadRequest, gin.H{"error": i18n.T("role.error.name_empty")})
 		return
 	}
 
 	if h.config.Roles == nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "角色不存在"})
+		c.JSON(http.StatusNotFound, gin.H{"error": i18n.T("role.error.not_found")})
 		return
 	}
 
 	role, exists := h.config.Roles[roleName]
 	if !exists {
-		c.JSON(http.StatusNotFound, gin.H{"error": "角色不存在"})
+		c.JSON(http.StatusNotFound, gin.H{"error": i18n.T("role.error.not_found")})
 		return
 	}
 
@@ -119,13 +120,13 @@ func (h *RoleHandler) GetRole(c *gin.Context) {
 func (h *RoleHandler) UpdateRole(c *gin.Context) {
 	roleName := c.Param("name")
 	if roleName == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "角色名称不能为空"})
+		c.JSON(http.StatusBadRequest, gin.H{"error": i18n.T("role.error.name_empty")})
 		return
 	}
 
 	var req config.RoleConfig
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "无效的请求参数: " + err.Error()})
+		c.JSON(http.StatusBadRequest, gin.H{"error": i18n.T("role.error.invalid_params", err.Error())})
 		return
 	}
 
@@ -203,13 +204,13 @@ func (h *RoleHandler) UpdateRole(c *gin.Context) {
 	// 保存配置到文件
 	if err := h.saveConfig(); err != nil {
 		h.logger.Error("保存配置失败", zap.Error(err))
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "保存配置失败: " + err.Error()})
+		c.JSON(http.StatusInternalServerError, gin.H{"error": i18n.T("role.error.invalid_params", err.Error())})
 		return
 	}
 
 	h.logger.Info("更新角色", zap.String("oldKey", roleName), zap.String("newKey", finalKey), zap.String("name", req.Name))
 	c.JSON(http.StatusOK, gin.H{
-		"message": "角色已更新",
+		"message": i18n.T("role.message.updated"),
 		"role":    req,
 	})
 }
@@ -218,12 +219,12 @@ func (h *RoleHandler) UpdateRole(c *gin.Context) {
 func (h *RoleHandler) CreateRole(c *gin.Context) {
 	var req config.RoleConfig
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "无效的请求参数: " + err.Error()})
+		c.JSON(http.StatusBadRequest, gin.H{"error": i18n.T("role.error.invalid_params", err.Error())})
 		return
 	}
 
 	if req.Name == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "角色名称不能为空"})
+		c.JSON(http.StatusBadRequest, gin.H{"error": i18n.T("role.error.name_empty")})
 		return
 	}
 
@@ -234,7 +235,7 @@ func (h *RoleHandler) CreateRole(c *gin.Context) {
 
 	// 检查角色是否已存在
 	if _, exists := h.config.Roles[req.Name]; exists {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "角色已存在"})
+		c.JSON(http.StatusBadRequest, gin.H{"error": i18n.T("role.error.already_exists")})
 		return
 	}
 
@@ -248,13 +249,13 @@ func (h *RoleHandler) CreateRole(c *gin.Context) {
 	// 保存配置到文件
 	if err := h.saveConfig(); err != nil {
 		h.logger.Error("保存配置失败", zap.Error(err))
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "保存配置失败: " + err.Error()})
+		c.JSON(http.StatusInternalServerError, gin.H{"error": i18n.T("role.error.invalid_params", err.Error())})
 		return
 	}
 
 	h.logger.Info("创建角色", zap.String("roleName", req.Name))
 	c.JSON(http.StatusOK, gin.H{
-		"message": "角色已创建",
+		"message": i18n.T("role.message.created"),
 		"role":    req,
 	})
 }
@@ -263,23 +264,23 @@ func (h *RoleHandler) CreateRole(c *gin.Context) {
 func (h *RoleHandler) DeleteRole(c *gin.Context) {
 	roleName := c.Param("name")
 	if roleName == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "角色名称不能为空"})
+		c.JSON(http.StatusBadRequest, gin.H{"error": i18n.T("role.error.name_empty")})
 		return
 	}
 
 	if h.config.Roles == nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "角色不存在"})
+		c.JSON(http.StatusNotFound, gin.H{"error": i18n.T("role.error.not_found")})
 		return
 	}
 
 	if _, exists := h.config.Roles[roleName]; !exists {
-		c.JSON(http.StatusNotFound, gin.H{"error": "角色不存在"})
+		c.JSON(http.StatusNotFound, gin.H{"error": i18n.T("role.error.not_found")})
 		return
 	}
 
 	// 不允许删除"默认"角色
 	if roleName == "默认" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "不能删除默认角色"})
+		c.JSON(http.StatusBadRequest, gin.H{"error": i18n.T("role.error.cannot_delete_default")})
 		return
 	}
 
@@ -322,7 +323,7 @@ func (h *RoleHandler) DeleteRole(c *gin.Context) {
 
 	h.logger.Info("删除角色", zap.String("roleName", roleName))
 	c.JSON(http.StatusOK, gin.H{
-		"message": "角色已删除",
+		"message": i18n.T("role.message.deleted"),
 	})
 }
 

--- a/internal/handler/skills.go
+++ b/internal/handler/skills.go
@@ -10,6 +10,7 @@ import (
 
 	"cyberstrike-ai/internal/config"
 	"cyberstrike-ai/internal/database"
+	"cyberstrike-ai/internal/i18n"
 	"cyberstrike-ai/internal/skills"
 
 	"github.com/gin-gonic/gin"
@@ -166,14 +167,14 @@ func (h *SkillsHandler) GetSkills(c *gin.Context) {
 func (h *SkillsHandler) GetSkill(c *gin.Context) {
 	skillName := c.Param("name")
 	if skillName == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "skill名称不能为空"})
+		c.JSON(http.StatusBadRequest, gin.H{"error": i18n.T("skill.error.name_empty")})
 		return
 	}
 
 	skill, err := h.manager.LoadSkill(skillName)
 	if err != nil {
 		h.logger.Warn("加载skill失败", zap.String("skill", skillName), zap.Error(err))
-		c.JSON(http.StatusNotFound, gin.H{"error": "skill不存在: " + err.Error()})
+		c.JSON(http.StatusNotFound, gin.H{"error": i18n.T("skill.error.not_found") + ": " + err.Error()})
 		return
 	}
 
@@ -218,7 +219,7 @@ func (h *SkillsHandler) GetSkill(c *gin.Context) {
 func (h *SkillsHandler) GetSkillBoundRoles(c *gin.Context) {
 	skillName := c.Param("name")
 	if skillName == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "skill名称不能为空"})
+		c.JSON(http.StatusBadRequest, gin.H{"error": i18n.T("skill.error.name_empty")})
 		return
 	}
 
@@ -266,13 +267,13 @@ func (h *SkillsHandler) CreateSkill(c *gin.Context) {
 	}
 
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "无效的请求参数: " + err.Error()})
+		c.JSON(http.StatusBadRequest, gin.H{"error": i18n.T("role.error.invalid_params", err.Error())})
 		return
 	}
 
 	// 验证skill名称（只允许字母、数字、连字符和下划线）
 	if !isValidSkillName(req.Name) {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "skill名称只能包含字母、数字、连字符和下划线"})
+		c.JSON(http.StatusBadRequest, gin.H{"error": i18n.T("skill.error.name_invalid")})
 		return
 	}
 
@@ -290,14 +291,14 @@ func (h *SkillsHandler) CreateSkill(c *gin.Context) {
 	skillDir := filepath.Join(skillsDir, req.Name)
 	if err := os.MkdirAll(skillDir, 0755); err != nil {
 		h.logger.Error("创建skill目录失败", zap.String("skill", req.Name), zap.Error(err))
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "创建skill目录失败: " + err.Error()})
+		c.JSON(http.StatusInternalServerError, gin.H{"error": i18n.T("skill.error.create_dir_failed", err.Error())})
 		return
 	}
 
 	// 检查是否已存在
 	skillFile := filepath.Join(skillDir, "SKILL.md")
 	if _, err := os.Stat(skillFile); err == nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "skill已存在"})
+		c.JSON(http.StatusBadRequest, gin.H{"error": i18n.T("skill.error.already_exists")})
 		return
 	}
 
@@ -320,13 +321,13 @@ func (h *SkillsHandler) CreateSkill(c *gin.Context) {
 	// 写入文件
 	if err := os.WriteFile(skillFile, []byte(content.String()), 0644); err != nil {
 		h.logger.Error("创建skill文件失败", zap.String("skill", req.Name), zap.Error(err))
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "创建skill文件失败: " + err.Error()})
+		c.JSON(http.StatusInternalServerError, gin.H{"error": i18n.T("skill.error.create_file_failed", err.Error())})
 		return
 	}
 
 	h.logger.Info("创建skill成功", zap.String("skill", req.Name))
 	c.JSON(http.StatusOK, gin.H{
-		"message": "skill已创建",
+		"message": i18n.T("skill.message.created"),
 		"skill": map[string]interface{}{
 			"name": req.Name,
 			"path": skillDir,
@@ -338,7 +339,7 @@ func (h *SkillsHandler) CreateSkill(c *gin.Context) {
 func (h *SkillsHandler) UpdateSkill(c *gin.Context) {
 	skillName := c.Param("name")
 	if skillName == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "skill名称不能为空"})
+		c.JSON(http.StatusBadRequest, gin.H{"error": i18n.T("skill.error.name_empty")})
 		return
 	}
 
@@ -348,7 +349,7 @@ func (h *SkillsHandler) UpdateSkill(c *gin.Context) {
 	}
 
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "无效的请求参数: " + err.Error()})
+		c.JSON(http.StatusBadRequest, gin.H{"error": i18n.T("role.error.invalid_params", err.Error())})
 		return
 	}
 
@@ -380,7 +381,7 @@ func (h *SkillsHandler) UpdateSkill(c *gin.Context) {
 			}
 		}
 		if !found {
-			c.JSON(http.StatusNotFound, gin.H{"error": "skill不存在"})
+			c.JSON(http.StatusNotFound, gin.H{"error": i18n.T("skill.error.not_found")})
 			return
 		}
 	}
@@ -389,7 +390,7 @@ func (h *SkillsHandler) UpdateSkill(c *gin.Context) {
 	existingContent, err := os.ReadFile(skillFile)
 	if err != nil {
 		h.logger.Error("读取skill文件失败", zap.String("skill", skillName), zap.Error(err))
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "读取skill文件失败: " + err.Error()})
+		c.JSON(http.StatusInternalServerError, gin.H{"error": i18n.T("skill.error.read_file_failed", err.Error())})
 		return
 	}
 
@@ -435,7 +436,7 @@ func (h *SkillsHandler) UpdateSkill(c *gin.Context) {
 	targetFile := filepath.Join(skillDir, "SKILL.md")
 	if err := os.WriteFile(targetFile, []byte(newContent.String()), 0644); err != nil {
 		h.logger.Error("更新skill文件失败", zap.String("skill", skillName), zap.Error(err))
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "更新skill文件失败: " + err.Error()})
+		c.JSON(http.StatusInternalServerError, gin.H{"error": i18n.T("skill.error.update_file_failed", err.Error())})
 		return
 	}
 
@@ -446,7 +447,7 @@ func (h *SkillsHandler) UpdateSkill(c *gin.Context) {
 
 	h.logger.Info("更新skill成功", zap.String("skill", skillName))
 	c.JSON(http.StatusOK, gin.H{
-		"message": "skill已更新",
+		"message": i18n.T("skill.message.updated"),
 	})
 }
 
@@ -454,7 +455,7 @@ func (h *SkillsHandler) UpdateSkill(c *gin.Context) {
 func (h *SkillsHandler) DeleteSkill(c *gin.Context) {
 	skillName := c.Param("name")
 	if skillName == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "skill名称不能为空"})
+		c.JSON(http.StatusBadRequest, gin.H{"error": i18n.T("skill.error.name_empty")})
 		return
 	}
 
@@ -484,10 +485,10 @@ func (h *SkillsHandler) DeleteSkill(c *gin.Context) {
 		return
 	}
 
-	responseMsg := "skill已删除"
+	responseMsg := i18n.T("skill.message.deleted")
 	if len(affectedRoles) > 0 {
-		responseMsg = fmt.Sprintf("skill已删除，已自动从 %d 个角色中移除绑定: %s", 
-			len(affectedRoles), strings.Join(affectedRoles, ", "))
+		responseMsg = fmt.Sprintf("%s，已自动从 %d 个角色中移除绑定: %s",
+			i18n.T("skill.message.deleted"), len(affectedRoles), strings.Join(affectedRoles, ", "))
 	}
 
 	h.logger.Info("删除skill成功", zap.String("skill", skillName))
@@ -578,7 +579,7 @@ func (h *SkillsHandler) GetSkillStats(c *gin.Context) {
 // ClearSkillStats 清空所有Skills统计信息
 func (h *SkillsHandler) ClearSkillStats(c *gin.Context) {
 	if h.db == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "数据库连接未配置"})
+		c.JSON(http.StatusInternalServerError, gin.H{"error": i18n.T("common.error.db_not_configured")})
 		return
 	}
 
@@ -590,7 +591,7 @@ func (h *SkillsHandler) ClearSkillStats(c *gin.Context) {
 
 	h.logger.Info("已清空所有Skills统计信息")
 	c.JSON(http.StatusOK, gin.H{
-		"message": "已清空所有Skills统计信息",
+		"message": i18n.T("skill.message.stats_cleared"),
 	})
 }
 
@@ -598,12 +599,12 @@ func (h *SkillsHandler) ClearSkillStats(c *gin.Context) {
 func (h *SkillsHandler) ClearSkillStatsByName(c *gin.Context) {
 	skillName := c.Param("name")
 	if skillName == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "skill名称不能为空"})
+		c.JSON(http.StatusBadRequest, gin.H{"error": i18n.T("skill.error.name_empty")})
 		return
 	}
 
 	if h.db == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "数据库连接未配置"})
+		c.JSON(http.StatusInternalServerError, gin.H{"error": i18n.T("common.error.db_not_configured")})
 		return
 	}
 
@@ -615,7 +616,7 @@ func (h *SkillsHandler) ClearSkillStatsByName(c *gin.Context) {
 
 	h.logger.Info("已清空指定skill统计信息", zap.String("skill", skillName))
 	c.JSON(http.StatusOK, gin.H{
-		"message": fmt.Sprintf("已清空skill '%s' 的统计信息", skillName),
+		"message": i18n.T("skill.message.stat_cleared", skillName),
 	})
 }
 

--- a/internal/handler/terminal.go
+++ b/internal/handler/terminal.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"time"
 
+	"cyberstrike-ai/internal/i18n"
+
 	"github.com/gin-gonic/gin"
 	"go.uber.org/zap"
 )
@@ -64,17 +66,17 @@ type RunCommandResponse struct {
 func (h *TerminalHandler) RunCommand(c *gin.Context) {
 	var req RunCommandRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "请求体无效，需要 command 字段"})
+		c.JSON(http.StatusBadRequest, gin.H{"error": i18n.T("terminal.error.invalid_body")})
 		return
 	}
 
 	cmdStr := strings.TrimSpace(req.Command)
 	if cmdStr == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "command 不能为空"})
+		c.JSON(http.StatusBadRequest, gin.H{"error": i18n.T("terminal.error.command_empty")})
 		return
 	}
 	if len(cmdStr) > terminalMaxCommandLen {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "命令过长"})
+		c.JSON(http.StatusBadRequest, gin.H{"error": i18n.T("terminal.error.command_too_long")})
 		return
 	}
 
@@ -102,14 +104,14 @@ func (h *TerminalHandler) RunCommand(c *gin.Context) {
 	if req.Cwd != "" {
 		absCwd, err := filepath.Abs(req.Cwd)
 		if err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "工作目录无效"})
+			c.JSON(http.StatusBadRequest, gin.H{"error": i18n.T("terminal.error.workdir_invalid")})
 			return
 		}
 		cur, _ := os.Getwd()
 		curAbs, _ := filepath.Abs(cur)
 		rel, err := filepath.Rel(curAbs, absCwd)
 		if err != nil || strings.HasPrefix(rel, "..") || rel == ".." {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "工作目录必须在当前进程目录下"})
+			c.JSON(http.StatusBadRequest, gin.H{"error": i18n.T("terminal.error.workdir_outside")})
 			return
 		}
 		cmd.Dir = absCwd
@@ -190,16 +192,16 @@ type streamEvent struct {
 func (h *TerminalHandler) RunCommandStream(c *gin.Context) {
 	var req RunCommandRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "请求体无效，需要 command 字段"})
+		c.JSON(http.StatusBadRequest, gin.H{"error": i18n.T("terminal.error.invalid_body")})
 		return
 	}
 	cmdStr := strings.TrimSpace(req.Command)
 	if cmdStr == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "command 不能为空"})
+		c.JSON(http.StatusBadRequest, gin.H{"error": i18n.T("terminal.error.command_empty")})
 		return
 	}
 	if len(cmdStr) > terminalMaxCommandLen {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "命令过长"})
+		c.JSON(http.StatusBadRequest, gin.H{"error": i18n.T("terminal.error.command_too_long")})
 		return
 	}
 	shell := req.Shell
@@ -223,14 +225,14 @@ func (h *TerminalHandler) RunCommandStream(c *gin.Context) {
 	if req.Cwd != "" {
 		absCwd, err := filepath.Abs(req.Cwd)
 		if err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "工作目录无效"})
+			c.JSON(http.StatusBadRequest, gin.H{"error": i18n.T("terminal.error.workdir_invalid")})
 			return
 		}
 		cur, _ := os.Getwd()
 		curAbs, _ := filepath.Abs(cur)
 		rel, err := filepath.Rel(curAbs, absCwd)
 		if err != nil || strings.HasPrefix(rel, "..") || rel == ".." {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "工作目录必须在当前进程目录下"})
+			c.JSON(http.StatusBadRequest, gin.H{"error": i18n.T("terminal.error.workdir_outside")})
 			return
 		}
 		cmd.Dir = absCwd

--- a/internal/handler/vulnerability.go
+++ b/internal/handler/vulnerability.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	"cyberstrike-ai/internal/database"
+	"cyberstrike-ai/internal/i18n"
 	"github.com/gin-gonic/gin"
 	"go.uber.org/zap"
 )
@@ -75,7 +76,7 @@ func (h *VulnerabilityHandler) GetVulnerability(c *gin.Context) {
 	vuln, err := h.db.GetVulnerability(id)
 	if err != nil {
 		h.logger.Error("获取漏洞失败", zap.Error(err))
-		c.JSON(http.StatusNotFound, gin.H{"error": "漏洞不存在"})
+		c.JSON(http.StatusNotFound, gin.H{"error": i18n.T("vuln.error.not_found")})
 		return
 	}
 
@@ -184,7 +185,7 @@ func (h *VulnerabilityHandler) UpdateVulnerability(c *gin.Context) {
 	// 获取现有漏洞
 	existing, err := h.db.GetVulnerability(id)
 	if err != nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "漏洞不存在"})
+		c.JSON(http.StatusNotFound, gin.H{"error": i18n.T("vuln.error.not_found")})
 		return
 	}
 
@@ -244,7 +245,7 @@ func (h *VulnerabilityHandler) DeleteVulnerability(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"message": "删除成功"})
+	c.JSON(http.StatusOK, gin.H{"message": i18n.T("common.message.deleted")})
 }
 
 // GetVulnerabilityStats 获取漏洞统计

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -1,0 +1,136 @@
+package i18n
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+var (
+	mu       sync.RWMutex
+	cnMap    = map[string]string{}
+	koMap    = map[string]string{}
+	language = "cn"
+)
+
+// Init loads message property files from the given directory and sets the active language.
+// It always loads message_cn.properties as the fallback, and optionally loads
+// message_ko.properties when language is "ko".
+func Init(messagesDir, lang string) error {
+	mu.Lock()
+	defer mu.Unlock()
+
+	if lang == "" {
+		lang = "cn"
+	}
+	language = lang
+
+	// Always load CN as fallback
+	cnPath := filepath.Join(messagesDir, "message_cn.properties")
+	loaded, err := loadProperties(cnPath)
+	if err != nil {
+		return fmt.Errorf("load message_cn.properties: %w", err)
+	}
+	cnMap = loaded
+
+	// Load KO if requested
+	koMap = map[string]string{}
+	if lang == "ko" {
+		koPath := filepath.Join(messagesDir, "message_ko.properties")
+		loadedKO, err := loadProperties(koPath)
+		if err == nil {
+			koMap = loadedKO
+		}
+		// Missing KO file is not fatal — falls back to CN
+	}
+
+	return nil
+}
+
+// T returns the translated string for the given key.
+// Lookup order: ko → cn → key itself.
+// Positional placeholders {0}, {1}, … are replaced with args.
+func T(key string, args ...interface{}) string {
+	mu.RLock()
+	defer mu.RUnlock()
+
+	msg := ""
+	if language == "ko" {
+		if v, ok := koMap[key]; ok {
+			msg = v
+		}
+	}
+	if msg == "" {
+		if v, ok := cnMap[key]; ok {
+			msg = v
+		}
+	}
+	if msg == "" {
+		msg = key
+	}
+
+	for i, arg := range args {
+		placeholder := fmt.Sprintf("{%d}", i)
+		msg = strings.ReplaceAll(msg, placeholder, fmt.Sprintf("%v", arg))
+	}
+	return msg
+}
+
+// Lang returns the currently active language code.
+func Lang() string {
+	mu.RLock()
+	defer mu.RUnlock()
+	return language
+}
+
+// TemplateMap returns a read-only copy of the merged translation map
+// (ko values override cn) suitable for JSON serialisation and injection
+// into HTML templates.
+func TemplateMap() map[string]string {
+	mu.RLock()
+	defer mu.RUnlock()
+
+	out := make(map[string]string, len(cnMap)+len(koMap))
+	for k, v := range cnMap {
+		out[k] = v
+	}
+	if language == "ko" {
+		for k, v := range koMap {
+			out[k] = v
+		}
+	}
+	return out
+}
+
+// loadProperties parses a Java-style .properties file.
+// Lines starting with '#' are treated as comments; blank lines are skipped.
+// Only the first '=' on a line separates key from value.
+func loadProperties(path string) (map[string]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	m := map[string]string{}
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		idx := strings.IndexByte(line, '=')
+		if idx < 0 {
+			continue
+		}
+		key := strings.TrimSpace(line[:idx])
+		val := strings.TrimSpace(line[idx+1:])
+		if key != "" {
+			m[key] = val
+		}
+	}
+	return m, scanner.Err()
+}

--- a/messages/message_cn.properties
+++ b/messages/message_cn.properties
@@ -1,0 +1,1095 @@
+# ============================================================
+# CyberStrikeAI - 中文 (Chinese) messages
+# ============================================================
+
+# ---- auth ----
+auth.error.password_empty=密码不能为空
+auth.error.password_wrong=密码错误
+auth.error.invalid_params=参数无效
+auth.error.passwords_required=当前密码和新密码均不能为空
+auth.error.password_too_short=新密码长度至少需要 8 位
+auth.error.password_same=新密码不能与旧密码相同
+auth.error.password_incorrect=当前密码不正确
+auth.error.save_password_failed=保存新密码失败，请重试
+auth.error.update_config_failed=更新认证配置失败
+auth.error.session_invalid=会话无效
+auth.error.session_expired=会话已过期
+auth.message.logout=已退出登录
+auth.message.password_updated=密码已更新，请使用新密码重新登录
+
+# ---- role ----
+role.error.name_empty=角色名称不能为空
+role.error.not_found=角色不存在
+role.error.invalid_params=无效的请求参数: {0}
+role.error.already_exists=角色已存在
+role.error.cannot_delete_default=不能删除默认角色
+role.message.updated=角色已更新
+role.message.created=角色已创建
+role.message.deleted=角色已删除
+
+# ---- skill ----
+skill.error.name_empty=skill名称不能为空
+skill.error.name_invalid=skill名称只能包含字母、数字、连字符和下划线
+skill.error.already_exists=skill已存在
+skill.error.not_found=skill不存在
+skill.message.created=skill已创建
+skill.message.updated=skill已更新
+skill.message.deleted=skill已删除
+skill.message.stats_cleared=已清空所有Skills统计信息
+skill.message.stat_cleared=已清空skill '{0}' 的统计信息
+skill.error.delete_failed=删除skill失败: {0}
+skill.error.create_dir_failed=创建skill目录失败: {0}
+skill.error.create_file_failed=创建skill文件失败: {0}
+skill.error.update_file_failed=更新skill文件失败: {0}
+skill.error.read_file_failed=读取skill文件失败: {0}
+
+# ---- vulnerability ----
+vuln.error.not_found=漏洞不存在
+
+# ---- conversation ----
+conversation.error.not_found=对话不存在
+conversation.error.title_empty=标题不能为空
+
+# ---- monitor ----
+monitor.error.not_found=执行记录未找到
+monitor.error.id_empty=执行记录ID不能为空
+monitor.error.ids_empty=执行记录ID列表不能为空
+monitor.message.already_deleted=执行记录不存在或已被删除
+monitor.message.deleted=执行记录已删除
+monitor.message.deleted_if_exists=执行记录已删除（如果存在）
+monitor.message.batch_deleted=成功删除执行记录
+
+# ---- config ----
+config.message.updated=配置已更新
+config.message.applied=配置已应用
+
+# ---- external mcp ----
+mcp.error.not_found=外部MCP配置不存在
+mcp.error.name_empty=名称不能为空
+mcp.error.config_not_found=配置不存在
+mcp.message.updated=配置已更新
+mcp.message.deleted=配置已删除
+mcp.message.connecting=外部MCP启动请求已提交，正在后台连接中
+mcp.message.stopped=外部MCP已停止
+
+# ---- terminal ----
+terminal.error.invalid_body=请求体无效，需要 command 字段
+terminal.error.command_empty=command 不能为空
+terminal.error.command_too_long=命令过长
+terminal.error.workdir_invalid=工作目录无效
+terminal.error.workdir_outside=工作目录必须在当前进程目录下
+
+# ---- fofa ----
+fofa.error.text_empty=text 不能为空
+fofa.error.config_not_init=系统配置未初始化
+fofa.error.ai_not_configured=未配置 AI 模型：请在系统设置中填写 openai.api_key 与 openai.model（支持 OpenAI 兼容 API，如 DeepSeek）
+fofa.error.ai_client_not_init=AI 客户端未初始化
+fofa.error.ai_parse_failed=AI 解析失败（上游返回非 200），请检查模型配置或稍后重试
+fofa.error.ai_no_result=AI 未返回有效结果
+fofa.error.ai_json_parse_failed=AI 返回内容无法解析为 JSON，请稍后重试或换个描述方式
+fofa.error.query_empty=query 不能为空
+fofa.error.fofa_not_configured=FOFA 未配置：请在系统设置中填写 FOFA Email/API Key，或设置环境变量 FOFA_EMAIL/FOFA_API_KEY
+fofa.error.fofa_non_2xx=FOFA 返回非 2xx: {0}
+
+# ---- common ----
+common.message.deleted=删除成功
+common.error.db_not_configured=数据库连接未配置
+
+# ---- nav (UI) ----
+nav.dashboard=仪表盘
+nav.chat=对话
+nav.vulnerability=漏洞管理
+nav.tasks=批量任务
+nav.knowledge=知识库
+nav.skills=Skills
+nav.roles=角色
+nav.tools=工具
+nav.monitor=监控
+nav.settings=设置
+nav.terminal=终端
+nav.info_collect=信息收集
+nav.attack_chain=攻击链
+
+# ---- login UI ----
+login.title=登录 CyberStrikeAI
+login.subtitle=请输入配置中的访问密码
+login.password_label=密码
+login.password_placeholder=输入登录密码
+login.submit=登录
+login.error.empty=请输入密码
+login.error.failed=密码错误，请重试
+
+# ---- dashboard ----
+dashboard.title=仪表盘
+dashboard.kpi.conversations=总对话数
+dashboard.kpi.tools=工具调用
+dashboard.kpi.vulnerabilities=发现漏洞
+dashboard.kpi.tasks=批量任务
+dashboard.recent_activity=最近活动
+dashboard.no_activity=暂无活动记录
+
+# ---- chat ----
+chat.placeholder=输入消息，Shift+Enter 换行，Enter 发送
+chat.btn.send=发送
+chat.btn.stop=停止
+chat.btn.new=新建对话
+chat.btn.clear=清空
+chat.thinking=思考中...
+chat.no_conversations=暂无对话
+chat.select_role=选择角色
+chat.select_model=选择模型
+
+# ---- settings ----
+settings.title=系统设置
+settings.save=保存配置
+settings.apply=应用配置
+settings.section.openai=AI 模型配置
+settings.section.agent=Agent 配置
+settings.section.auth=认证配置
+settings.section.robots=机器人配置
+settings.section.knowledge=知识库配置
+settings.saved=配置已保存
+settings.applied=配置已应用
+
+# ---- vulnerability UI ----
+vuln.title=漏洞管理
+vuln.btn.create=新建漏洞
+vuln.btn.export=导出
+vuln.severity.critical=严重
+vuln.severity.high=高危
+vuln.severity.medium=中危
+vuln.severity.low=低危
+vuln.severity.info=信息
+vuln.status.open=待修复
+vuln.status.in_progress=修复中
+vuln.status.resolved=已修复
+vuln.status.wont_fix=不修复
+vuln.no_data=暂无漏洞记录
+
+# ---- task UI ----
+task.title=批量任务
+task.btn.create=新建任务
+task.status.pending=等待中
+task.status.running=运行中
+task.status.completed=已完成
+task.status.failed=失败
+task.no_data=暂无任务记录
+
+# ---- knowledge UI ----
+knowledge.title=知识库
+knowledge.btn.scan=扫描文件
+knowledge.btn.index=建立索引
+knowledge.no_data=暂无知识条目
+
+# ---- skill UI ----
+skill.title=Skills 管理
+skill.btn.create=新建 Skill
+skill.no_data=暂无 Skill
+
+# ---- role UI ----
+role.title=角色管理
+role.btn.create=新建角色
+role.no_data=暂无角色
+role.error.load_failed=加载角色失败
+role.error.not_exists=角色不存在
+role.error.save_failed=保存角色失败
+role.error.delete_failed=删除角色失败
+role.message.refreshed=已刷新
+
+# ---- tool UI ----
+tool.title=工具管理
+tool.no_data=暂无工具
+
+# ---- monitor UI ----
+monitor.title=执行监控
+monitor.no_data=暂无执行记录
+monitor.btn.clear=清空记录
+
+# ---- common UI buttons ----
+ui.btn.edit=编辑
+ui.btn.delete=删除
+ui.btn.view=查看
+ui.btn.create=创建
+ui.btn.save=保存
+ui.btn.cancel=取消
+ui.btn.confirm=确认
+ui.btn.close=关闭
+ui.btn.stop=停止
+ui.btn.start=启动
+ui.btn.refresh=刷新
+ui.btn.export=导出
+ui.btn.clear=清空
+ui.btn.add=添加
+ui.btn.remove=移除
+ui.btn.download=下载
+ui.btn.enabled=已启用
+ui.btn.disabled=已禁用
+
+# ---- pagination ----
+ui.pagination.first=首页
+ui.pagination.prev=上一页
+ui.pagination.next=下一页
+ui.pagination.last=末页
+ui.pagination.page=第 {0} / {1} 页
+ui.pagination.showing=显示 {0}-{1} / 共 {2} 个
+
+# ---- common status ----
+ui.status.loading=加载中...
+ui.status.enabled=已启用
+ui.status.disabled=已禁用
+ui.empty.no_data=暂无数据
+ui.label.default=默认
+
+# ---- role extended ----
+role.btn.edit=编辑角色
+role.label.tools=工具:
+role.label.use_all_tools=使用所有工具
+role.label.external_tool=外部 ({0})
+role.label.external_mcp=外部MCP工具
+role.label.no_tools=暂无工具
+role.label.no_results=没有找到匹配的角色
+role.label.tool_count=显示 {0}-{1} / 共 {2} 个工具
+role.confirm.delete=确定要删除角色"{0}"吗？此操作不可撤销。
+role.label.skills_no_results=没有找到匹配的skills
+role.label.skills_selected={0} / {1} 已选择
+
+# ---- skill extended ----
+skill.btn.view=查看
+skill.btn.edit=编辑
+skill.label.description=描述:
+skill.label.path=路径:
+skill.label.mod_time=修改时间:
+skill.label.content=内容:
+skill.label.no_results=没有找到匹配的skills
+skill.label.no_skills=暂无skills，点击"创建Skill"创建第一个skill
+skill.modal.add=添加Skill
+skill.modal.edit=编辑Skill
+skill.modal.view=查看Skill: {0}
+skill.confirm.delete=确定要删除skill "{0}" 吗？此操作不可恢复。
+skill.confirm.delete_bound=⚠️ 该skill当前已被以下 {0} 个角色绑定
+skill.error.content_empty=skill内容不能为空
+skill.confirm.clear_stats=确定要清空所有Skills统计数据吗？此操作不可恢复。
+skill.stats.total=总Skills数
+skill.stats.total_calls=总调用次数
+skill.stats.success=成功调用
+skill.stats.failed=失败调用
+skill.stats.rate=成功率
+skill.stats.col_name=Skill名称
+skill.stats.col_total=总调用
+skill.stats.col_success=成功
+skill.stats.col_failed=失败
+skill.stats.col_rate=成功率
+skill.stats.col_last=最后调用时间
+
+# ---- task extended ----
+task.status.running=执行中
+task.status.cancelling=取消中
+task.status.failed=执行失败
+task.status.timeout=执行超时
+task.status.cancelled=已取消
+task.status.paused=已暂停
+task.label.recent=📜 最近完成的任务（最近24小时）
+task.btn.clear_history=清空历史
+task.label.unnamed=未命名任务
+task.label.conv_id=对话ID:
+task.label.queue_id=队列ID:
+task.label.created_at=创建时间:
+task.label.role=角色
+task.label.task_list=任务列表
+task.confirm.clear_history=确定要清空所有任务历史记录吗？
+task.confirm.cancel_selected=确定要取消 {0} 个任务吗？
+task.queue.status.pending=待执行
+task.queue.status.running=执行中
+task.queue.status.paused=已暂停
+task.queue.status.completed=已完成
+task.queue.status.cancelled=已取消
+
+# ---- vulnerability extended ----
+vuln.status.pending=待处理
+vuln.status.confirmed=已确认
+vuln.status.false_positive=误报
+vuln.btn.download_md=下载Markdown
+vuln.label.id=漏洞ID:
+vuln.label.type=类型:
+vuln.label.target=目标:
+vuln.label.session_id=会话ID:
+vuln.label.proof=证明:
+vuln.label.impact=影响:
+vuln.label.recommendation=修复建议:
+vuln.export.basic_info=## 基本信息
+vuln.export.description=## 描述
+vuln.export.proof=## 证明（POC）
+vuln.export.impact=## 影响
+vuln.export.recommendation=## 修复建议
+vuln.export.download_success=下载成功！
+
+# ---- settings extended ----
+settings.error.load_failed=获取配置失败
+settings.tools.loading=⏳ 正在加载工具列表...
+settings.tools.load_failed=获取工具列表失败
+settings.tools.no_tools=暂无工具
+settings.tools.showing=显示 {0}-{1} / 共 {2} 个工具
+settings.mcp.no_config=📋 暂无外部MCP配置
+settings.mcp.status.connected=已连接
+settings.mcp.status.connecting=连接中...
+settings.mcp.status.failed=连接失败
+settings.mcp.status.disabled=已禁用
+settings.mcp.btn.stop=停止
+settings.mcp.btn.start=启动
+settings.mcp.btn.connecting=连接中...
+settings.mcp.stats.total=总数:
+settings.mcp.stats.enabled=已启用:
+settings.mcp.stats.disabled=已停用:
+settings.mcp.stats.connected=已连接:
+settings.password.validation=请正确填写当前密码和新密码，新密码至少 8 位且需要两次输入一致。
+
+# ---- monitor extended ----
+monitor.status.running=🔍 渗透测试进行中...
+monitor.btn.stop_task=停止任务
+monitor.btn.collapse=收起详情
+monitor.btn.expand=展开详情
+monitor.label.no_details=暂无过程详情
+monitor.label.tool_calls=🔧 检测到 {0} 个工具调用
+monitor.label.calling_tool=🔧 调用工具: {0} ({1}/{2})
+monitor.label.cancelled=⛔ 任务已取消
+monitor.label.error=❌ 错误
+monitor.label.completed=✅ 渗透测试完成
+
+# ---- chat extended ----
+chat.file.default_prompt=请根据上传的文件内容进行分析。
+chat.file.max_exceeded=最多同时上传 {0} 个文件，当前已选 {1} 个。
+chat.file.read_failed=读取文件失败：{0}
+chat.btn.remove=移除
+chat.btn.remove_file=移除 {0}
+
+# ---- knowledge extended ----
+knowledge.disabled=知识库功能未启用
+knowledge.goto_settings=请前往系统设置启用知识检索功能
+knowledge.empty=暂无知识项
+
+# ---- fofa / info-collect ----
+fofa.status.querying=查询中...
+fofa.error.query_failed=查询失败
+fofa.label.input_placeholder=请输入自然语言描述
+fofa.ai.parsing=AI 解析中...
+fofa.ai.parsing_long=AI 解析耗时较长，仍在处理中…
+fofa.ai.result_title=AI 解析结果
+fofa.ai.natural_lang=自然语言
+fofa.ai.fofa_syntax=FOFA 查询语法
+fofa.ai.reminder=提醒
+fofa.ai.parse_notes=解析说明
+fofa.ai.result_empty=解析结果为空
+fofa.table.loading=加载中...
+fofa.table.summary=共 {0} 条 · 本页 {1} 条
+fofa.export.no_results=暂无可导出的结果
+fofa.export.no_xlsx=未加载 XLSX 库
+fofa.export.sheet_name=FOFA结果
+fofa.scan.no_results=暂无结果
+fofa.scan.select_rows=请先勾选需要扫描的行
+fofa.scan.title=FOFA 批量扫描
+
+# ---- terminal ----
+terminal.welcome=CyberStrikeAI 终端 - 真实 Shell 会话，直接输入命令；Ctrl+L 清屏\r\n
+terminal.session_closed=[会话已关闭]
+terminal.connect_error=[终端连接出错]
+terminal.connect_failed=[无法连接终端服务:
+terminal.hint=点击此处后输入命令
+terminal.tab_label=终端 {0}
+
+# ---- dashboard ----
+dashboard.loading=加载中…
+dashboard.no_call_data=暂无调用数据
+dashboard.status.not_enabled=未启用
+dashboard.status.enabled=已启用
+dashboard.status.pending=待配置
+dashboard.tool.pending=待使用
+dashboard.tool.active=活跃
+dashboard.tool.frequent=高频
+
+# ---- auth ----
+auth.error.expired=认证已过期，请重新登录
+auth.status.pending=等待中
+auth.status.running=执行中
+auth.status.completed=已完成
+auth.status.failed=失败
+
+# ---- ui common (added) ----
+ui.btn.copy=复制
+ui.btn.copied=已复制
+ui.btn.retry=重试
+ui.btn.close_tab=关闭
+ui.pagination.per_page=每页显示
+ui.status.searching=搜索中...
+ui.status.saving=保存中...
+
+# ---- chat (added) ----
+chat.mention.loading=正在加载工具...
+chat.mention.no_match=没有匹配的工具
+chat.btn.copy=复制
+chat.btn.copied=已复制
+chat.mcp.label=📋 渗透测试详情
+chat.mcp.call=调用 #{0}
+chat.details.expand=展开详情
+chat.details.collapse=收起详情
+chat.copy.failed=复制失败，请手动选择内容复制
+chat.no_response=暂无响应数据
+chat.progress.empty=暂无过程详情...
+chat.conv.delete_title=删除对话
+chat.conv.confirm_delete=确定要删除这个对话吗？此操作不可恢复。
+chat.conv.confirm_delete_selected=确定要删除选中的 {0} 条对话吗？
+chat.conv.no_selected=请先选择要删除的对话
+chat.conv.delete_failed=删除失败: {0}
+chat.conv.loading=加载中...
+chat.conv.load_failed=加载失败，请重试
+chat.conv.data_error=数据格式错误
+chat.conv.no_results=未找到匹配的对话
+chat.group.name_empty=请输入分组名称
+chat.group.name_exists=分组名称已存在，请使用其他名称
+chat.group.confirm_delete=确定要删除此分组吗？分组中的对话不会被删除。
+chat.attack.loading=加载中...
+chat.attack.regenerating=重新生成中...
+chat.attack.no_data=暂无攻击链数据
+chat.attack.load_failed=加载失败: {0}
+chat.attack.regen_failed=重新生成失败: {0}
+chat.attack.no_chain=请先加载攻击链
+chat.attack.export_failed=导出PNG失败: {0}
+chat.attack.export_failed2=导出失败: {0}
+chat.attack.unsupported=不支持的导出格式: {0}
+chat.attack.stats=节点: {0} | 边: {1}
+chat.attack.running=当前对话正在执行，请稍后再生成攻击链
+chat.attack.view=查看当前对话的攻击链
+chat.attack.select_conv=请选择一个对话以查看攻击链
+chat.pin.pin_conv=置顶此对话
+chat.pin.pin_group=置顶此分组
+chat.pin.failed=置顶失败: {0}
+chat.rename.failed=重命名失败: {0}
+chat.move.failed=移动失败: {0}
+chat.remove.failed=移除失败: {0}
+
+# ---- knowledge (added) ----
+knowledge.filter.all=全部
+knowledge.pagination.info=第 {0} 页，共 {1} 页（共 {2} 个分类）
+knowledge.stats.categories=总分类数
+knowledge.stats.current_cats=当前页分类
+knowledge.stats.current_items=当前页知识项
+knowledge.index.failed=索引构建失败
+knowledge.index.building=正在重建索引
+knowledge.index.progress=正在构建索引: {0}
+knowledge.index.complete=索引构建完成
+knowledge.index.status_failed=无法获取索引状态
+knowledge.modal.add=添加知识
+knowledge.modal.edit=编辑知识
+knowledge.confirm.delete_item=确定要删除这个知识项吗？
+knowledge.confirm.delete_record=确定要删除这条检索记录吗？
+knowledge.retrieval.empty=暂无检索记录
+knowledge.stats.total_retrievals=总检索次数
+knowledge.stats.success_retrievals=成功检索
+knowledge.label.conv_id=对话ID
+
+# ---- tasks (added) ----
+task.role.default=默认
+task.alert.empty_input=请输入至少一个任务
+task.alert.no_valid=没有有效的任务
+task.alert.incomplete=任务信息不完整
+task.alert.message_empty=任务消息不能为空
+task.alert.cancel_result=批量取消完成：成功 {0} 个，失败 {1} 个
+task.alert.cancel_success=成功取消 {0} 个任务
+task.confirm.pause_queue=确定要暂停这个批量任务队列吗？当前正在执行的任务将被停止。
+task.confirm.delete_queue=确定要删除这个批量任务队列吗？此操作不可恢复。
+task.confirm.delete_task=确定要删除这个任务吗？
+
+# ---- monitor (added) ----
+monitor.alert.not_synced=任务信息尚未同步，请稍后再试。
+monitor.alert.cancel_failed=取消任务失败: {0}
+monitor.error.load_stats=无法加载统计信息：{0}
+monitor.error.load_records=无法加载执行记录：{0}
+monitor.label.no_calls=暂无调用
+monitor.confirm.delete_record=确定要删除此执行记录吗？此操作不可恢复。
+monitor.alert.delete_failed=删除执行记录失败: {0}
+monitor.alert.no_selected=请先选择要删除的执行记录
+monitor.confirm.delete_selected=确定要删除选中的 {0} 条执行记录吗？此操作不可恢复。
+monitor.alert.batch_delete_failed=批量删除执行记录失败: {0}
+
+# ---- settings (added) ----
+settings.mcp.modal.add=添加外部MCP
+settings.mcp.modal.edit=编辑外部MCP
+settings.mcp.confirm.delete=确定要删除外部MCP "{0}" 吗？
+settings.mcp.error.json_empty=JSON不能为空
+settings.mcp.error.json_invalid=JSON格式错误: {0}
+settings.mcp.error.config_empty=JSON配置不能为空
+settings.mcp.error.not_object=配置错误: 必须是JSON对象格式
+settings.mcp.error.no_items=配置错误: 至少需要一个配置项
+settings.mcp.error.name_empty=配置错误: 配置名称不能为空
+settings.mcp.error.item_not_object=配置错误: "{0}" 的配置必须是对象
+settings.mcp.error.no_transport=配置错误: "{0}" 需要指定command或url
+settings.mcp.error.stdio_cmd=配置错误: "{0}" stdio模式需要command字段
+settings.mcp.error.http_url=配置错误: "{0}" http模式需要url字段
+settings.mcp.error.sse_url=配置错误: "{0}" sse模式需要url字段
+settings.mcp.error.edit_missing=配置错误: 编辑模式下JSON必须包含配置名称
+settings.mcp.error.save_failed=保存失败: {0}
+
+# ---- auth (added) ----
+auth.error.login_failed=登录失败，请检查密码
+auth.error.login_retry=登录失败，请稍后重试
+auth.message.logged_out=已退出登录
+
+# ---- terminal (added) ----
+terminal.load_error=未加载 xterm.js，请刷新页面或检查网络。
+
+# ---- fofa / info-collect (added) ----
+fofa.alert.query_empty=请输入 FOFA 查询语法
+fofa.alert.query_failed2=FOFA 查询失败: {0}
+fofa.alert.lang_empty=请输入自然语言描述
+fofa.btn.cancel_parse=点击取消 AI 解析
+fofa.btn.start_parse=将自然语言解析为 FOFA 查询语法
+fofa.label.selected=已选择 {0} 条
+fofa.btn.select_all=全选/全不选
+fofa.alert.no_targets=没有可复制的目标
+fofa.alert.copy_failed=复制失败，请手动复制：{0}
+fofa.alert.infer_failed=无法从该行推断扫描目标
+fofa.alert.no_send=未找到 sendMessage()，请刷新页面后重试
+fofa.alert.no_scan_targets=未能从所选行推断任何可扫描目标
+fofa.alert.scan_failed=批量扫描失败: {0}
+fofa.toast.copied=已复制
+fofa.alert.copy_failed2=复制失败
+
+# ---- roles (added) ----
+role.label.default_name=默认
+role.info.first_role_all_tools=检测到这是首次添加角色且未选择工具，将默认使用全部工具
+
+# ---- nav (added) ----
+nav.version_title=当前版本
+nav.api_docs=API 文档
+nav.api_docs_title=OpenAPI 文档
+nav.logout=退出登录
+nav.sidebar_toggle=折叠/展开侧边栏
+nav.user_menu=用户菜单
+
+# ---- index.html UI (phase 3) ----
+
+# -- nav submenu --
+nav.mcp_monitor=MCP状态监控
+nav.mcp_management=MCP管理
+nav.knowledge_retrieval_logs=检索历史
+nav.knowledge_management=知识管理
+nav.skills_monitor=Skills状态监控
+nav.skills_management=Skills管理
+nav.roles_management=角色管理
+
+# -- dashboard section --
+dashboard.section.vuln_severity=漏洞严重程度分布
+dashboard.section.run_overview=运行概览
+dashboard.section.quick_links=快捷入口
+dashboard.section.tool_exec_count=工具执行次数
+dashboard.kpi.running_tasks=运行中任务
+dashboard.kpi.vuln_total=漏洞总数
+dashboard.kpi.tool_calls=工具调用次数
+dashboard.kpi.tool_success_rate=工具执行成功率
+dashboard.kpi.click_tasks=点击查看任务管理
+dashboard.kpi.click_vulns=点击查看漏洞管理
+dashboard.kpi.click_mcp=点击查看 MCP 监控
+dashboard.overview.batch_queue=批量任务队列
+dashboard.overview.pending=待执行
+dashboard.overview.running=执行中
+dashboard.overview.done=已完成
+dashboard.overview.tool_calls=工具调用
+dashboard.overview.calls_unit=次调用
+dashboard.overview.tools_unit=个工具
+dashboard.overview.knowledge=知识
+dashboard.overview.knowledge_items_unit=项知识
+dashboard.overview.knowledge_categories_unit=个分类
+dashboard.overview.skills_calls_unit=次调用
+dashboard.overview.skills_count_unit=个 Skill
+dashboard.cta.title=开始你的安全之旅
+dashboard.cta.subtitle=在对话中描述目标，AI 将协助执行扫描与漏洞分析
+dashboard.cta.btn=前往对话
+dashboard.no_data=暂无数据
+
+# -- quick links --
+dashboard.quick.chat=对话
+dashboard.quick.tasks=任务管理
+dashboard.quick.vulns=漏洞管理
+dashboard.quick.mcp=MCP 管理
+dashboard.quick.knowledge=知识管理
+dashboard.quick.skills=Skills 管理
+dashboard.quick.roles=角色管理
+
+# -- chat page --
+chat.sidebar.new=新对话
+chat.sidebar.search_placeholder=搜索历史记录...
+chat.sidebar.clear_search=清除搜索
+chat.sidebar.groups_title=对话分组
+chat.sidebar.new_group=新建分组
+chat.sidebar.recent_title=最近对话
+chat.sidebar.batch_manage=批量管理
+chat.group.search_placeholder=搜索分组中的对话...
+chat.group.clear_search=清除搜索
+chat.group.search=搜索
+chat.group.edit=编辑
+chat.group.delete=删除
+chat.attack_chain.btn=攻击链
+chat.attack_chain.view_title=查看攻击链
+chat.role.select_title=选择角色
+chat.role.select_heading=选择角色
+chat.role.close=关闭
+chat.role.default=默认
+chat.file.selected_label=已选文件列表
+chat.input.placeholder=输入测试目标或命令... (输入 @ 选择工具 | Shift+Enter 换行，Enter 发送)
+chat.input.mention_label=工具提及候选
+chat.file.select=选择文件
+chat.file.upload_title=上传文件（可多选或拖拽到此处）
+chat.btn.send_label=发送
+
+# -- MCP monitor page --
+mcp_monitor.title=MCP 状态监控
+mcp_monitor.exec_stats=执行统计
+mcp_monitor.latest_records=最新执行记录
+mcp_monitor.tool_search=工具搜索
+mcp_monitor.tool_search_placeholder=输入工具名称...
+mcp_monitor.status_filter=状态筛选
+mcp_monitor.status.all=全部
+mcp_monitor.status.completed=已完成
+mcp_monitor.status.running=执行中
+mcp_monitor.status.failed=失败
+mcp_monitor.selected_count=已选择 0 项
+mcp_monitor.select_all=全选
+mcp_monitor.deselect_all=取消全选
+mcp_monitor.batch_delete=批量删除
+
+# -- MCP management page --
+mcp_mgmt.title=MCP 管理
+mcp_mgmt.add_external=添加外部MCP
+mcp_mgmt.tool_config=MCP 工具配置
+mcp_mgmt.save_tool_config=保存工具配置
+mcp_mgmt.select_all=全选
+mcp_mgmt.deselect_all=全不选
+mcp_mgmt.search_placeholder=搜索工具...
+mcp_mgmt.search=搜索
+mcp_mgmt.external_config=外部 MCP 配置
+
+# -- knowledge management page --
+knowledge_mgmt.title=知识管理
+knowledge_mgmt.rebuild_index=重建索引
+knowledge_mgmt.add_knowledge=添加知识
+knowledge_mgmt.total_items=总知识项
+knowledge_mgmt.categories_count=分类数
+knowledge_mgmt.total_content=总内容
+knowledge_mgmt.category_filter=分类筛选
+knowledge_mgmt.all=全部
+knowledge_mgmt.search_placeholder=搜索知识...
+
+# -- knowledge retrieval logs page --
+knowledge_retrieval.title=检索历史
+knowledge_retrieval.total=总检索次数
+knowledge_retrieval.success=成功检索
+knowledge_retrieval.success_rate=成功率
+knowledge_retrieval.items_found=检索到知识项
+knowledge_retrieval.conv_id=对话ID
+knowledge_retrieval.conv_placeholder=可选：筛选特定对话
+knowledge_retrieval.msg_id=消息ID
+knowledge_retrieval.msg_placeholder=可选：筛选特定消息
+knowledge_retrieval.filter=筛选
+
+# -- info collect (FOFA) page --
+info_collect.title=信息收集
+info_collect.reset=重置
+info_collect.submit=确定
+info_collect.fofa_query=FOFA 查询语法
+info_collect.fofa_query_hint=查询语法参考 FOFA 文档，支持 && / || / () 等。
+info_collect.preset.apache_cn=Apache + 中国
+info_collect.preset.login_cn=登录页 + 中国
+info_collect.preset.domain=指定域名
+info_collect.preset.ip=指定 IP
+info_collect.preset.fill_hint=填入示例
+info_collect.nl_label=自然语言（AI 解析为 FOFA 语法）
+info_collect.nl_placeholder=例如：找美国 Missouri 的 Apache 站点，标题包含 Home
+info_collect.nl_parse=AI 解析
+info_collect.nl_parse_title=将自然语言解析为 FOFA 查询语法
+info_collect.nl_hint=解析后会弹窗展示 FOFA 语法（可编辑），确认无误后再填入查询框并执行查询。
+info_collect.return_count=返回数量
+info_collect.page_num=页码
+info_collect.return_fields=返回字段名（逗号分隔）
+info_collect.preset.minimal=最小字段
+info_collect.preset.minimal_hint=适合快速导出目标
+info_collect.preset.web_common=Web 常用
+info_collect.preset.web_common_hint=适合浏览和筛选
+info_collect.preset.intel=情报增强
+info_collect.preset.intel_hint=更偏指纹/情报
+info_collect.results_title=查询结果
+info_collect.results_toolbar=结果工具条
+info_collect.selected=已选择 0 条
+info_collect.columns=列
+info_collect.columns_toggle=显示/隐藏字段
+info_collect.export_csv=导出 CSV
+info_collect.export_csv_title=导出当前结果为 CSV（UTF-8，兼容中文）
+info_collect.export_json=导出 JSON
+info_collect.export_json_title=导出当前结果为 JSON
+info_collect.export_xlsx=导出 XLSX
+info_collect.export_xlsx_title=导出当前结果为 Excel
+info_collect.batch_scan=批量扫描
+info_collect.batch_scan_title=将所选行创建为批量任务队列
+info_collect.show_fields=显示字段
+info_collect.show_all=全选
+info_collect.hide_all=全不选
+
+# -- vulnerability page --
+vuln.page.title=漏洞管理
+vuln.page.add=添加漏洞
+vuln.stat.total=总漏洞数
+vuln.filter.vuln_id=漏洞ID
+vuln.filter.vuln_id_placeholder=搜索漏洞ID
+vuln.filter.session_id=会话ID
+vuln.filter.session_placeholder=筛选特定会话
+vuln.filter.severity=严重程度
+vuln.filter.all=全部
+vuln.filter.status=状态
+vuln.filter.status_open=待处理
+vuln.filter.status_confirmed=已确认
+vuln.filter.status_fixed=已修复
+vuln.filter.status_false_positive=误报
+vuln.filter.filter_btn=筛选
+vuln.filter.clear_btn=清除
+
+# -- tasks page --
+task.page.title=任务管理
+task.page.new=新建任务
+task.page.auto_refresh=自动刷新
+task.filter.status=状态筛选
+task.filter.all=全部
+task.filter.pending=待执行
+task.filter.running=执行中
+task.filter.paused=已暂停
+task.filter.completed=已完成
+task.filter.cancelled=已取消
+task.filter.search=搜索队列ID、标题或创建时间
+task.filter.search_placeholder=输入关键字搜索...
+
+# -- roles management page --
+roles_mgmt.title=角色管理
+roles_mgmt.create=创建角色
+roles_mgmt.search_placeholder=搜索角色...
+roles_mgmt.clear_search=清除搜索
+
+# -- skills monitor page --
+skills_monitor.title=Skills状态监控
+skills_monitor.call_stats=调用统计
+skills_monitor.skills_call_stats=Skills调用统计
+skills_monitor.clear_stats=清空统计
+
+# -- skills management page --
+skills_mgmt.title=Skills管理
+skills_mgmt.create=创建Skill
+skills_mgmt.search_placeholder=搜索Skills...
+skills_mgmt.clear_search=清除搜索
+
+# -- settings page --
+settings.page.title=系统设置
+settings.nav.basic=基本设置
+settings.nav.robots=机器人设置
+settings.nav.terminal=终端
+settings.nav.security=安全设置
+settings.basic.title=基本设置
+settings.openai.title=OpenAI 配置
+settings.openai.api_key_placeholder=输入OpenAI API Key
+settings.openai.model=模型
+settings.fofa.title=FOFA 配置
+settings.fofa.base_url_placeholder=https://fofa.info/api/v1/search/all（可选）
+settings.fofa.base_url_hint=留空则使用默认地址。
+settings.fofa.email_placeholder=输入 FOFA 账号邮箱
+settings.fofa.api_key_placeholder=输入 FOFA API Key
+settings.fofa.api_key_hint=仅保存在服务器配置中（`config.yaml`）。
+settings.agent.title=Agent 配置
+settings.agent.max_iterations=最大迭代次数
+settings.knowledge.title=知识库配置
+settings.knowledge.enabled=启用知识检索功能
+settings.knowledge.base_path=知识库路径
+settings.knowledge.base_path_hint=相对于配置文件所在目录的路径
+settings.knowledge.embedding_title=嵌入模型配置
+settings.knowledge.provider=提供商
+settings.knowledge.embedding_base_url_placeholder=留空则使用OpenAI配置的base_url
+settings.knowledge.embedding_api_key_placeholder=留空则使用OpenAI配置的api_key
+settings.knowledge.embedding_model=模型名称
+settings.knowledge.retrieval_title=检索配置
+settings.knowledge.top_k=Top-K 结果数量
+settings.knowledge.top_k_hint=检索返回的Top-K结果数量
+settings.knowledge.similarity=相似度阈值
+settings.knowledge.similarity_hint=相似度阈值（0-1），低于此值的结果将被过滤
+settings.knowledge.hybrid_weight=混合检索权重
+settings.knowledge.hybrid_weight_hint=向量检索的权重（0-1），1.0表示纯向量检索，0.0表示纯关键词检索
+settings.knowledge.indexing_title=索引配置
+settings.knowledge.chunk_size=分块大小（Chunk Size）
+settings.knowledge.chunk_size_hint=每个块的最大 token 数（默认 512），长文本会被分割成多个块
+settings.knowledge.chunk_overlap=分块重叠（Chunk Overlap）
+settings.knowledge.chunk_overlap_hint=块之间的重叠 token 数（默认 50），保持上下文连贯性
+settings.knowledge.max_chunks=单个知识项最大块数
+settings.knowledge.max_chunks_hint=单个知识项的最大块数量（0 表示不限制），防止单个文件消耗过多 API 配额
+settings.knowledge.max_rpm=每分钟最大请求数（Max RPM）
+settings.knowledge.max_rpm_hint=每分钟最大请求数（默认 0 表示不限制），如 OpenAI 默认 200 RPM
+settings.knowledge.rate_delay=请求间隔延迟（毫秒）
+settings.knowledge.rate_delay_hint=请求间隔毫秒数（默认 300），用于避免 API 速率限制，设为 0 不限制
+settings.knowledge.max_retries=最大重试次数
+settings.knowledge.max_retries_hint=最大重试次数（默认 3），遇到速率限制或服务器错误时自动重试
+settings.knowledge.retry_delay=重试间隔（毫秒）
+settings.knowledge.retry_delay_hint=重试间隔毫秒数（默认 1000），每次重试会递增延迟
+settings.apply_config=应用配置
+
+# -- settings robots --
+settings.robots.title=机器人设置
+settings.robots.description=配置企业微信、钉钉、飞书等机器人，在手机端直接与 CyberStrikeAI 对话，无需在服务器上打开网页。
+settings.robots.wecom=企业微信
+settings.robots.wecom_enabled=启用企业微信机器人
+settings.robots.wecom_encoding_hint=EncodingAESKey（明文模式可留空）
+settings.robots.wecom_corp_id=企业 ID
+settings.robots.wecom_secret=应用 Secret
+settings.robots.wecom_agent_id=应用 AgentId
+settings.robots.dingtalk=钉钉
+settings.robots.dingtalk_enabled=启用钉钉机器人
+settings.robots.dingtalk_client_id=钉钉应用 AppKey
+settings.robots.dingtalk_client_secret=钉钉应用 Secret
+settings.robots.dingtalk_hint=需开启机器人能力并配置流式接入
+settings.robots.lark=飞书 (Lark)
+settings.robots.lark_enabled=启用飞书机器人
+settings.robots.lark_app_id=飞书应用 App ID
+settings.robots.lark_app_secret=飞书应用 App Secret
+settings.robots.lark_verify_token=Verify Token（可选）
+settings.robots.lark_verify_placeholder=事件订阅 Verification Token
+settings.robots.commands_title=机器人命令说明
+settings.robots.commands_desc=在对话中可发送以下命令（支持中英文）：
+
+# -- settings terminal --
+settings.terminal.title=终端
+settings.terminal.description=在服务器上执行命令，便于运维与调试。命令在服务端执行，请勿执行敏感或破坏性操作。
+settings.terminal.tab=终端 1
+settings.terminal.close=关闭
+settings.terminal.new=新终端
+
+# -- settings security --
+settings.security.title=安全设置
+settings.security.change_password=修改密码
+settings.security.change_password_desc=修改登录密码后，需要使用新密码重新登录。
+settings.security.current_password=当前密码
+settings.security.current_password_placeholder=输入当前登录密码
+settings.security.new_password=新密码
+settings.security.new_password_placeholder=设置新密码（至少 8 位）
+settings.security.confirm_password=确认新密码
+settings.security.confirm_password_placeholder=再次输入新密码
+settings.security.clear_form=清空
+settings.security.submit=修改密码
+
+# -- MCP detail modal --
+modal.mcp_detail.title=工具调用详情
+modal.mcp_detail.exec_info=执行信息
+modal.mcp_detail.tool=工具
+modal.mcp_detail.status=状态
+modal.mcp_detail.time=时间
+modal.mcp_detail.exec_id=执行 ID
+modal.mcp_detail.request=请求参数
+modal.mcp_detail.copy_json=复制 JSON
+modal.mcp_detail.response=响应结果
+modal.mcp_detail.copy_content=复制内容
+modal.mcp_detail.success_info=正确信息
+modal.mcp_detail.error_info=错误信息
+modal.mcp_detail.copy_error=复制错误
+
+# -- external MCP modal --
+modal.external_mcp.add_title=添加外部MCP
+modal.external_mcp.config_json=配置JSON
+modal.external_mcp.config_format=配置格式：
+modal.external_mcp.config_format_desc=JSON对象，key为配置名称，value为配置内容。状态通过"启动/停止"按钮控制，无需在JSON中配置。
+modal.external_mcp.example=配置示例：
+modal.external_mcp.stdio_mode=stdio模式：
+modal.external_mcp.http_mode=HTTP模式：
+modal.external_mcp.sse_mode=SSE模式：
+modal.external_mcp.format_json=格式化JSON
+modal.external_mcp.load_example=加载示例
+
+# -- attack chain modal --
+modal.attack_chain.title=攻击链可视化
+modal.attack_chain.regenerate=重新生成
+modal.attack_chain.regenerate_title=重新生成攻击链（包含最新对话内容）
+modal.attack_chain.export_png=导出为PNG
+modal.attack_chain.export_svg=导出为SVG
+modal.attack_chain.refresh=刷新
+modal.attack_chain.refresh_title=刷新当前攻击链（不重新生成）
+modal.attack_chain.search_placeholder=搜索节点...
+modal.attack_chain.type_all=所有类型
+modal.attack_chain.type_target=目标
+modal.attack_chain.type_action=行动
+modal.attack_chain.type_vulnerability=漏洞
+modal.attack_chain.risk_all=所有风险
+modal.attack_chain.risk_high=高风险 (80-100)
+modal.attack_chain.risk_medium_high=中高风险 (60-79)
+modal.attack_chain.risk_medium=中风险 (40-59)
+modal.attack_chain.risk_low=低风险 (0-39)
+modal.attack_chain.reset_filters=重置筛选
+modal.attack_chain.legend_risk=风险等级
+modal.attack_chain.legend_connections=连接线含义
+modal.attack_chain.legend_blue=蓝色线：行动发现漏洞
+modal.attack_chain.legend_red=红色线：使能/促成关系
+modal.attack_chain.legend_gray=灰色线：逻辑顺序
+modal.attack_chain.node_details=节点详情
+modal.attack_chain.close_details=关闭详情
+
+# -- skill modal --
+modal.skill.add_title=添加Skill
+modal.skill.name=Skill名称
+modal.skill.name_placeholder=例如: sql-injection-testing
+modal.skill.name_hint=只能包含字母、数字、连字符和下划线
+modal.skill.description=描述
+modal.skill.description_placeholder=Skill的简短描述
+modal.skill.content=内容（Markdown格式）
+modal.skill.content_placeholder=输入skill内容，支持Markdown格式...
+modal.skill.content_hint_prefix=支持YAML front matter格式（可选），例如：
+
+# -- knowledge item modal --
+modal.knowledge.add_title=添加知识
+modal.knowledge.category=分类（风险类型）
+modal.knowledge.category_placeholder=例如：SQL注入
+modal.knowledge.item_title=标题
+modal.knowledge.item_title_placeholder=知识项标题
+modal.knowledge.content=内容（Markdown格式）
+modal.knowledge.content_placeholder=输入知识内容，支持Markdown格式...
+
+# -- batch manage modal --
+modal.batch_manage.title=管理对话记录·共
+modal.batch_manage.title_suffix=条
+modal.batch_manage.search_placeholder=搜索历史记录
+modal.batch_manage.col_name=对话名称
+modal.batch_manage.col_time=最近一次对话时间
+modal.batch_manage.col_action=操作
+modal.batch_manage.select_all=全选
+modal.batch_manage.delete_selected=删除所选
+
+# -- create group modal --
+modal.create_group.title=创建分组
+modal.create_group.description=分组功能可将对话集中归类管理，让对话更加井然有序。
+modal.create_group.name_placeholder=请输入分组名称
+modal.create_group.select_icon=选择图标
+modal.create_group.custom=自定义
+modal.create_group.apply=确定
+modal.create_group.suggestion_pentest=渗透测试
+modal.create_group.suggestion_ctf=CTF
+modal.create_group.suggestion_redteam=红队
+modal.create_group.suggestion_vulnhunt=漏洞挖掘
+modal.create_group.create=创建
+
+# -- context menu --
+ctx.view_attack_chain=查看攻击链
+ctx.rename=重命名
+ctx.pin_conversation=置顶此对话
+ctx.batch_manage=批量管理
+ctx.move_to_group=移动到分组
+ctx.delete_conversation=删除此对话
+ctx.pin_group=置顶此分组
+ctx.delete_group=删除此分组
+
+# -- batch import modal --
+modal.batch_import.title=新建任务
+modal.batch_import.queue_title=任务标题
+modal.batch_import.queue_title_placeholder=请输入任务标题（可选，用于标识和筛选）
+modal.batch_import.queue_title_hint=为批量任务队列设置一个标题，方便后续查找和管理。
+modal.batch_import.role=角色
+modal.batch_import.role_default=默认
+modal.batch_import.role_hint=选择一个角色，所有任务将使用该角色的配置（提示词和工具）执行。
+modal.batch_import.tasks_label=任务列表（每行一个任务）
+modal.batch_import.tasks_placeholder=请输入任务列表，每行一个任务
+modal.batch_import.tasks_hint=每行输入一个任务指令，系统将依次执行这些任务。空行会被自动忽略。
+modal.batch_import.create_queue=创建队列
+
+# -- batch queue detail modal --
+modal.batch_queue.detail_title=批量任务队列详情
+modal.batch_queue.add_task=添加任务
+modal.batch_queue.start=开始执行
+modal.batch_queue.pause=暂停队列
+modal.batch_queue.delete=删除队列
+
+# -- edit batch task modal --
+modal.edit_task.title=编辑任务
+modal.edit_task.message=任务消息
+modal.edit_task.message_placeholder=请输入任务消息
+
+# -- add batch task modal --
+modal.add_task.title=添加任务
+modal.add_task.message=任务消息
+modal.add_task.message_placeholder=请输入任务消息
+modal.add_task.add=添加
+
+# -- vulnerability modal --
+modal.vuln.add_title=添加漏洞
+modal.vuln.session_id=会话ID
+modal.vuln.session_id_placeholder=输入会话ID
+modal.vuln.title=标题
+modal.vuln.title_placeholder=漏洞标题
+modal.vuln.description=描述
+modal.vuln.description_placeholder=漏洞详细描述
+modal.vuln.severity=严重程度
+modal.vuln.severity_select=请选择
+modal.vuln.status=状态
+modal.vuln.type=漏洞类型
+modal.vuln.type_placeholder=如：SQL注入、XSS、CSRF等
+modal.vuln.target=目标
+modal.vuln.target_placeholder=受影响的目标（URL、IP地址等）
+modal.vuln.proof=证明（POC）
+modal.vuln.proof_placeholder=漏洞证明，如请求/响应、截图等
+modal.vuln.impact=影响
+modal.vuln.impact_placeholder=漏洞影响说明
+modal.vuln.recommendation=修复建议
+modal.vuln.recommendation_placeholder=修复建议
+
+# -- role select modal --
+modal.role_select.title=选择角色
+
+# -- role modal --
+modal.role.add_title=添加角色
+modal.role.name=角色名称
+modal.role.name_placeholder=输入角色名称
+modal.role.description=角色描述
+modal.role.description_placeholder=输入角色描述
+modal.role.icon=角色图标
+modal.role.icon_placeholder=输入emoji图标，例如: 🏆
+modal.role.icon_hint=输入一个emoji作为角色的图标，将显示在角色选择器中。
+modal.role.user_prompt=用户提示词
+modal.role.user_prompt_placeholder=输入用户提示词，会在用户消息前追加此提示词...
+modal.role.user_prompt_hint=此提示词会追加到用户消息前，用于指导AI的行为。注意：这不会修改系统提示词。
+modal.role.tools=关联的工具（可选）
+modal.role.tools_default_title=默认角色使用所有工具
+modal.role.tools_default_desc=默认角色会自动使用MCP管理中启用的所有工具，无需单独配置。
+modal.role.tools_select_all=全选
+modal.role.tools_deselect_all=全不选
+modal.role.tools_search_placeholder=搜索工具...
+modal.role.tools_clear_search=清除搜索
+modal.role.tools_loading=正在加载工具列表...
+modal.role.tools_hint=勾选要关联的工具，留空则使用MCP管理中的全部工具配置。
+modal.role.skills=关联的Skills（可选）
+modal.role.skills_select_all=全选
+modal.role.skills_deselect_all=全不选
+modal.role.skills_search_placeholder=搜索skill...
+modal.role.skills_clear_search=清除搜索
+modal.role.skills_loading=正在加载skills列表...
+modal.role.skills_hint=勾选要关联的skills，这些skills的内容会在执行任务前注入到系统提示词中，帮助AI更好地理解相关专业知识。
+modal.role.enabled=启用此角色
+
+# -- remaining strings (phase 3 pass 2) --
+info_collect.fofa_query_placeholder=例如：app="Apache" && country="CN"
+info_collect.fofa_query_presets_aria=FOFA 查询示例
+info_collect.fofa_fields_presets_aria=FOFA 字段模板
+modal.attack_chain.stats_nodes=节点
+modal.attack_chain.stats_edges=边
+settings.robots.cmd_help=显示本帮助
+settings.robots.cmd_list=列出所有对话标题与 ID
+settings.robots.cmd_switch=指定对话继续
+settings.robots.cmd_new=开启新对话
+settings.robots.cmd_clear=清空当前上下文
+settings.robots.cmd_current=显示当前对话 ID 与标题
+settings.robots.cmd_stop=中断当前任务
+settings.robots.cmd_roles=列出所有可用角色
+settings.robots.cmd_role=切换当前角色
+settings.robots.cmd_delete=删除指定对话
+settings.robots.cmd_version=显示当前版本号
+settings.robots.cmd_other=除以上命令外，直接输入内容将发送给 AI 进行渗透测试/安全分析。Otherwise, send any text for AI penetration testing / security analysis.
+
+# -- common UI --
+ui.loading=加载中...
+ui.btn.search=搜索
+ui.btn.filter=筛选
+ui.btn.reset=重置

--- a/messages/message_ko.properties
+++ b/messages/message_ko.properties
@@ -1,0 +1,1096 @@
+# ============================================================
+# CyberStrikeAI - 한국어 (Korean) messages
+# 미번역 키는 중국어(message_cn.properties)로 폴백됩니다.
+# ============================================================
+
+# ---- auth ----
+auth.error.password_empty=비밀번호를 입력해주세요
+auth.error.password_wrong=비밀번호가 올바르지 않습니다
+auth.error.invalid_params=잘못된 요청입니다
+auth.error.passwords_required=현재 비밀번호와 새 비밀번호를 모두 입력해주세요
+auth.error.password_too_short=새 비밀번호는 8자 이상이어야 합니다
+auth.error.password_same=새 비밀번호는 현재 비밀번호와 달라야 합니다
+auth.error.password_incorrect=현재 비밀번호가 올바르지 않습니다
+auth.error.save_password_failed=비밀번호 저장에 실패했습니다. 다시 시도해주세요
+auth.error.update_config_failed=인증 설정 업데이트에 실패했습니다
+auth.error.session_invalid=세션이 유효하지 않습니다
+auth.error.session_expired=세션이 만료되었습니다
+auth.message.logout=로그아웃되었습니다
+auth.message.password_updated=비밀번호가 변경되었습니다. 새 비밀번호로 다시 로그인해주세요
+
+# ---- role ----
+role.error.name_empty=역할 이름을 입력해주세요
+role.error.not_found=역할을 찾을 수 없습니다
+role.error.invalid_params=잘못된 요청 파라미터: {0}
+role.error.already_exists=이미 존재하는 역할입니다
+role.error.cannot_delete_default=기본 역할은 삭제할 수 없습니다
+role.message.updated=역할이 업데이트되었습니다
+role.message.created=역할이 생성되었습니다
+role.message.deleted=역할이 삭제되었습니다
+
+# ---- skill ----
+skill.error.name_empty=스킬 이름을 입력해주세요
+skill.error.name_invalid=스킬 이름은 영문자, 숫자, 하이픈, 언더스코어만 사용할 수 있습니다
+skill.error.already_exists=이미 존재하는 스킬입니다
+skill.error.not_found=스킬을 찾을 수 없습니다
+skill.message.created=스킬이 생성되었습니다
+skill.message.updated=스킬이 업데이트되었습니다
+skill.message.deleted=스킬이 삭제되었습니다
+skill.message.stats_cleared=모든 스킬 통계가 초기화되었습니다
+skill.message.stat_cleared=스킬 '{0}' 통계가 초기화되었습니다
+skill.error.delete_failed=스킬 삭제 실패: {0}
+skill.error.create_dir_failed=스킬 디렉토리 생성 실패: {0}
+skill.error.create_file_failed=스킬 파일 생성 실패: {0}
+skill.error.update_file_failed=스킬 파일 업데이트 실패: {0}
+skill.error.read_file_failed=스킬 파일 읽기 실패: {0}
+
+# ---- vulnerability ----
+vuln.error.not_found=취약점을 찾을 수 없습니다
+
+# ---- conversation ----
+conversation.error.not_found=대화를 찾을 수 없습니다
+conversation.error.title_empty=제목을 입력해주세요
+
+# ---- monitor ----
+monitor.error.not_found=실행 기록을 찾을 수 없습니다
+monitor.error.id_empty=실행 기록 ID를 입력해주세요
+monitor.error.ids_empty=실행 기록 ID 목록을 입력해주세요
+monitor.message.already_deleted=실행 기록이 존재하지 않거나 이미 삭제되었습니다
+monitor.message.deleted=실행 기록이 삭제되었습니다
+monitor.message.deleted_if_exists=실행 기록이 삭제되었습니다 (존재하는 경우)
+monitor.message.batch_deleted=실행 기록이 삭제되었습니다
+
+# ---- config ----
+config.message.updated=설정이 업데이트되었습니다
+config.message.applied=설정이 적용되었습니다
+
+# ---- external mcp ----
+mcp.error.not_found=외부 MCP 설정을 찾을 수 없습니다
+mcp.error.name_empty=이름을 입력해주세요
+mcp.error.config_not_found=설정을 찾을 수 없습니다
+mcp.message.updated=설정이 업데이트되었습니다
+mcp.message.deleted=설정이 삭제되었습니다
+mcp.message.connecting=외부 MCP 시작 요청이 제출되었습니다. 백그라운드에서 연결 중입니다
+mcp.message.stopped=외부 MCP가 중지되었습니다
+
+# ---- terminal ----
+terminal.error.invalid_body=요청 본문이 유효하지 않습니다. command 필드가 필요합니다
+terminal.error.command_empty=command를 입력해주세요
+terminal.error.command_too_long=명령어가 너무 깁니다
+terminal.error.workdir_invalid=작업 디렉토리가 유효하지 않습니다
+terminal.error.workdir_outside=작업 디렉토리는 현재 프로세스 디렉토리 내에 있어야 합니다
+
+# ---- fofa ----
+fofa.error.text_empty=text를 입력해주세요
+fofa.error.config_not_init=시스템 설정이 초기화되지 않았습니다
+fofa.error.ai_not_configured=AI 모델이 설정되지 않았습니다. 시스템 설정에서 openai.api_key와 openai.model을 입력해주세요 (OpenAI 호환 API 지원, 예: DeepSeek)
+fofa.error.ai_client_not_init=AI 클라이언트가 초기화되지 않았습니다
+fofa.error.ai_parse_failed=AI 파싱 실패 (업스트림 비-200 응답). 모델 설정을 확인하거나 잠시 후 다시 시도해주세요
+fofa.error.ai_no_result=AI가 유효한 결과를 반환하지 않았습니다
+fofa.error.ai_json_parse_failed=AI 응답을 JSON으로 파싱할 수 없습니다. 잠시 후 다시 시도하거나 다른 표현을 사용해주세요
+fofa.error.query_empty=query를 입력해주세요
+fofa.error.fofa_not_configured=FOFA가 설정되지 않았습니다. 시스템 설정에서 FOFA Email/API Key를 입력하거나 환경변수 FOFA_EMAIL/FOFA_API_KEY를 설정해주세요
+fofa.error.fofa_non_2xx=FOFA 응답 오류: {0}
+
+# ---- common ----
+common.message.deleted=삭제되었습니다
+common.error.db_not_configured=데이터베이스 연결이 설정되지 않았습니다
+
+# ---- nav (UI) ----
+nav.dashboard=대시보드
+nav.chat=대화
+nav.vulnerability=취약점 관리
+nav.tasks=일괄 작업
+nav.knowledge=지식 베이스
+nav.skills=스킬
+nav.roles=역할
+nav.tools=도구
+nav.monitor=모니터링
+nav.settings=설정
+nav.terminal=터미널
+nav.info_collect=정보 수집
+nav.attack_chain=공격 체인
+
+# ---- login UI ----
+login.title=CyberStrikeAI 로그인
+login.subtitle=설정에서 지정한 접근 비밀번호를 입력하세요
+login.password_label=비밀번호
+login.password_placeholder=로그인 비밀번호 입력
+login.submit=로그인
+login.error.empty=비밀번호를 입력해주세요
+login.error.failed=비밀번호가 올바르지 않습니다. 다시 시도해주세요
+
+# ---- dashboard ----
+dashboard.title=대시보드
+dashboard.kpi.conversations=총 대화 수
+dashboard.kpi.tools=도구 호출
+dashboard.kpi.vulnerabilities=발견된 취약점
+dashboard.kpi.tasks=일괄 작업
+dashboard.recent_activity=최근 활동
+dashboard.no_activity=활동 기록이 없습니다
+
+# ---- chat ----
+chat.placeholder=메시지 입력 (Shift+Enter: 줄바꿈, Enter: 전송)
+chat.btn.send=전송
+chat.btn.stop=중지
+chat.btn.new=새 대화
+chat.btn.clear=지우기
+chat.thinking=생각 중...
+chat.no_conversations=대화가 없습니다
+chat.select_role=역할 선택
+chat.select_model=모델 선택
+
+# ---- settings ----
+settings.title=시스템 설정
+settings.save=설정 저장
+settings.apply=설정 적용
+settings.section.openai=AI 모델 설정
+settings.section.agent=에이전트 설정
+settings.section.auth=인증 설정
+settings.section.robots=봇 설정
+settings.section.knowledge=지식 베이스 설정
+settings.saved=설정이 저장되었습니다
+settings.applied=설정이 적용되었습니다
+
+# ---- vulnerability UI ----
+vuln.title=취약점 관리
+vuln.btn.create=새 취약점
+vuln.btn.export=내보내기
+vuln.severity.critical=치명적
+vuln.severity.high=높음
+vuln.severity.medium=중간
+vuln.severity.low=낮음
+vuln.severity.info=정보
+vuln.status.open=수정 필요
+vuln.status.in_progress=수정 중
+vuln.status.resolved=수정 완료
+vuln.status.wont_fix=수정 안 함
+vuln.no_data=취약점 기록이 없습니다
+
+# ---- task UI ----
+task.title=일괄 작업
+task.btn.create=새 작업
+task.status.pending=대기 중
+task.status.running=실행 중
+task.status.completed=완료
+task.status.failed=실패
+task.no_data=작업 기록이 없습니다
+
+# ---- knowledge UI ----
+knowledge.title=지식 베이스
+knowledge.btn.scan=파일 스캔
+knowledge.btn.index=인덱스 생성
+knowledge.no_data=지식 항목이 없습니다
+
+# ---- skill UI ----
+skill.title=스킬 관리
+skill.btn.create=새 스킬
+skill.no_data=스킬이 없습니다
+
+# ---- role UI ----
+role.title=역할 관리
+role.btn.create=새 역할
+role.no_data=역할이 없습니다
+role.error.load_failed=역할을 불러오지 못했습니다
+role.error.not_exists=역할이 존재하지 않습니다
+role.error.save_failed=역할을 저장하지 못했습니다
+role.error.delete_failed=역할을 삭제하지 못했습니다
+role.message.refreshed=새로 고침되었습니다
+
+# ---- tool UI ----
+tool.title=도구 관리
+tool.no_data=도구가 없습니다
+
+# ---- monitor UI ----
+monitor.title=실행 모니터링
+monitor.no_data=실행 기록이 없습니다
+monitor.btn.clear=기록 지우기
+
+# ---- common UI buttons ----
+ui.btn.edit=편집
+ui.btn.delete=삭제
+ui.btn.view=보기
+ui.btn.create=생성
+ui.btn.save=저장
+ui.btn.cancel=취소
+ui.btn.confirm=확인
+ui.btn.close=닫기
+ui.btn.stop=중지
+ui.btn.start=시작
+ui.btn.refresh=새로 고침
+ui.btn.export=내보내기
+ui.btn.clear=초기화
+ui.btn.add=추가
+ui.btn.remove=제거
+ui.btn.download=다운로드
+ui.btn.enabled=활성화됨
+ui.btn.disabled=비활성화됨
+
+# ---- pagination ----
+ui.pagination.first=첫 페이지
+ui.pagination.prev=이전
+ui.pagination.next=다음
+ui.pagination.last=마지막 페이지
+ui.pagination.page={0} / {1} 페이지
+ui.pagination.showing={0}-{1} / 총 {2}개
+
+# ---- common status ----
+ui.status.loading=로딩 중...
+ui.status.enabled=활성화
+ui.status.disabled=비활성화
+ui.empty.no_data=데이터 없음
+ui.label.default=기본
+
+# ---- role extended ----
+role.btn.edit=역할 편집
+role.label.tools=도구:
+role.label.use_all_tools=모든 도구 사용
+role.label.external_tool=외부 ({0})
+role.label.external_mcp=외부 MCP 도구
+role.label.no_tools=도구 없음
+role.label.no_results=일치하는 역할 없음
+role.label.tool_count={0}-{1} / 총 {2}개 도구
+role.confirm.delete=역할 "{0}"을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.
+role.label.skills_no_results=일치하는 스킬 없음
+role.label.skills_selected={0} / {1} 선택됨
+
+# ---- skill extended ----
+skill.btn.view=보기
+skill.btn.edit=편집
+skill.label.description=설명:
+skill.label.path=경로:
+skill.label.mod_time=수정 시간:
+skill.label.content=내용:
+skill.label.no_results=일치하는 스킬 없음
+skill.label.no_skills=스킬이 없습니다. "스킬 생성"을 클릭하여 첫 번째 스킬을 만드세요
+skill.modal.add=스킬 추가
+skill.modal.edit=스킬 편집
+skill.modal.view=스킬 보기: {0}
+skill.confirm.delete=스킬 "{0}"을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.
+skill.confirm.delete_bound=⚠️ 이 스킬은 현재 {0}개의 역할에 연결되어 있습니다
+skill.error.content_empty=스킬 내용을 입력해주세요
+skill.confirm.clear_stats=모든 스킬 통계를 초기화하시겠습니까? 이 작업은 되돌릴 수 없습니다.
+skill.stats.total=총 스킬 수
+skill.stats.total_calls=총 호출 수
+skill.stats.success=성공 호출
+skill.stats.failed=실패 호출
+skill.stats.rate=성공률
+skill.stats.col_name=스킬 이름
+skill.stats.col_total=총 호출
+skill.stats.col_success=성공
+skill.stats.col_failed=실패
+skill.stats.col_rate=성공률
+skill.stats.col_last=마지막 호출 시간
+
+# ---- task extended ----
+task.status.running=실행 중
+task.status.cancelling=취소 중
+task.status.failed=실행 실패
+task.status.timeout=실행 시간 초과
+task.status.cancelled=취소됨
+task.status.paused=일시 정지
+task.label.recent=📜 최근 완료된 작업 (지난 24시간)
+task.btn.clear_history=기록 초기화
+task.label.unnamed=이름 없는 작업
+task.label.conv_id=대화 ID:
+task.label.queue_id=큐 ID:
+task.label.created_at=생성 시간:
+task.label.role=역할
+task.label.task_list=작업 목록
+task.confirm.clear_history=모든 작업 기록을 초기화하시겠습니까?
+task.confirm.cancel_selected={0}개의 작업을 취소하시겠습니까?
+task.queue.status.pending=대기 중
+task.queue.status.running=실행 중
+task.queue.status.paused=일시 정지
+task.queue.status.completed=완료됨
+task.queue.status.cancelled=취소됨
+
+# ---- vulnerability extended ----
+vuln.status.pending=대기 중
+vuln.status.confirmed=확인됨
+vuln.status.false_positive=오탐
+vuln.btn.download_md=Markdown 다운로드
+vuln.label.id=취약점 ID:
+vuln.label.type=유형:
+vuln.label.target=대상:
+vuln.label.session_id=세션 ID:
+vuln.label.proof=증거:
+vuln.label.impact=영향:
+vuln.label.recommendation=수정 권장사항:
+vuln.export.basic_info=## 기본 정보
+vuln.export.description=## 설명
+vuln.export.proof=## 증거 (POC)
+vuln.export.impact=## 영향
+vuln.export.recommendation=## 수정 권장사항
+vuln.export.download_success=다운로드 완료!
+
+# ---- settings extended ----
+settings.error.load_failed=설정 로드 실패
+settings.tools.loading=⏳ 도구 목록 로딩 중...
+settings.tools.load_failed=도구 목록 로드 실패
+settings.tools.no_tools=도구 없음
+settings.tools.showing={0}-{1} / 총 {2}개 도구
+settings.mcp.no_config=📋 외부 MCP 설정 없음
+settings.mcp.status.connected=연결됨
+settings.mcp.status.connecting=연결 중...
+settings.mcp.status.failed=연결 실패
+settings.mcp.status.disabled=비활성화됨
+settings.mcp.btn.stop=중지
+settings.mcp.btn.start=시작
+settings.mcp.btn.connecting=연결 중...
+settings.mcp.stats.total=총:
+settings.mcp.stats.enabled=활성화:
+settings.mcp.stats.disabled=비활성화:
+settings.mcp.stats.connected=연결됨:
+settings.password.validation=현재 비밀번호와 새 비밀번호를 올바르게 입력해주세요. 새 비밀번호는 8자 이상이며 두 번 모두 동일해야 합니다.
+
+# ---- monitor extended ----
+monitor.status.running=🔍 침투 테스트 진행 중...
+monitor.btn.stop_task=작업 중지
+monitor.btn.collapse=상세 접기
+monitor.btn.expand=상세 펼치기
+monitor.label.no_details=진행 세부 정보 없음
+monitor.label.tool_calls=🔧 {0}개의 도구 호출 감지
+monitor.label.calling_tool=🔧 도구 호출: {0} ({1}/{2})
+monitor.label.cancelled=⛔ 작업이 취소되었습니다
+monitor.label.error=❌ 오류
+monitor.label.completed=✅ 침투 테스트 완료
+
+# ---- chat extended ----
+chat.file.default_prompt=업로드된 파일 내용을 분석해주세요.
+chat.file.max_exceeded=최대 {0}개의 파일을 동시에 업로드할 수 있습니다. 현재 {1}개 선택됨.
+chat.file.read_failed=파일 읽기 실패: {0}
+chat.btn.remove=제거
+chat.btn.remove_file={0} 제거
+
+# ---- knowledge extended ----
+knowledge.disabled=지식 베이스 기능이 비활성화되어 있습니다
+knowledge.goto_settings=시스템 설정에서 지식 검색 기능을 활성화하세요
+knowledge.empty=지식 항목 없음
+
+# ---- fofa / info-collect ----
+fofa.status.querying=조회 중...
+fofa.error.query_failed=조회 실패
+fofa.label.input_placeholder=자연어 설명을 입력하세요
+fofa.ai.parsing=AI 분석 중...
+fofa.ai.parsing_long=AI 분석에 시간이 걸리고 있습니다. 처리 중...
+fofa.ai.result_title=AI 분석 결과
+fofa.ai.natural_lang=자연어
+fofa.ai.fofa_syntax=FOFA 조회 구문
+fofa.ai.reminder=알림
+fofa.ai.parse_notes=분석 설명
+fofa.ai.result_empty=분석 결과 없음
+fofa.table.loading=로딩 중...
+fofa.table.summary=총 {0}개 · 현재 페이지 {1}개
+fofa.export.no_results=내보낼 결과 없음
+fofa.export.no_xlsx=XLSX 라이브러리가 로드되지 않았습니다
+fofa.export.sheet_name=FOFA 결과
+fofa.scan.no_results=결과 없음
+fofa.scan.select_rows=스캔할 행을 먼저 선택하세요
+fofa.scan.title=FOFA 일괄 스캔
+
+# ---- terminal ----
+terminal.welcome=CyberStrikeAI 터미널 - 실제 Shell 세션, 명령을 직접 입력하세요; Ctrl+L 화면 지우기\r\n
+terminal.session_closed=[세션이 종료되었습니다]
+terminal.connect_error=[터미널 연결 오류]
+terminal.connect_failed=[터미널 서비스에 연결할 수 없습니다:
+terminal.hint=여기를 클릭한 후 명령을 입력하세요
+terminal.tab_label=터미널 {0}
+
+# ---- dashboard ----
+dashboard.loading=로딩 중...
+dashboard.no_call_data=호출 데이터 없음
+dashboard.status.not_enabled=미활성화
+dashboard.status.enabled=활성화
+dashboard.status.pending=설정 필요
+dashboard.tool.pending=대기 중
+dashboard.tool.active=활성
+dashboard.tool.frequent=고빈도
+
+# ---- auth ----
+auth.error.expired=인증이 만료되었습니다. 다시 로그인해주세요
+auth.status.pending=대기 중
+auth.status.running=실행 중
+auth.status.completed=완료됨
+auth.status.failed=실패
+
+# ---- ui common (added) ----
+ui.btn.copy=복사
+ui.btn.copied=복사됨
+ui.btn.retry=다시 시도
+ui.btn.close_tab=닫기
+ui.pagination.per_page=페이지당
+ui.status.searching=검색 중...
+ui.status.saving=저장 중...
+
+# ---- chat (added) ----
+chat.mention.loading=도구 로딩 중...
+chat.mention.no_match=일치하는 도구 없음
+chat.btn.copy=복사
+chat.btn.copied=복사됨
+chat.mcp.label=📋 침투 테스트 상세
+chat.mcp.call=호출 #{0}
+chat.details.expand=상세 펼치기
+chat.details.collapse=상세 접기
+chat.copy.failed=복사 실패. 직접 선택하여 복사해주세요
+chat.no_response=응답 데이터 없음
+chat.progress.empty=진행 세부 정보 없음...
+chat.conv.delete_title=대화 삭제
+chat.conv.confirm_delete=이 대화를 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.
+chat.conv.confirm_delete_selected=선택한 {0}개의 대화를 삭제하시겠습니까?
+chat.conv.no_selected=먼저 삭제할 대화를 선택하세요
+chat.conv.delete_failed=삭제 실패: {0}
+chat.conv.loading=로딩 중...
+chat.conv.load_failed=로드 실패, 다시 시도해주세요
+chat.conv.data_error=데이터 형식 오류
+chat.conv.no_results=일치하는 대화 없음
+chat.group.name_empty=분류 이름을 입력하세요
+chat.group.name_exists=분류 이름이 이미 존재합니다. 다른 이름을 사용하세요
+chat.group.confirm_delete=이 분류를 삭제하시겠습니까? 분류 내 대화는 삭제되지 않습니다.
+chat.attack.loading=로딩 중...
+chat.attack.regenerating=재생성 중...
+chat.attack.no_data=공격 체인 데이터 없음
+chat.attack.load_failed=로드 실패: {0}
+chat.attack.regen_failed=재생성 실패: {0}
+chat.attack.no_chain=먼저 공격 체인을 로드하세요
+chat.attack.export_failed=PNG 내보내기 실패: {0}
+chat.attack.export_failed2=내보내기 실패: {0}
+chat.attack.unsupported=지원하지 않는 내보내기 형식: {0}
+chat.attack.stats=노드: {0} | 엣지: {1}
+chat.attack.running=현재 대화가 실행 중입니다. 나중에 공격 체인을 생성하세요
+chat.attack.view=현재 대화의 공격 체인 보기
+chat.attack.select_conv=공격 체인을 보려면 대화를 선택하세요
+chat.pin.pin_conv=이 대화 고정
+chat.pin.pin_group=이 분류 고정
+chat.pin.failed=고정 실패: {0}
+chat.rename.failed=이름 변경 실패: {0}
+chat.move.failed=이동 실패: {0}
+chat.remove.failed=제거 실패: {0}
+
+# ---- knowledge (added) ----
+knowledge.filter.all=전체
+knowledge.pagination.info={0} / {1} 페이지 (총 {2}개 분류)
+knowledge.stats.categories=총 분류 수
+knowledge.stats.current_cats=현재 페이지 분류
+knowledge.stats.current_items=현재 페이지 항목
+knowledge.index.failed=인덱스 구축 실패
+knowledge.index.building=인덱스 재구축 중
+knowledge.index.progress=인덱스 구축 중: {0}
+knowledge.index.complete=인덱스 구축 완료
+knowledge.index.status_failed=인덱스 상태를 가져올 수 없습니다
+knowledge.modal.add=지식 추가
+knowledge.modal.edit=지식 편집
+knowledge.confirm.delete_item=이 지식 항목을 삭제하시겠습니까?
+knowledge.confirm.delete_record=이 검색 기록을 삭제하시겠습니까?
+knowledge.retrieval.empty=검색 기록 없음
+knowledge.stats.total_retrievals=총 검색 횟수
+knowledge.stats.success_retrievals=성공 검색
+knowledge.label.conv_id=대화 ID
+
+# ---- tasks (added) ----
+task.role.default=기본
+task.alert.empty_input=최소 한 개의 작업을 입력하세요
+task.alert.no_valid=유효한 작업이 없습니다
+task.alert.incomplete=작업 정보가 불완전합니다
+task.alert.message_empty=작업 메시지를 입력해주세요
+task.alert.cancel_result=일괄 취소 완료: 성공 {0}개, 실패 {1}개
+task.alert.cancel_success={0}개 작업을 성공적으로 취소했습니다
+task.confirm.pause_queue=이 일괄 작업 큐를 일시 중지하시겠습니까? 현재 실행 중인 작업이 중지됩니다.
+task.confirm.delete_queue=이 일괄 작업 큐를 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.
+task.confirm.delete_task=이 작업을 삭제하시겠습니까?
+
+# ---- monitor (added) ----
+monitor.alert.not_synced=작업 정보가 아직 동기화되지 않았습니다. 나중에 다시 시도해주세요.
+monitor.alert.cancel_failed=작업 취소 실패: {0}
+monitor.error.load_stats=통계 정보를 로드할 수 없습니다: {0}
+monitor.error.load_records=실행 기록을 로드할 수 없습니다: {0}
+monitor.label.no_calls=호출 없음
+monitor.confirm.delete_record=이 실행 기록을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.
+monitor.alert.delete_failed=실행 기록 삭제 실패: {0}
+monitor.alert.no_selected=먼저 삭제할 실행 기록을 선택하세요
+monitor.confirm.delete_selected=선택한 {0}개의 실행 기록을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.
+monitor.alert.batch_delete_failed=실행 기록 일괄 삭제 실패: {0}
+
+# ---- settings (added) ----
+settings.mcp.modal.add=외부 MCP 추가
+settings.mcp.modal.edit=외부 MCP 편집
+settings.mcp.confirm.delete=외부 MCP "{0}"을 삭제하시겠습니까?
+settings.mcp.error.json_empty=JSON을 입력해주세요
+settings.mcp.error.json_invalid=JSON 형식 오류: {0}
+settings.mcp.error.config_empty=JSON 설정을 입력해주세요
+settings.mcp.error.not_object=설정 오류: JSON 객체 형식이어야 합니다
+settings.mcp.error.no_items=설정 오류: 최소 하나의 설정 항목이 필요합니다
+settings.mcp.error.name_empty=설정 오류: 설정 이름을 입력해주세요
+settings.mcp.error.item_not_object=설정 오류: "{0}"의 설정은 객체여야 합니다
+settings.mcp.error.no_transport=설정 오류: "{0}"에 command 또는 url을 지정해야 합니다
+settings.mcp.error.stdio_cmd=설정 오류: "{0}" stdio 모드에는 command 필드가 필요합니다
+settings.mcp.error.http_url=설정 오류: "{0}" http 모드에는 url 필드가 필요합니다
+settings.mcp.error.sse_url=설정 오류: "{0}" sse 모드에는 url 필드가 필요합니다
+settings.mcp.error.edit_missing=설정 오류: 편집 모드에서 JSON에 설정 이름이 포함되어야 합니다
+settings.mcp.error.save_failed=저장 실패: {0}
+
+# ---- auth (added) ----
+auth.error.login_failed=로그인 실패. 비밀번호를 확인해주세요
+auth.error.login_retry=로그인 실패. 나중에 다시 시도해주세요
+auth.message.logged_out=로그아웃되었습니다
+
+# ---- terminal (added) ----
+terminal.load_error=xterm.js가 로드되지 않았습니다. 페이지를 새로 고치거나 네트워크를 확인하세요.
+
+# ---- fofa / info-collect (added) ----
+fofa.alert.query_empty=FOFA 조회 구문을 입력하세요
+fofa.alert.query_failed2=FOFA 조회 실패: {0}
+fofa.alert.lang_empty=자연어 설명을 입력하세요
+fofa.btn.cancel_parse=AI 분석 취소 클릭
+fofa.btn.start_parse=자연어를 FOFA 조회 구문으로 변환
+fofa.label.selected={0}개 선택됨
+fofa.btn.select_all=전체 선택/해제
+fofa.alert.no_targets=복사할 대상이 없습니다
+fofa.alert.copy_failed=복사 실패. 직접 복사해주세요: {0}
+fofa.alert.infer_failed=이 행에서 스캔 대상을 추론할 수 없습니다
+fofa.alert.no_send=sendMessage()를 찾을 수 없습니다. 페이지를 새로 고쳐주세요
+fofa.alert.no_scan_targets=선택한 행에서 스캔 가능한 대상을 추론할 수 없습니다
+fofa.alert.scan_failed=일괄 스캔 실패: {0}
+fofa.toast.copied=복사됨
+fofa.alert.copy_failed2=복사 실패
+
+# ---- roles (added) ----
+role.label.default_name=기본
+role.info.first_role_all_tools=첫 역할 추가 시 도구를 선택하지 않으면 모든 도구가 기본으로 사용됩니다
+
+# ---- nav (added) ----
+nav.version_title=현재 버전
+nav.api_docs=API 문서
+nav.api_docs_title=OpenAPI 문서
+nav.logout=로그아웃
+nav.sidebar_toggle=사이드바 접기/펼치기
+nav.user_menu=사용자 메뉴
+
+# ---- index.html UI (phase 3) ----
+
+# -- nav submenu --
+nav.mcp_monitor=MCP 상태 모니터링
+nav.mcp_management=MCP 관리
+nav.knowledge_retrieval_logs=검색 기록
+nav.knowledge_management=지식 관리
+nav.skills_monitor=스킬 상태 모니터링
+nav.skills_management=스킬 관리
+nav.roles_management=역할 관리
+
+# -- dashboard section --
+dashboard.section.vuln_severity=취약점 심각도 분포
+dashboard.section.run_overview=실행 개요
+dashboard.section.quick_links=빠른 링크
+dashboard.section.tool_exec_count=도구 실행 횟수
+dashboard.kpi.running_tasks=실행 중 작업
+dashboard.kpi.vuln_total=총 취약점
+dashboard.kpi.tool_calls=도구 호출 횟수
+dashboard.kpi.tool_success_rate=도구 실행 성공률
+dashboard.kpi.click_tasks=작업 관리 보기 클릭
+dashboard.kpi.click_vulns=취약점 관리 보기 클릭
+dashboard.kpi.click_mcp=MCP 모니터링 보기 클릭
+dashboard.overview.batch_queue=일괄 작업 큐
+dashboard.overview.pending=대기 중
+dashboard.overview.running=실행 중
+dashboard.overview.done=완료됨
+dashboard.overview.tool_calls=도구 호출
+dashboard.overview.calls_unit=회 호출
+dashboard.overview.tools_unit=개 도구
+dashboard.overview.knowledge=지식
+dashboard.overview.knowledge_items_unit=개 지식
+dashboard.overview.knowledge_categories_unit=개 분류
+dashboard.overview.skills_calls_unit=회 호출
+dashboard.overview.skills_count_unit=개 스킬
+dashboard.cta.title=보안 여정을 시작하세요
+dashboard.cta.subtitle=대화에서 대상을 설명하면 AI가 스캔 및 취약점 분석을 도와드립니다
+dashboard.cta.btn=대화로 이동
+dashboard.no_data=데이터 없음
+
+# -- quick links --
+dashboard.quick.chat=대화
+dashboard.quick.tasks=작업 관리
+dashboard.quick.vulns=취약점 관리
+dashboard.quick.mcp=MCP 관리
+dashboard.quick.knowledge=지식 관리
+dashboard.quick.skills=스킬 관리
+dashboard.quick.roles=역할 관리
+
+# -- chat page --
+chat.sidebar.new=새 대화
+chat.sidebar.search_placeholder=기록 검색...
+chat.sidebar.clear_search=검색 지우기
+chat.sidebar.groups_title=대화 그룹
+chat.sidebar.new_group=새 그룹
+chat.sidebar.recent_title=최근 대화
+chat.sidebar.batch_manage=일괄 관리
+chat.group.search_placeholder=그룹 내 대화 검색...
+chat.group.clear_search=검색 지우기
+chat.group.search=검색
+chat.group.edit=편집
+chat.group.delete=삭제
+chat.attack_chain.btn=공격 체인
+chat.attack_chain.view_title=공격 체인 보기
+chat.role.select_title=역할 선택
+chat.role.select_heading=역할 선택
+chat.role.close=닫기
+chat.role.default=기본
+chat.file.selected_label=선택한 파일 목록
+chat.input.placeholder=테스트 대상 또는 명령 입력... (@ 입력으로 도구 선택 | Shift+Enter 줄바꿈, Enter 전송)
+chat.input.mention_label=도구 멘션 후보
+chat.file.select=파일 선택
+chat.file.upload_title=파일 업로드 (여러 개 선택 또는 드래그 앤 드롭)
+chat.btn.send_label=전송
+
+# -- MCP monitor page --
+mcp_monitor.title=MCP 상태 모니터링
+mcp_monitor.exec_stats=실행 통계
+mcp_monitor.latest_records=최신 실행 기록
+mcp_monitor.tool_search=도구 검색
+mcp_monitor.tool_search_placeholder=도구 이름 입력...
+mcp_monitor.status_filter=상태 필터
+mcp_monitor.status.all=전체
+mcp_monitor.status.completed=완료됨
+mcp_monitor.status.running=실행 중
+mcp_monitor.status.failed=실패
+mcp_monitor.selected_count=0개 선택됨
+mcp_monitor.select_all=전체 선택
+mcp_monitor.deselect_all=선택 해제
+mcp_monitor.batch_delete=일괄 삭제
+
+# -- MCP management page --
+mcp_mgmt.title=MCP 관리
+mcp_mgmt.add_external=외부 MCP 추가
+mcp_mgmt.tool_config=MCP 도구 설정
+mcp_mgmt.save_tool_config=도구 설정 저장
+mcp_mgmt.select_all=전체 선택
+mcp_mgmt.deselect_all=선택 해제
+mcp_mgmt.search_placeholder=도구 검색...
+mcp_mgmt.search=검색
+mcp_mgmt.external_config=외부 MCP 설정
+
+# -- knowledge management page --
+knowledge_mgmt.title=지식 관리
+knowledge_mgmt.rebuild_index=인덱스 재구축
+knowledge_mgmt.add_knowledge=지식 추가
+knowledge_mgmt.total_items=총 지식 항목
+knowledge_mgmt.categories_count=분류 수
+knowledge_mgmt.total_content=총 콘텐츠
+knowledge_mgmt.category_filter=분류 필터
+knowledge_mgmt.all=전체
+knowledge_mgmt.search_placeholder=지식 검색...
+
+# -- knowledge retrieval logs page --
+knowledge_retrieval.title=검색 기록
+knowledge_retrieval.total=총 검색 횟수
+knowledge_retrieval.success=성공 검색
+knowledge_retrieval.success_rate=성공률
+knowledge_retrieval.items_found=검색된 지식 항목
+knowledge_retrieval.conv_id=대화 ID
+knowledge_retrieval.conv_placeholder=선택사항: 특정 대화 필터
+knowledge_retrieval.msg_id=메시지 ID
+knowledge_retrieval.msg_placeholder=선택사항: 특정 메시지 필터
+knowledge_retrieval.filter=필터
+
+# -- info collect (FOFA) page --
+info_collect.title=정보 수집
+info_collect.reset=초기화
+info_collect.submit=확인
+info_collect.fofa_query=FOFA 조회 구문
+info_collect.fofa_query_hint=조회 구문은 FOFA 문서를 참고하세요. && / || / () 등을 지원합니다.
+info_collect.preset.apache_cn=Apache + 중국
+info_collect.preset.login_cn=로그인 페이지 + 중국
+info_collect.preset.domain=특정 도메인
+info_collect.preset.ip=특정 IP
+info_collect.preset.fill_hint=예시 입력
+info_collect.nl_label=자연어 (AI가 FOFA 구문으로 변환)
+info_collect.nl_placeholder=예: 미국 Missouri의 Apache 사이트, 제목에 Home 포함
+info_collect.nl_parse=AI 분석
+info_collect.nl_parse_title=자연어를 FOFA 조회 구문으로 변환
+info_collect.nl_hint=변환 후 FOFA 구문이 팝업으로 표시됩니다 (편집 가능). 확인 후 조회 입력란에 입력하고 실행하세요.
+info_collect.return_count=반환 수량
+info_collect.page_num=페이지
+info_collect.return_fields=반환 필드명 (쉼표로 구분)
+info_collect.preset.minimal=최소 필드
+info_collect.preset.minimal_hint=빠른 대상 내보내기에 적합
+info_collect.preset.web_common=웹 일반
+info_collect.preset.web_common_hint=탐색 및 필터링에 적합
+info_collect.preset.intel=정보 강화
+info_collect.preset.intel_hint=핑거프린트/인텔리전스 중심
+info_collect.results_title=조회 결과
+info_collect.results_toolbar=결과 도구 모음
+info_collect.selected=0개 선택됨
+info_collect.columns=열
+info_collect.columns_toggle=필드 표시/숨기기
+info_collect.export_csv=CSV 내보내기
+info_collect.export_csv_title=현재 결과를 CSV로 내보내기 (UTF-8, 한국어 지원)
+info_collect.export_json=JSON 내보내기
+info_collect.export_json_title=현재 결과를 JSON으로 내보내기
+info_collect.export_xlsx=XLSX 내보내기
+info_collect.export_xlsx_title=현재 결과를 Excel로 내보내기
+info_collect.batch_scan=일괄 스캔
+info_collect.batch_scan_title=선택한 행으로 일괄 작업 큐 생성
+info_collect.show_fields=표시 필드
+info_collect.show_all=전체 선택
+info_collect.hide_all=선택 해제
+
+# -- vulnerability page --
+vuln.page.title=취약점 관리
+vuln.page.add=취약점 추가
+vuln.stat.total=총 취약점 수
+vuln.filter.vuln_id=취약점 ID
+vuln.filter.vuln_id_placeholder=취약점 ID 검색
+vuln.filter.session_id=세션 ID
+vuln.filter.session_placeholder=특정 세션 필터
+vuln.filter.severity=심각도
+vuln.filter.all=전체
+vuln.filter.status=상태
+vuln.filter.status_open=대기 중
+vuln.filter.status_confirmed=확인됨
+vuln.filter.status_fixed=수정 완료
+vuln.filter.status_false_positive=오탐
+vuln.filter.filter_btn=필터
+vuln.filter.clear_btn=초기화
+
+# -- tasks page --
+task.page.title=작업 관리
+task.page.new=새 작업
+task.page.auto_refresh=자동 새로 고침
+task.filter.status=상태 필터
+task.filter.all=전체
+task.filter.pending=대기 중
+task.filter.running=실행 중
+task.filter.paused=일시 정지
+task.filter.completed=완료됨
+task.filter.cancelled=취소됨
+task.filter.search=큐 ID, 제목 또는 생성 시간 검색
+task.filter.search_placeholder=키워드 검색...
+
+# -- roles management page --
+roles_mgmt.title=역할 관리
+roles_mgmt.create=역할 생성
+roles_mgmt.search_placeholder=역할 검색...
+roles_mgmt.clear_search=검색 지우기
+
+# -- skills monitor page --
+skills_monitor.title=스킬 상태 모니터링
+skills_monitor.call_stats=호출 통계
+skills_monitor.skills_call_stats=스킬 호출 통계
+skills_monitor.clear_stats=통계 초기화
+
+# -- skills management page --
+skills_mgmt.title=스킬 관리
+skills_mgmt.create=스킬 생성
+skills_mgmt.search_placeholder=스킬 검색...
+skills_mgmt.clear_search=검색 지우기
+
+# -- settings page --
+settings.page.title=시스템 설정
+settings.nav.basic=기본 설정
+settings.nav.robots=봇 설정
+settings.nav.terminal=터미널
+settings.nav.security=보안 설정
+settings.basic.title=기본 설정
+settings.openai.title=OpenAI 설정
+settings.openai.api_key_placeholder=OpenAI API Key 입력
+settings.openai.model=모델
+settings.fofa.title=FOFA 설정
+settings.fofa.base_url_placeholder=https://fofa.info/api/v1/search/all (선택사항)
+settings.fofa.base_url_hint=비워두면 기본 주소를 사용합니다.
+settings.fofa.email_placeholder=FOFA 계정 이메일 입력
+settings.fofa.api_key_placeholder=FOFA API Key 입력
+settings.fofa.api_key_hint=서버 설정(`config.yaml`)에만 저장됩니다.
+settings.agent.title=에이전트 설정
+settings.agent.max_iterations=최대 반복 횟수
+settings.knowledge.title=지식 베이스 설정
+settings.knowledge.enabled=지식 검색 기능 활성화
+settings.knowledge.base_path=지식 베이스 경로
+settings.knowledge.base_path_hint=설정 파일 위치 기준 상대 경로
+settings.knowledge.embedding_title=임베딩 모델 설정
+settings.knowledge.provider=제공자
+settings.knowledge.embedding_base_url_placeholder=비워두면 OpenAI 설정의 base_url 사용
+settings.knowledge.embedding_api_key_placeholder=비워두면 OpenAI 설정의 api_key 사용
+settings.knowledge.embedding_model=모델명
+settings.knowledge.retrieval_title=검색 설정
+settings.knowledge.top_k=Top-K 결과 수
+settings.knowledge.top_k_hint=검색에서 반환할 Top-K 결과 수
+settings.knowledge.similarity=유사도 임계값
+settings.knowledge.similarity_hint=유사도 임계값 (0-1), 이 값 미만의 결과는 필터링됩니다
+settings.knowledge.hybrid_weight=하이브리드 검색 가중치
+settings.knowledge.hybrid_weight_hint=벡터 검색 가중치 (0-1), 1.0은 순수 벡터 검색, 0.0은 순수 키워드 검색
+settings.knowledge.indexing_title=인덱스 설정
+settings.knowledge.chunk_size=청크 크기 (Chunk Size)
+settings.knowledge.chunk_size_hint=블록당 최대 토큰 수 (기본 512), 긴 텍스트는 여러 블록으로 분할됩니다
+settings.knowledge.chunk_overlap=청크 오버랩 (Chunk Overlap)
+settings.knowledge.chunk_overlap_hint=블록 간 오버랩 토큰 수 (기본 50), 컨텍스트 연속성 유지
+settings.knowledge.max_chunks=항목당 최대 블록 수
+settings.knowledge.max_chunks_hint=항목당 최대 블록 수 (0은 제한 없음), 단일 파일의 과도한 API 사용 방지
+settings.knowledge.max_rpm=분당 최대 요청 수 (Max RPM)
+settings.knowledge.max_rpm_hint=분당 최대 요청 수 (기본 0은 제한 없음), OpenAI 기본 200 RPM
+settings.knowledge.rate_delay=요청 간격 (밀리초)
+settings.knowledge.rate_delay_hint=요청 간 밀리초 간격 (기본 300), API 속도 제한 방지, 0은 제한 없음
+settings.knowledge.max_retries=최대 재시도 횟수
+settings.knowledge.max_retries_hint=최대 재시도 횟수 (기본 3), 속도 제한 또는 서버 오류 시 자동 재시도
+settings.knowledge.retry_delay=재시도 간격 (밀리초)
+settings.knowledge.retry_delay_hint=재시도 간 밀리초 간격 (기본 1000), 매 재시도마다 지연 증가
+settings.apply_config=설정 적용
+
+# -- settings robots --
+settings.robots.title=봇 설정
+settings.robots.description=기업용 WeChat, DingTalk, Feishu 등의 봇을 설정하여 모바일에서 직접 CyberStrikeAI와 대화하세요. 서버에서 웹페이지를 열 필요가 없습니다.
+settings.robots.wecom=기업용 WeChat
+settings.robots.wecom_enabled=기업용 WeChat 봇 활성화
+settings.robots.wecom_encoding_hint=EncodingAESKey (평문 모드에서는 비워둘 수 있음)
+settings.robots.wecom_corp_id=기업 ID
+settings.robots.wecom_secret=앱 Secret
+settings.robots.wecom_agent_id=앱 AgentId
+settings.robots.dingtalk=DingTalk
+settings.robots.dingtalk_enabled=DingTalk 봇 활성화
+settings.robots.dingtalk_client_id=DingTalk 앱 AppKey
+settings.robots.dingtalk_client_secret=DingTalk 앱 Secret
+settings.robots.dingtalk_hint=봇 기능을 활성화하고 스트리밍 접근을 설정해야 합니다
+settings.robots.lark=Feishu (Lark)
+settings.robots.lark_enabled=Feishu 봇 활성화
+settings.robots.lark_app_id=Feishu 앱 App ID
+settings.robots.lark_app_secret=Feishu 앱 App Secret
+settings.robots.lark_verify_token=Verify Token (선택사항)
+settings.robots.lark_verify_placeholder=이벤트 구독 Verification Token
+settings.robots.commands_title=봇 명령 설명
+settings.robots.commands_desc=대화에서 다음 명령을 보낼 수 있습니다 (중국어/영어 지원):
+
+# -- settings terminal --
+settings.terminal.title=터미널
+settings.terminal.description=서버에서 명령을 실행합니다. 운영 및 디버깅에 유용합니다. 명령은 서버 측에서 실행되므로 민감하거나 파괴적인 작업은 피하세요.
+settings.terminal.tab=터미널 1
+settings.terminal.close=닫기
+settings.terminal.new=새 터미널
+
+# -- settings security --
+settings.security.title=보안 설정
+settings.security.change_password=비밀번호 변경
+settings.security.change_password_desc=비밀번호 변경 후 새 비밀번호로 다시 로그인해야 합니다.
+settings.security.current_password=현재 비밀번호
+settings.security.current_password_placeholder=현재 로그인 비밀번호 입력
+settings.security.new_password=새 비밀번호
+settings.security.new_password_placeholder=새 비밀번호 설정 (최소 8자)
+settings.security.confirm_password=새 비밀번호 확인
+settings.security.confirm_password_placeholder=새 비밀번호 다시 입력
+settings.security.clear_form=초기화
+settings.security.submit=비밀번호 변경
+
+# -- MCP detail modal --
+modal.mcp_detail.title=도구 호출 상세
+modal.mcp_detail.exec_info=실행 정보
+modal.mcp_detail.tool=도구
+modal.mcp_detail.status=상태
+modal.mcp_detail.time=시간
+modal.mcp_detail.exec_id=실행 ID
+modal.mcp_detail.request=요청 파라미터
+modal.mcp_detail.copy_json=JSON 복사
+modal.mcp_detail.response=응답 결과
+modal.mcp_detail.copy_content=내용 복사
+modal.mcp_detail.success_info=성공 정보
+modal.mcp_detail.error_info=오류 정보
+modal.mcp_detail.copy_error=오류 복사
+
+# -- external MCP modal --
+modal.external_mcp.add_title=외부 MCP 추가
+modal.external_mcp.config_json=설정 JSON
+modal.external_mcp.config_format=설정 형식:
+modal.external_mcp.config_format_desc=JSON 객체, key는 설정 이름, value는 설정 내용. 상태는 "시작/중지" 버튼으로 제어하며 JSON에 설정할 필요 없습니다.
+modal.external_mcp.example=설정 예시:
+modal.external_mcp.stdio_mode=stdio 모드:
+modal.external_mcp.http_mode=HTTP 모드:
+modal.external_mcp.sse_mode=SSE 모드:
+modal.external_mcp.format_json=JSON 포맷
+modal.external_mcp.load_example=예시 로드
+
+# -- attack chain modal --
+modal.attack_chain.title=공격 체인 시각화
+modal.attack_chain.regenerate=재생성
+modal.attack_chain.regenerate_title=공격 체인 재생성 (최신 대화 내용 포함)
+modal.attack_chain.export_png=PNG로 내보내기
+modal.attack_chain.export_svg=SVG로 내보내기
+modal.attack_chain.refresh=새로 고침
+modal.attack_chain.refresh_title=현재 공격 체인 새로 고침 (재생성하지 않음)
+modal.attack_chain.search_placeholder=노드 검색...
+modal.attack_chain.type_all=모든 유형
+modal.attack_chain.type_target=대상
+modal.attack_chain.type_action=행동
+modal.attack_chain.type_vulnerability=취약점
+modal.attack_chain.risk_all=모든 위험
+modal.attack_chain.risk_high=높은 위험 (80-100)
+modal.attack_chain.risk_medium_high=중상 위험 (60-79)
+modal.attack_chain.risk_medium=중간 위험 (40-59)
+modal.attack_chain.risk_low=낮은 위험 (0-39)
+modal.attack_chain.reset_filters=필터 초기화
+modal.attack_chain.legend_risk=위험 등급
+modal.attack_chain.legend_connections=연결선 의미
+modal.attack_chain.legend_blue=파란선: 행동으로 발견된 취약점
+modal.attack_chain.legend_red=빨간선: 활성화/촉진 관계
+modal.attack_chain.legend_gray=회색선: 논리적 순서
+modal.attack_chain.node_details=노드 상세
+modal.attack_chain.close_details=상세 닫기
+
+# -- skill modal --
+modal.skill.add_title=스킬 추가
+modal.skill.name=스킬 이름
+modal.skill.name_placeholder=예: sql-injection-testing
+modal.skill.name_hint=영문자, 숫자, 하이픈, 언더스코어만 사용 가능
+modal.skill.description=설명
+modal.skill.description_placeholder=스킬에 대한 간단한 설명
+modal.skill.content=내용 (Markdown 형식)
+modal.skill.content_placeholder=스킬 내용 입력, Markdown 형식 지원...
+modal.skill.content_hint_prefix=YAML front matter 형식 지원 (선택사항), 예시:
+
+# -- knowledge item modal --
+modal.knowledge.add_title=지식 추가
+modal.knowledge.category=분류 (위험 유형)
+modal.knowledge.category_placeholder=예: SQL 인젝션
+modal.knowledge.item_title=제목
+modal.knowledge.item_title_placeholder=지식 항목 제목
+modal.knowledge.content=내용 (Markdown 형식)
+modal.knowledge.content_placeholder=지식 내용 입력, Markdown 형식 지원...
+
+# -- batch manage modal --
+modal.batch_manage.title=대화 기록 관리 · 총
+modal.batch_manage.title_suffix=건
+modal.batch_manage.search_placeholder=기록 검색
+modal.batch_manage.col_name=대화 이름
+modal.batch_manage.col_time=마지막 대화 시간
+modal.batch_manage.col_action=작업
+modal.batch_manage.select_all=전체 선택
+modal.batch_manage.delete_selected=선택 항목 삭제
+
+# -- create group modal --
+modal.create_group.title=그룹 생성
+modal.create_group.description=그룹 기능으로 대화를 분류하여 체계적으로 관리할 수 있습니다.
+modal.create_group.name_placeholder=그룹 이름을 입력하세요
+modal.create_group.select_icon=아이콘 선택
+modal.create_group.custom=사용자 정의
+modal.create_group.apply=확인
+modal.create_group.suggestion_pentest=침투 테스트
+modal.create_group.suggestion_ctf=CTF
+modal.create_group.suggestion_redteam=레드팀
+modal.create_group.suggestion_vulnhunt=취약점 발굴
+modal.create_group.create=생성
+
+# -- context menu --
+ctx.view_attack_chain=공격 체인 보기
+ctx.rename=이름 변경
+ctx.pin_conversation=이 대화 고정
+ctx.batch_manage=일괄 관리
+ctx.move_to_group=그룹으로 이동
+ctx.delete_conversation=이 대화 삭제
+ctx.pin_group=이 그룹 고정
+ctx.delete_group=이 그룹 삭제
+
+# -- batch import modal --
+modal.batch_import.title=새 작업
+modal.batch_import.queue_title=작업 제목
+modal.batch_import.queue_title_placeholder=작업 제목 입력 (선택사항, 식별 및 필터링용)
+modal.batch_import.queue_title_hint=일괄 작업 큐에 제목을 설정하면 나중에 찾고 관리하기 쉽습니다.
+modal.batch_import.role=역할
+modal.batch_import.role_default=기본
+modal.batch_import.role_hint=역할을 선택하면 모든 작업이 해당 역할의 설정 (프롬프트 및 도구)으로 실행됩니다.
+modal.batch_import.tasks_label=작업 목록 (한 줄에 하나씩)
+modal.batch_import.tasks_placeholder=작업 목록을 입력하세요, 한 줄에 하나씩
+modal.batch_import.tasks_hint=한 줄에 하나의 작업 지시를 입력하면 시스템이 순차적으로 실행합니다. 빈 줄은 자동으로 무시됩니다.
+modal.batch_import.create_queue=큐 생성
+
+# -- batch queue detail modal --
+modal.batch_queue.detail_title=일괄 작업 큐 상세
+modal.batch_queue.add_task=작업 추가
+modal.batch_queue.start=실행 시작
+modal.batch_queue.pause=큐 일시 정지
+modal.batch_queue.delete=큐 삭제
+
+# -- edit batch task modal --
+modal.edit_task.title=작업 편집
+modal.edit_task.message=작업 메시지
+modal.edit_task.message_placeholder=작업 메시지를 입력하세요
+
+# -- add batch task modal --
+modal.add_task.title=작업 추가
+modal.add_task.message=작업 메시지
+modal.add_task.message_placeholder=작업 메시지를 입력하세요
+modal.add_task.add=추가
+
+# -- vulnerability modal --
+modal.vuln.add_title=취약점 추가
+modal.vuln.session_id=세션 ID
+modal.vuln.session_id_placeholder=세션 ID 입력
+modal.vuln.title=제목
+modal.vuln.title_placeholder=취약점 제목
+modal.vuln.description=설명
+modal.vuln.description_placeholder=취약점 상세 설명
+modal.vuln.severity=심각도
+modal.vuln.severity_select=선택하세요
+modal.vuln.status=상태
+modal.vuln.type=취약점 유형
+modal.vuln.type_placeholder=예: SQL 인젝션, XSS, CSRF 등
+modal.vuln.target=대상
+modal.vuln.target_placeholder=영향받는 대상 (URL, IP 주소 등)
+modal.vuln.proof=증거 (POC)
+modal.vuln.proof_placeholder=취약점 증거, 예: 요청/응답, 스크린샷 등
+modal.vuln.impact=영향
+modal.vuln.impact_placeholder=취약점 영향 설명
+modal.vuln.recommendation=수정 권장사항
+modal.vuln.recommendation_placeholder=수정 권장사항
+
+# -- role select modal --
+modal.role_select.title=역할 선택
+
+# -- role modal --
+modal.role.add_title=역할 추가
+modal.role.name=역할 이름
+modal.role.name_placeholder=역할 이름 입력
+modal.role.description=역할 설명
+modal.role.description_placeholder=역할 설명 입력
+modal.role.icon=역할 아이콘
+modal.role.icon_placeholder=이모지 아이콘 입력, 예: 🏆
+modal.role.icon_hint=역할 선택기에 표시될 이모지 아이콘을 입력하세요.
+modal.role.user_prompt=사용자 프롬프트
+modal.role.user_prompt_placeholder=사용자 프롬프트 입력, 사용자 메시지 앞에 추가됩니다...
+modal.role.user_prompt_hint=이 프롬프트는 사용자 메시지 앞에 추가되어 AI의 동작을 안내합니다. 참고: 시스템 프롬프트는 변경되지 않습니다.
+modal.role.tools=연결된 도구 (선택사항)
+modal.role.tools_default_title=기본 역할은 모든 도구 사용
+modal.role.tools_default_desc=기본 역할은 MCP 관리에서 활성화된 모든 도구를 자동으로 사용하며 별도 설정이 필요 없습니다.
+modal.role.tools_select_all=전체 선택
+modal.role.tools_deselect_all=선택 해제
+modal.role.tools_search_placeholder=도구 검색...
+modal.role.tools_clear_search=검색 지우기
+modal.role.tools_loading=도구 목록 로딩 중...
+modal.role.tools_hint=연결할 도구를 선택하세요. 비워두면 MCP 관리의 전체 도구 설정을 사용합니다.
+modal.role.skills=연결된 스킬 (선택사항)
+modal.role.skills_select_all=전체 선택
+modal.role.skills_deselect_all=선택 해제
+modal.role.skills_search_placeholder=스킬 검색...
+modal.role.skills_clear_search=검색 지우기
+modal.role.skills_loading=스킬 목록 로딩 중...
+modal.role.skills_hint=연결할 스킬을 선택하세요. 이 스킬의 내용은 작업 실행 전 시스템 프롬프트에 주입되어 AI가 관련 전문 지식을 더 잘 이해하도록 돕습니다.
+modal.role.enabled=이 역할 활성화
+
+# -- remaining strings (phase 3 pass 2) --
+info_collect.fofa_query_placeholder=예: app="Apache" && country="CN"
+info_collect.fofa_query_presets_aria=FOFA 쿼리 예시
+info_collect.fofa_fields_presets_aria=FOFA 필드 템플릿
+modal.attack_chain.stats_nodes=노드
+modal.attack_chain.stats_edges=엣지
+settings.robots.cmd_help=도움말 표시
+settings.robots.cmd_list=모든 대화 제목과 ID 나열
+settings.robots.cmd_switch=지정 대화로 전환
+settings.robots.cmd_new=새 대화 시작
+settings.robots.cmd_clear=현재 컨텍스트 초기화
+settings.robots.cmd_current=현재 대화 ID와 제목 표시
+settings.robots.cmd_stop=현재 작업 중단
+settings.robots.cmd_roles=사용 가능한 모든 역할 나열
+settings.robots.cmd_role=현재 역할 전환
+settings.robots.cmd_delete=지정 대화 삭제
+settings.robots.cmd_version=현재 버전 표시
+settings.robots.cmd_other=위 명령어 외에 직접 내용을 입력하면 AI에게 전송되어 침투 테스트/보안 분석이 수행됩니다. Otherwise, send any text for AI penetration testing / security analysis.
+
+# -- common UI --
+ui.loading=로딩 중...
+ui.btn.search=검색
+ui.btn.filter=필터
+ui.btn.reset=초기화

--- a/run.sh
+++ b/run.sh
@@ -2,46 +2,44 @@
 
 set -euo pipefail
 
-# CyberStrikeAI 一键部署启动脚本
+# CyberStrikeAI 원클릭 배포 시작 스크립트
 ROOT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$ROOT_DIR"
 
-# 颜色定义
+# 색상 정의
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 CYAN='\033[0;36m'
-NC='\033[0m' # No Color
+NC='\033[0m' # 색상 초기화
 
-# 打印带颜色的消息
+# 색상 메시지 출력 함수
 info() { echo -e "${BLUE}ℹ️  $1${NC}"; }
 success() { echo -e "${GREEN}✅ $1${NC}"; }
 warning() { echo -e "${YELLOW}⚠️  $1${NC}"; }
 error() { echo -e "${RED}❌ $1${NC}"; }
 note() { echo -e "${CYAN}ℹ️  $1${NC}"; }
 
-# 临时源配置（仅在此脚本中生效）
+# 임시 미러 설정 (이 스크립트 실행 중에만 적용)
 PIP_INDEX_URL="${PIP_INDEX_URL:-https://pypi.tuna.tsinghua.edu.cn/simple}"
 GOPROXY="${GOPROXY:-https://goproxy.cn,direct}"
 
-# 保存原始环境变量（用于恢复）
+# 원래 환경 변수 저장 (복원용)
 ORIGINAL_PIP_INDEX_URL="${PIP_INDEX_URL:-}"
 ORIGINAL_GOPROXY="${GOPROXY:-}"
 
-# 进度显示函数
+# 진행 상태 표시 함수
 show_progress() {
     local pid=$1
     local message=$2
     local i=0
     local dots=""
-    
-    # 检查进程是否存在
+
     if ! kill -0 "$pid" 2>/dev/null; then
-        # 进程已经结束，立即返回
         return 0
     fi
-    
+
     while kill -0 "$pid" 2>/dev/null; do
         i=$((i + 1))
         case $((i % 4)) in
@@ -52,8 +50,7 @@ show_progress() {
         esac
         printf "\r${BLUE}⏳ %s%s${NC}" "$message" "$dots"
         sleep 0.5
-        
-        # 再次检查进程是否还存在
+
         if ! kill -0 "$pid" 2>/dev/null; then
             break
         fi
@@ -63,20 +60,19 @@ show_progress() {
 
 echo ""
 echo "=========================================="
-echo "  CyberStrikeAI 一键部署启动脚本"
+echo "  CyberStrikeAI 원클릭 배포 시작 스크립트"
 echo "=========================================="
 echo ""
 
-# 显示临时源配置信息
 echo ""
-warning "⚠️  注意：此脚本将使用临时镜像源加速下载"
+warning "⚠️  주의: 이 스크립트는 임시 미러를 사용하여 다운로드를 가속합니다"
 echo ""
-info "Python pip 临时镜像源:"
+info "Python pip 임시 미러:"
 echo "  ${PIP_INDEX_URL}"
-info "Go Proxy 临时镜像源:"
+info "Go Proxy 임시 미러:"
 echo "  ${GOPROXY}"
 echo ""
-note "这些设置仅在脚本运行期间生效，不会修改系统配置"
+note "이 설정은 스크립트 실행 중에만 적용되며 시스템 설정을 변경하지 않습니다"
 echo ""
 sleep 1
 
@@ -85,250 +81,230 @@ VENV_DIR="$ROOT_DIR/venv"
 REQUIREMENTS_FILE="$ROOT_DIR/requirements.txt"
 BINARY_NAME="cyberstrike-ai"
 
-# 检查配置文件
+# 설정 파일 확인
 if [ ! -f "$CONFIG_FILE" ]; then
-    error "配置文件 config.yaml 不存在"
-    info "请确保在项目根目录运行此脚本"
+    error "설정 파일 config.yaml 이 존재하지 않습니다"
+    info "프로젝트 루트 디렉토리에서 스크립트를 실행했는지 확인하세요"
     exit 1
 fi
 
-# 检查并安装 Python 环境
+# Python 환경 확인
 check_python() {
     if ! command -v python3 >/dev/null 2>&1; then
-        error "未找到 python3"
+        error "python3 를 찾을 수 없습니다"
         echo ""
-        info "请先安装 Python 3.10 或更高版本："
+        info "Python 3.10 이상을 먼저 설치해주세요:"
         echo "  macOS:   brew install python3"
         echo "  Ubuntu:  sudo apt-get install python3 python3-venv"
         echo "  CentOS:  sudo yum install python3 python3-pip"
         exit 1
     fi
-    
+
     PYTHON_VERSION=$(python3 --version 2>&1 | awk '{print $2}')
     PYTHON_MAJOR=$(echo "$PYTHON_VERSION" | cut -d. -f1)
     PYTHON_MINOR=$(echo "$PYTHON_VERSION" | cut -d. -f2)
-    
+
     if [ "$PYTHON_MAJOR" -lt 3 ] || ([ "$PYTHON_MAJOR" -eq 3 ] && [ "$PYTHON_MINOR" -lt 10 ]); then
-        error "Python 版本过低: $PYTHON_VERSION (需要 3.10+)"
+        error "Python 버전이 너무 낮습니다: $PYTHON_VERSION (3.10 이상 필요)"
         exit 1
     fi
-    
-    success "Python 环境检查通过: $PYTHON_VERSION"
+
+    success "Python 환경 확인 완료: $PYTHON_VERSION"
 }
 
-# 检查并安装 Go 环境
+# Go 환경 확인
 check_go() {
     if ! command -v go >/dev/null 2>&1; then
-        error "未找到 Go"
+        error "Go 를 찾을 수 없습니다"
         echo ""
-        info "请先安装 Go 1.21 或更高版本："
+        info "Go 1.21 이상을 먼저 설치해주세요:"
         echo "  macOS:   brew install go"
         echo "  Ubuntu:  sudo apt-get install golang-go"
         echo "  CentOS:  sudo yum install golang"
-        echo "  或访问:  https://go.dev/dl/"
+        echo "  또는:    https://go.dev/dl/"
         exit 1
     fi
-    
+
     GO_VERSION=$(go version | awk '{print $3}' | sed 's/go//')
     GO_MAJOR=$(echo "$GO_VERSION" | cut -d. -f1)
     GO_MINOR=$(echo "$GO_VERSION" | cut -d. -f2)
-    
+
     if [ "$GO_MAJOR" -lt 1 ] || ([ "$GO_MAJOR" -eq 1 ] && [ "$GO_MINOR" -lt 21 ]); then
-        error "Go 版本过低: $GO_VERSION (需要 1.21+)"
+        error "Go 버전이 너무 낮습니다: $GO_VERSION (1.21 이상 필요)"
         exit 1
     fi
-    
-    success "Go 环境检查通过: $(go version)"
+
+    success "Go 환경 확인 완료: $(go version)"
 }
 
-# 设置 Python 虚拟环境
+# Python 가상환경 설정
 setup_python_env() {
     if [ ! -d "$VENV_DIR" ]; then
-        info "创建 Python 虚拟环境..."
+        info "Python 가상환경 생성 중..."
         python3 -m venv "$VENV_DIR"
-        success "虚拟环境创建完成"
+        success "가상환경 생성 완료"
     else
-        info "Python 虚拟环境已存在"
+        info "Python 가상환경이 이미 존재합니다"
     fi
-    
-    info "激活虚拟环境..."
+
+    info "가상환경 활성화 중..."
     # shellcheck disable=SC1091
     source "$VENV_DIR/bin/activate"
-    
+
     if [ -f "$REQUIREMENTS_FILE" ]; then
         echo ""
         note "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-        note "⚠️  使用临时 pip 镜像源（仅本次脚本运行有效）"
-        note "   镜像地址: ${PIP_INDEX_URL}"
-        note "   如需永久配置，请设置环境变量 PIP_INDEX_URL"
+        note "⚠️  임시 pip 미러 사용 중 (이번 스크립트 실행에만 적용)"
+        note "   미러 주소: ${PIP_INDEX_URL}"
+        note "   영구 설정이 필요하면 환경변수 PIP_INDEX_URL 을 설정하세요"
         note "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
         echo ""
-        
-        info "升级 pip..."
+
+        info "pip 업그레이드 중..."
         pip install --index-url "$PIP_INDEX_URL" --upgrade pip >/dev/null 2>&1 || true
-        
-        info "安装 Python 依赖包..."
+
+        info "Python 패키지 설치 중..."
         echo ""
-        
-        # 尝试安装依赖，捕获错误输出并显示进度
+
         PIP_LOG=$(mktemp)
         (
-            set +e  # 在子shell中禁用错误退出
+            set +e
             pip install --index-url "$PIP_INDEX_URL" -r "$REQUIREMENTS_FILE" >"$PIP_LOG" 2>&1
             echo $? > "${PIP_LOG}.exit"
         ) &
         PIP_PID=$!
-        
-        # 等待一小段时间，确保进程启动
+
         sleep 0.1
-        
-        # 显示进度（如果进程还在运行）
+
         if kill -0 "$PIP_PID" 2>/dev/null; then
-            show_progress "$PIP_PID" "正在安装依赖包"
+            show_progress "$PIP_PID" "패키지 설치 중"
         else
-            # 进程已经结束，等待一下确保退出码文件已写入
             sleep 0.2
         fi
-        
-        # 等待进程完成，忽略 wait 的退出码
+
         wait "$PIP_PID" 2>/dev/null || true
-        
+
         PIP_EXIT_CODE=0
         if [ -f "${PIP_LOG}.exit" ]; then
             PIP_EXIT_CODE=$(cat "${PIP_LOG}.exit" 2>/dev/null || echo "1")
             rm -f "${PIP_LOG}.exit" 2>/dev/null || true
         else
-            # 如果没有退出码文件，检查日志中是否有错误
             if [ -f "$PIP_LOG" ] && grep -q -i "error\|failed\|exception" "$PIP_LOG" 2>/dev/null; then
                 PIP_EXIT_CODE=1
             fi
         fi
-        
+
         if [ $PIP_EXIT_CODE -eq 0 ]; then
-            success "Python 依赖安装完成"
+            success "Python 패키지 설치 완료"
         else
-            # 检查是否是 angr 安装失败（需要 Rust）
             if grep -q "angr" "$PIP_LOG" && grep -q "Rust compiler\|can't find Rust" "$PIP_LOG"; then
-                warning "angr 安装失败（需要 Rust 编译器）"
+                warning "angr 설치 실패 (Rust 컴파일러 필요)"
                 echo ""
-                info "angr 是可选依赖，主要用于二进制分析工具"
-                info "如果需要使用 angr，请先安装 Rust："
-                echo "  macOS:   curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh"
-                echo "  Ubuntu:  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh"
-                echo "  或访问:  https://rustup.rs/"
+                info "angr 는 선택적 의존성으로 주로 바이너리 분석 도구에 사용됩니다"
+                info "angr 가 필요하다면 먼저 Rust 를 설치하세요:"
+                echo "  macOS/Ubuntu: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh"
+                echo "  또는:         https://rustup.rs/"
                 echo ""
-                info "其他依赖已安装，可以继续使用（部分工具可能不可用）"
+                info "다른 패키지는 설치되었으며 계속 실행할 수 있습니다 (일부 도구 사용 불가)"
             else
-                warning "部分 Python 依赖安装失败，但可以继续尝试运行"
-                warning "如果遇到问题，请检查错误信息并手动安装缺失的依赖"
-                # 显示最后几行错误信息
+                warning "일부 Python 패키지 설치에 실패했지만 계속 시도합니다"
+                warning "문제가 발생하면 오류 메시지를 확인하고 누락된 패키지를 수동으로 설치하세요"
                 echo ""
-                info "错误详情（最后 10 行）："
+                info "오류 상세 (마지막 10줄):"
                 tail -n 10 "$PIP_LOG" | sed 's/^/  /'
                 echo ""
             fi
         fi
         rm -f "$PIP_LOG"
     else
-        warning "未找到 requirements.txt，跳过 Python 依赖安装"
+        warning "requirements.txt 를 찾을 수 없습니다. Python 패키지 설치를 건너뜁니다"
     fi
 }
 
-# 构建 Go 项目
+# Go 프로젝트 빌드
 build_go_project() {
     echo ""
     note "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-    note "⚠️  使用临时 Go Proxy（仅本次脚本运行有效）"
-    note "   Proxy 地址: ${GOPROXY}"
-    note "   如需永久配置，请设置环境变量 GOPROXY"
+    note "⚠️  임시 Go Proxy 사용 중 (이번 스크립트 실행에만 적용)"
+    note "   Proxy 주소: ${GOPROXY}"
+    note "   영구 설정이 필요하면 환경변수 GOPROXY 를 설정하세요"
     note "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
     echo ""
-    
-    info "下载 Go 依赖..."
+
+    info "Go 의존성 다운로드 중..."
     GO_DOWNLOAD_LOG=$(mktemp)
     (
-        set +e  # 在子shell中禁用错误退出
+        set +e
         export GOPROXY="$GOPROXY"
         go mod download >"$GO_DOWNLOAD_LOG" 2>&1
         echo $? > "${GO_DOWNLOAD_LOG}.exit"
     ) &
     GO_DOWNLOAD_PID=$!
-    
-    # 等待一小段时间，确保进程启动
+
     sleep 0.1
-    
-    # 显示进度（如果进程还在运行）
+
     if kill -0 "$GO_DOWNLOAD_PID" 2>/dev/null; then
-        show_progress "$GO_DOWNLOAD_PID" "正在下载 Go 依赖"
+        show_progress "$GO_DOWNLOAD_PID" "Go 의존성 다운로드 중"
     else
-        # 进程已经结束，等待一下确保退出码文件已写入
         sleep 0.2
     fi
-    
-    # 等待进程完成，忽略 wait 的退出码
+
     wait "$GO_DOWNLOAD_PID" 2>/dev/null || true
-    
+
     GO_DOWNLOAD_EXIT_CODE=0
     if [ -f "${GO_DOWNLOAD_LOG}.exit" ]; then
         GO_DOWNLOAD_EXIT_CODE=$(cat "${GO_DOWNLOAD_LOG}.exit" 2>/dev/null || echo "1")
         rm -f "${GO_DOWNLOAD_LOG}.exit" 2>/dev/null || true
     else
-        # 如果没有退出码文件，检查日志中是否有错误
         if [ -f "$GO_DOWNLOAD_LOG" ] && grep -q -i "error\|failed" "$GO_DOWNLOAD_LOG" 2>/dev/null; then
             GO_DOWNLOAD_EXIT_CODE=1
         fi
     fi
     rm -f "$GO_DOWNLOAD_LOG" 2>/dev/null || true
-    
+
     if [ $GO_DOWNLOAD_EXIT_CODE -ne 0 ]; then
-        error "Go 依赖下载失败"
+        error "Go 의존성 다운로드 실패"
         exit 1
     fi
-    success "Go 依赖下载完成"
-    
-    info "构建项目..."
+    success "Go 의존성 다운로드 완료"
+
+    info "프로젝트 빌드 중..."
     GO_BUILD_LOG=$(mktemp)
     (
-        set +e  # 在子shell中禁用错误退出
+        set +e
         export GOPROXY="$GOPROXY"
         go build -o "$BINARY_NAME" cmd/server/main.go >"$GO_BUILD_LOG" 2>&1
         echo $? > "${GO_BUILD_LOG}.exit"
     ) &
     GO_BUILD_PID=$!
-    
-    # 等待一小段时间，确保进程启动
+
     sleep 0.1
-    
-    # 显示进度（如果进程还在运行）
+
     if kill -0 "$GO_BUILD_PID" 2>/dev/null; then
-        show_progress "$GO_BUILD_PID" "正在构建项目"
+        show_progress "$GO_BUILD_PID" "프로젝트 빌드 중"
     else
-        # 进程已经结束，等待一下确保退出码文件已写入
         sleep 0.2
     fi
-    
-    # 等待进程完成，忽略 wait 的退出码
+
     wait "$GO_BUILD_PID" 2>/dev/null || true
-    
+
     GO_BUILD_EXIT_CODE=0
     if [ -f "${GO_BUILD_LOG}.exit" ]; then
         GO_BUILD_EXIT_CODE=$(cat "${GO_BUILD_LOG}.exit" 2>/dev/null || echo "1")
         rm -f "${GO_BUILD_LOG}.exit" 2>/dev/null || true
     else
-        # 如果没有退出码文件，检查日志中是否有错误
         if [ -f "$GO_BUILD_LOG" ] && grep -q -i "error\|failed" "$GO_BUILD_LOG" 2>/dev/null; then
             GO_BUILD_EXIT_CODE=1
         fi
     fi
-    
+
     if [ $GO_BUILD_EXIT_CODE -eq 0 ]; then
-        success "项目构建完成: $BINARY_NAME"
+        success "프로젝트 빌드 완료: $BINARY_NAME"
         rm -f "$GO_BUILD_LOG"
     else
-        error "项目构建失败"
-        # 显示构建错误
+        error "프로젝트 빌드 실패"
         echo ""
-        info "构建错误详情："
+        info "빌드 오류 상세:"
         cat "$GO_BUILD_LOG" | sed 's/^/  /'
         echo ""
         rm -f "$GO_BUILD_LOG"
@@ -336,54 +312,48 @@ build_go_project() {
     fi
 }
 
-# 检查是否需要重新构建
+# 재빌드 필요 여부 확인
 need_rebuild() {
     if [ ! -f "$BINARY_NAME" ]; then
-        return 0  # 需要构建
+        return 0  # 빌드 필요
     fi
-    
-    # 检查源代码是否有更新
+
     if [ "$BINARY_NAME" -ot cmd/server/main.go ] || \
        [ "$BINARY_NAME" -ot go.mod ] || \
        find internal cmd -name "*.go" -newer "$BINARY_NAME" 2>/dev/null | grep -q .; then
-        return 0  # 需要重新构建
+        return 0  # 재빌드 필요
     fi
-    
-    return 1  # 不需要构建
+
+    return 1  # 빌드 불필요
 }
 
-# 主流程
+# 메인 프로세스
 main() {
-    # 环境检查
-    info "检查运行环境..."
+    info "실행 환경 확인 중..."
     check_python
     check_go
     echo ""
-    
-    # 设置 Python 环境
-    info "设置 Python 环境..."
+
+    info "Python 환경 설정 중..."
     setup_python_env
     echo ""
-    
-    # 构建 Go 项目
+
     if need_rebuild; then
-        info "准备构建项目..."
+        info "프로젝트 빌드 준비 중..."
         build_go_project
     else
-        success "可执行文件已是最新，跳过构建"
+        success "실행 파일이 최신 상태입니다. 빌드를 건너뜁니다"
     fi
     echo ""
-    
-    # 启动服务器
-    success "所有准备工作完成！"
+
+    success "모든 준비가 완료되었습니다!"
     echo ""
-    info "启动 CyberStrikeAI 服务器..."
+    info "CyberStrikeAI 서버 시작 중..."
     echo "=========================================="
     echo ""
-    
-    # 运行服务器
+
     exec "./$BINARY_NAME"
 }
 
-# 执行主流程
+# 메인 프로세스 실행
 main

--- a/web/static/js/auth.js
+++ b/web/static/js/auth.js
@@ -123,7 +123,8 @@ async function ensureAuthenticated() {
     return true;
 }
 
-function handleUnauthorized({ message = '认证已过期，请重新登录', silent = false } = {}) {
+function handleUnauthorized({ message = null, silent = false } = {}) {
+    if (message === null) { message = t('auth.error.expired'); }
     clearAuthStorage();
     authPromise = null;
     authPromiseResolvers = [];
@@ -165,7 +166,7 @@ async function submitLogin(event) {
     const password = passwordInput.value.trim();
     if (!password) {
         if (errorBox) {
-            errorBox.textContent = '请输入密码';
+            errorBox.textContent = t('auth.error.password_empty');
             errorBox.style.display = 'block';
         }
         return;
@@ -186,7 +187,7 @@ async function submitLogin(event) {
         const result = await response.json().catch(() => ({}));
         if (!response.ok || !result.token) {
             if (errorBox) {
-                errorBox.textContent = result.error || '登录失败，请检查密码';
+                errorBox.textContent = result.error || t('auth.error.login_failed');
                 errorBox.style.display = 'block';
             }
             return;
@@ -203,7 +204,7 @@ async function submitLogin(event) {
     } catch (error) {
         console.error('登录失败:', error);
         if (errorBox) {
-            errorBox.textContent = '登录失败，请稍后重试';
+            errorBox.textContent = t('auth.error.login_retry');
             errorBox.style.display = 'block';
         }
     } finally {
@@ -231,10 +232,10 @@ async function bootstrapApp() {
 // 通用工具函数
 function getStatusText(status) {
     const statusMap = {
-        'pending': '等待中',
-        'running': '执行中',
-        'completed': '已完成',
-        'failed': '失败'
+        'pending': t('auth.status.pending'),
+        'running': t('auth.status.running'),
+        'completed': t('auth.status.completed'),
+        'failed': t('auth.status.failed')
     };
     return statusMap[status] || status;
 }
@@ -375,7 +376,7 @@ async function logout() {
         // 无论如何都清除本地认证信息
         clearAuthStorage();
         hideLoginOverlay();
-        showLoginOverlay('已退出登录');
+        showLoginOverlay(t('auth.message.logged_out'));
     }
 }
 

--- a/web/static/js/chat.js
+++ b/web/static/js/chat.js
@@ -24,7 +24,7 @@ const DRAFT_SAVE_DELAY = 500; // 500ms防抖延迟
 
 // 对话文件上传相关（后端会拼接路径与内容发给大模型，前端不再重复发文件列表）
 const MAX_CHAT_FILES = 10;
-const CHAT_FILE_DEFAULT_PROMPT = '请根据上传的文件内容进行分析。';
+const CHAT_FILE_DEFAULT_PROMPT = () => t('chat.file.default_prompt');
 /** @type {{ fileName: string, content: string, mimeType: string }[]} */
 let chatAttachments = [];
 
@@ -121,7 +121,7 @@ async function sendMessage() {
     }
     // 有附件且用户未输入时，发一句简短默认提示即可（后端会拼接路径和文件内容给大模型）
     if (hasAttachments && !message) {
-        message = CHAT_FILE_DEFAULT_PROMPT;
+        message = CHAT_FILE_DEFAULT_PROMPT();
     }
 
     // 显示用户消息（含附件名，便于用户确认）
@@ -263,9 +263,9 @@ function renderChatFileChips() {
         const remove = document.createElement('button');
         remove.type = 'button';
         remove.className = 'chat-file-chip-remove';
-        remove.title = '移除';
+        remove.title = t('chat.btn.remove');
         remove.innerHTML = '×';
-        remove.setAttribute('aria-label', '移除 ' + a.fileName);
+        remove.setAttribute('aria-label', t('chat.btn.remove_file').replace('{0}', a.fileName));
         remove.addEventListener('click', () => removeChatAttachment(i));
         chip.appendChild(name);
         chip.appendChild(remove);
@@ -283,7 +283,7 @@ function appendChatFilePrompt() {
     const input = document.getElementById('chat-input');
     if (!input || !chatAttachments.length) return;
     if (!input.value.trim()) {
-        input.value = CHAT_FILE_DEFAULT_PROMPT;
+        input.value = CHAT_FILE_DEFAULT_PROMPT();
         adjustTextareaHeight(input);
     }
 }
@@ -313,7 +313,7 @@ function addFilesToChat(files) {
     if (!files || !files.length) return;
     const next = Array.from(files);
     if (chatAttachments.length + next.length > MAX_CHAT_FILES) {
-        alert('最多同时上传 ' + MAX_CHAT_FILES + ' 个文件，当前已选 ' + chatAttachments.length + ' 个。');
+        alert(t('chat.file.max_exceeded').replace('{0}', MAX_CHAT_FILES).replace('{1}', chatAttachments.length));
         return;
     }
     const addOne = (file) => {
@@ -322,7 +322,7 @@ function addFilesToChat(files) {
             renderChatFileChips();
             appendChatFilePrompt();
         }).catch(() => {
-            alert('读取文件失败：' + file.name);
+            alert(t('chat.file.read_failed').replace('{0}', file.name));
         });
     };
     let p = Promise.resolve();
@@ -720,14 +720,14 @@ function renderMentionSuggestions({ showLoading = false } = {}) {
     const previousScrollTop = canPreserveScroll ? existingList.scrollTop : 0;
 
     if (showLoading) {
-        mentionSuggestionsEl.innerHTML = '<div class="mention-empty">正在加载工具...</div>';
+        mentionSuggestionsEl.innerHTML = '<div class="mention-empty">' + t('chat.mention.loading') + '</div>';
         mentionSuggestionsEl.style.display = 'block';
         delete mentionSuggestionsEl.dataset.lastMentionQuery;
         return;
     }
 
     if (!mentionFilteredTools.length) {
-        mentionSuggestionsEl.innerHTML = '<div class="mention-empty">没有匹配的工具</div>';
+        mentionSuggestionsEl.innerHTML = '<div class="mention-empty">' + t('chat.mention.no_match') + '</div>';
         mentionSuggestionsEl.style.display = 'block';
         mentionSuggestionsEl.dataset.lastMentionQuery = currentQuery;
         return;
@@ -1129,8 +1129,8 @@ function addMessage(role, content, mcpExecutionIds = null, progressId = null, cr
     if (role === 'assistant') {
         const copyBtn = document.createElement('button');
         copyBtn.className = 'message-copy-btn';
-        copyBtn.innerHTML = '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><rect x="9" y="9" width="13" height="13" rx="2" ry="2" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/></svg><span>复制</span>';
-        copyBtn.title = '复制消息内容';
+        copyBtn.innerHTML = '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><rect x="9" y="9" width="13" height="13" rx="2" ry="2" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/></svg><span>' + t('chat.btn.copy') + '</span>';
+        copyBtn.title = t('chat.btn.copy');
         copyBtn.onclick = function(e) {
             e.stopPropagation();
             copyMessageToClipboard(messageDiv, this);
@@ -1169,18 +1169,18 @@ function addMessage(role, content, mcpExecutionIds = null, progressId = null, cr
         
         const mcpLabel = document.createElement('div');
         mcpLabel.className = 'mcp-call-label';
-        mcpLabel.textContent = '📋 渗透测试详情';
+        mcpLabel.textContent = t('chat.mcp.label');
         mcpSection.appendChild(mcpLabel);
-        
+
         const buttonsContainer = document.createElement('div');
         buttonsContainer.className = 'mcp-call-buttons';
-        
+
         // 如果有MCP执行ID，添加MCP调用详情按钮
         if (mcpExecutionIds && Array.isArray(mcpExecutionIds) && mcpExecutionIds.length > 0) {
             mcpExecutionIds.forEach((execId, index) => {
                 const detailBtn = document.createElement('button');
                 detailBtn.className = 'mcp-detail-btn';
-                detailBtn.innerHTML = `<span>调用 #${index + 1}</span>`;
+                detailBtn.innerHTML = '<span>' + t('chat.mcp.call').replace('{0}', index + 1) + '</span>';
                 detailBtn.onclick = () => showMCPDetail(execId);
                 buttonsContainer.appendChild(detailBtn);
                 // 异步获取工具名称并更新按钮文本
@@ -1192,7 +1192,7 @@ function addMessage(role, content, mcpExecutionIds = null, progressId = null, cr
         if (progressId) {
             const progressDetailBtn = document.createElement('button');
             progressDetailBtn.className = 'mcp-detail-btn process-detail-btn';
-            progressDetailBtn.innerHTML = '<span>展开详情</span>';
+            progressDetailBtn.innerHTML = '<span>' + t('chat.details.expand') + '</span>';
             progressDetailBtn.onclick = () => toggleProcessDetails(progressId, messageDiv.id);
             buttonsContainer.appendChild(progressDetailBtn);
             // 存储进度ID到消息元素
@@ -1236,7 +1236,7 @@ function copyMessageToClipboard(messageDiv, button) {
                     showCopySuccess(button);
                 }).catch(err => {
                     console.error('复制失败:', err);
-                    alert('复制失败，请手动选择内容复制');
+                    alert(t('chat.copy.failed'));
                 });
             }
             return;
@@ -1247,11 +1247,11 @@ function copyMessageToClipboard(messageDiv, button) {
             showCopySuccess(button);
         }).catch(err => {
             console.error('复制失败:', err);
-            alert('复制失败，请手动选择内容复制');
+            alert(t('chat.copy.failed'));
         });
     } catch (error) {
         console.error('复制消息时出错:', error);
-        alert('复制失败，请手动选择内容复制');
+        alert(t('chat.copy.failed'));
     }
 }
 
@@ -1259,7 +1259,7 @@ function copyMessageToClipboard(messageDiv, button) {
 function showCopySuccess(button) {
     if (button) {
         const originalText = button.innerHTML;
-        button.innerHTML = '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M20 6L9 17l-5-5" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/></svg><span>已复制</span>';
+        button.innerHTML = '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M20 6L9 17l-5-5" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/></svg><span>' + t('chat.btn.copied') + '</span>';
         button.style.color = '#10b981';
         button.style.background = 'rgba(16, 185, 129, 0.1)';
         button.style.borderColor = 'rgba(16, 185, 129, 0.3)';
@@ -1301,11 +1301,11 @@ function renderProcessDetails(messageId, processDetails) {
     if (!mcpLabel && !buttonsContainer) {
         mcpLabel = document.createElement('div');
         mcpLabel.className = 'mcp-call-label';
-        mcpLabel.textContent = '📋 渗透测试详情';
+        mcpLabel.textContent = t('chat.mcp.label');
         mcpSection.appendChild(mcpLabel);
-    } else if (mcpLabel && mcpLabel.textContent !== '📋 渗透测试详情') {
+    } else if (mcpLabel && mcpLabel.textContent !== t('chat.mcp.label')) {
         // 如果标签存在但不是统一格式，更新它
-        mcpLabel.textContent = '📋 渗透测试详情';
+        mcpLabel.textContent = t('chat.mcp.label');
     }
     
     // 如果没有按钮容器，创建一个
@@ -1320,7 +1320,7 @@ function renderProcessDetails(messageId, processDetails) {
     if (!processDetailBtn) {
         processDetailBtn = document.createElement('button');
         processDetailBtn.className = 'mcp-detail-btn process-detail-btn';
-        processDetailBtn.innerHTML = '<span>展开详情</span>';
+        processDetailBtn.innerHTML = '<span>' + t('chat.details.expand') + '</span>';
         processDetailBtn.onclick = () => toggleProcessDetails(null, messageId);
         buttonsContainer.appendChild(processDetailBtn);
     }
@@ -1360,7 +1360,7 @@ function renderProcessDetails(messageId, processDetails) {
     // 如果没有processDetails或为空，显示空状态
     if (!processDetails || processDetails.length === 0) {
         // 显示空状态提示
-        timeline.innerHTML = '<div class="progress-timeline-empty">暂无过程详情（可能执行过快或未触发详细事件）</div>';
+        timeline.innerHTML = '<div class="progress-timeline-empty">' + t('chat.progress.empty') + '</div>';
         // 默认折叠
         timeline.classList.remove('expanded');
         return;
@@ -1425,7 +1425,7 @@ function renderProcessDetails(messageId, processDetails) {
         // 更新按钮文本为"展开详情"
         const processDetailBtn = messageElement.querySelector('.process-detail-btn');
         if (processDetailBtn) {
-            processDetailBtn.innerHTML = '<span>展开详情</span>';
+            processDetailBtn.innerHTML = '<span>' + t('chat.details.expand') + '</span>';
         }
     }
 }
@@ -1575,7 +1575,7 @@ async function showMCPDetail(executionId) {
                     }
                 }
             } else {
-                responseElement.textContent = '暂无响应数据';
+                responseElement.textContent = t('chat.no_response');
             }
             
             // 显示模态框
@@ -1613,11 +1613,11 @@ function copyDetailBlock(elementId, triggerBtn = null) {
         if (!triggerBtn) {
             return;
         }
-        triggerBtn.textContent = '已复制';
+        triggerBtn.textContent = t('chat.btn.copied');
         triggerBtn.disabled = true;
         setTimeout(() => {
             triggerBtn.disabled = false;
-            triggerBtn.textContent = triggerBtn.dataset.originalLabel || originalLabel || '复制';
+            triggerBtn.textContent = triggerBtn.dataset.originalLabel || originalLabel || t('chat.btn.copy');
         }, 1200);
     };
 
@@ -1656,9 +1656,9 @@ function copyDetailBlock(elementId, triggerBtn = null) {
         .catch(() => {
             if (triggerBtn) {
                 triggerBtn.disabled = false;
-                triggerBtn.textContent = triggerBtn.dataset.originalLabel || originalLabel || '复制';
+                triggerBtn.textContent = triggerBtn.dataset.originalLabel || originalLabel || t('chat.btn.copy');
             }
-            alert('复制失败，请手动选择文本复制。');
+            alert(t('chat.copy.failed'));
         });
 }
 
@@ -1854,7 +1854,7 @@ function createConversationListItem(conversation) {
                   stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
         </svg>
     `;
-    deleteBtn.title = '删除对话';
+    deleteBtn.title = t('chat.conv.delete_title');
     deleteBtn.onclick = (e) => {
         e.stopPropagation();
         deleteConversation(conversation.id);
@@ -2108,7 +2108,7 @@ async function loadConversation(conversationId) {
 async function deleteConversation(conversationId, skipConfirm = false) {
     // 确认删除（如果调用者没有跳过确认）
     if (!skipConfirm) {
-        if (!confirm('确定要删除这个对话吗？此操作不可恢复。')) {
+        if (!confirm(t('chat.conv.confirm_delete'))) {
             return;
         }
     }
@@ -2145,7 +2145,7 @@ async function deleteConversation(conversationId, skipConfirm = false) {
         loadConversations();
     } catch (error) {
         console.error('删除对话失败:', error);
-        alert('删除对话失败: ' + error.message);
+        alert(t('chat.conv.delete_failed').replace('{0}', error.message || ''));
     }
 }
 
@@ -2219,7 +2219,7 @@ async function showAttackChain(conversationId) {
     // 清空容器
     const container = document.getElementById('attack-chain-container');
     if (container) {
-        container.innerHTML = '<div class="loading-spinner">加载中...</div>';
+        container.innerHTML = '<div class="loading-spinner">' + t('chat.attack.loading') + '</div>';
     }
     
     // 隐藏详情面板
@@ -2319,7 +2319,7 @@ async function loadAttackChain(conversationId) {
         console.error('加载攻击链失败:', error);
         const container = document.getElementById('attack-chain-container');
         if (container) {
-            container.innerHTML = `<div class="error-message">加载失败: ${error.message}</div>`;
+            container.innerHTML = '<div class="error-message">' + t('chat.attack.load_failed').replace('{0}', error.message) + '</div>';
         }
         // 错误时也重置加载状态
         setAttackChainLoading(conversationId, false);
@@ -2345,7 +2345,7 @@ function renderAttackChain(chainData) {
     container.innerHTML = '';
     
     if (!chainData.nodes || chainData.nodes.length === 0) {
-        container.innerHTML = '<div class="empty-message">暂无攻击链数据</div>';
+        container.innerHTML = '<div class="empty-message">' + t('chat.attack.no_data') + '</div>';
         return;
     }
     
@@ -3296,7 +3296,7 @@ function updateAttackChainStats(chainData) {
     if (statsElement) {
         const nodeCount = chainData.nodes ? chainData.nodes.length : 0;
         const edgeCount = chainData.edges ? chainData.edges.length : 0;
-        statsElement.textContent = `节点: ${nodeCount} | 边: ${edgeCount}`;
+        statsElement.textContent = t('chat.attack.stats').replace('{0}', nodeCount).replace('{1}', edgeCount);
     }
 }
 
@@ -3377,7 +3377,7 @@ async function regenerateAttackChain() {
     
     const container = document.getElementById('attack-chain-container');
     if (container) {
-        container.innerHTML = '<div class="loading-spinner">重新生成中...</div>';
+        container.innerHTML = '<div class="loading-spinner">' + t('chat.attack.regenerating') + '</div>';
     }
     
     // 禁用重新生成按钮
@@ -3448,7 +3448,7 @@ async function regenerateAttackChain() {
     } catch (error) {
         console.error('重新生成攻击链失败:', error);
         if (container) {
-            container.innerHTML = `<div class="error-message">重新生成失败: ${error.message}</div>`;
+            container.innerHTML = '<div class="error-message">' + t('chat.attack.regen_failed').replace('{0}', error.message) + '</div>';
         }
     } finally {
         setAttackChainLoading(savedConversationId, false);
@@ -3465,7 +3465,7 @@ async function regenerateAttackChain() {
 // 导出攻击链
 function exportAttackChain(format) {
     if (!attackChainCytoscape) {
-        alert('请先加载攻击链');
+        alert(t('chat.attack.no_chain'));
         return;
     }
     
@@ -3497,7 +3497,7 @@ function exportAttackChain(format) {
                             setTimeout(() => URL.revokeObjectURL(url), 100);
                         }).catch(err => {
                             console.error('导出PNG失败:', err);
-                            alert('导出PNG失败: ' + (err.message || '未知错误'));
+                            alert(t('chat.attack.export_failed').replace('{0}', err.message || ''));
                         });
                     } else {
                         // 如果不是 Promise，直接使用
@@ -3512,7 +3512,7 @@ function exportAttackChain(format) {
                     }
                 } catch (err) {
                     console.error('PNG导出错误:', err);
-                    alert('导出PNG失败: ' + (err.message || '未知错误'));
+                    alert(t('chat.attack.export_failed').replace('{0}', err.message || ''));
                 }
             } else if (format === 'svg') {
                 try {
@@ -3821,14 +3821,14 @@ function exportAttackChain(format) {
                     setTimeout(() => URL.revokeObjectURL(url), 100);
                 } catch (err) {
                     console.error('SVG导出错误:', err);
-                    alert('导出SVG失败: ' + (err.message || '未知错误'));
+                    alert(t('chat.attack.export_failed').replace('{0}', err.message || ''));
                 }
             } else {
-                alert('不支持的导出格式: ' + format);
+                alert(t('chat.attack.unsupported').replace('{0}', format));
             }
         } catch (error) {
             console.error('导出失败:', error);
-            alert('导出失败: ' + (error.message || '未知错误'));
+            alert(t('chat.attack.export_failed2').replace('{0}', error.message || ''));
         }
     }, 100); // 小延迟确保图形已渲染
 }
@@ -4166,18 +4166,18 @@ async function showConversationContextMenu(event) {
                 attackChainMenuItem.style.opacity = '0.5';
                 attackChainMenuItem.style.cursor = 'not-allowed';
                 attackChainMenuItem.onclick = null;
-                attackChainMenuItem.title = '当前对话正在执行，请稍后再生成攻击链';
+                attackChainMenuItem.title = t('chat.attack.running');
             } else {
                 attackChainMenuItem.style.opacity = '1';
                 attackChainMenuItem.style.cursor = 'pointer';
                 attackChainMenuItem.onclick = showAttackChainFromContext;
-                attackChainMenuItem.title = '查看当前对话的攻击链';
+                attackChainMenuItem.title = t('chat.attack.view');
             }
         } else {
             attackChainMenuItem.style.opacity = '0.5';
             attackChainMenuItem.style.cursor = 'not-allowed';
             attackChainMenuItem.onclick = null;
-            attackChainMenuItem.title = '请选择一个对话以查看攻击链';
+            attackChainMenuItem.title = t('chat.attack.select_conv');
         }
     }
     
@@ -4211,21 +4211,21 @@ async function showConversationContextMenu(event) {
             // 更新菜单文本
             const pinMenuText = document.getElementById('pin-conversation-menu-text');
             if (pinMenuText) {
-                pinMenuText.textContent = isPinned ? '取消置顶' : '置顶此对话';
+                pinMenuText.textContent = isPinned ? t('chat.pin.unpin_conv') : t('chat.pin.pin_conv');
             }
         } catch (error) {
             console.error('获取对话置顶状态失败:', error);
             // 如果获取失败，使用默认文本
             const pinMenuText = document.getElementById('pin-conversation-menu-text');
             if (pinMenuText) {
-                pinMenuText.textContent = '置顶此对话';
+                pinMenuText.textContent = t('chat.pin.pin_conv');
             }
         }
     } else {
         // 如果没有对话ID，使用默认文本
         const pinMenuText = document.getElementById('pin-conversation-menu-text');
         if (pinMenuText) {
-            pinMenuText.textContent = '置顶此对话';
+            pinMenuText.textContent = t('chat.pin.pin_conv');
         }
     }
 
@@ -4334,14 +4334,14 @@ async function showGroupContextMenu(event, groupId) {
         // 更新菜单文本
         const pinMenuText = document.getElementById('pin-group-menu-text');
         if (pinMenuText) {
-            pinMenuText.textContent = isPinned ? '取消置顶' : '置顶此分组';
+            pinMenuText.textContent = isPinned ? t('chat.pin.unpin_group') : t('chat.pin.pin_group');
         }
     } catch (error) {
         console.error('获取分组置顶状态失败:', error);
         // 如果获取失败，使用默认文本
         const pinMenuText = document.getElementById('pin-group-menu-text');
         if (pinMenuText) {
-            pinMenuText.textContent = '置顶此分组';
+            pinMenuText.textContent = t('chat.pin.pin_group');
         }
     }
 
@@ -4443,7 +4443,7 @@ async function renameConversation() {
         loadConversationsWithGroups();
     } catch (error) {
         console.error('重命名对话失败:', error);
-        alert('重命名失败: ' + (error.message || '未知错误'));
+        alert(t('chat.rename.failed').replace('{0}', error.message || ''));
     }
 
     closeContextMenu();
@@ -4502,7 +4502,7 @@ async function pinConversation() {
         }
     } catch (error) {
         console.error('置顶对话失败:', error);
-        alert('置顶失败: ' + (error.message || '未知错误'));
+        alert(t('chat.pin.failed').replace('{0}', error.message || ''));
     }
 
     closeContextMenu();
@@ -4803,7 +4803,7 @@ async function moveConversationToGroup(convId, groupId) {
         await loadGroups();
     } catch (error) {
         console.error('移动对话到分组失败:', error);
-        alert('移动失败: ' + (error.message || '未知错误'));
+        alert(t('chat.move.failed').replace('{0}', error.message || ''));
     }
 
     closeContextMenu();
@@ -4845,7 +4845,7 @@ async function removeConversationFromGroup(convId, groupId) {
         currentGroupId = savedGroupId;
     } catch (error) {
         console.error('从分组中移除对话失败:', error);
-        alert('移除失败: ' + (error.message || '未知错误'));
+        alert(t('chat.remove.failed').replace('{0}', error.message || ''));
     }
 
     closeContextMenu();
@@ -4917,7 +4917,7 @@ function deleteConversationFromContext() {
     const convId = contextMenuConversationId;
     if (!convId) return;
 
-    if (confirm('确定要删除此对话吗？')) {
+    if (confirm(t('chat.conv.confirm_delete'))) {
         deleteConversation(convId, true); // 跳过内部确认，因为这里已经确认过了
     }
     closeContextMenu();
@@ -5105,11 +5105,11 @@ function toggleSelectAllBatch() {
 async function deleteSelectedConversations() {
     const checkboxes = document.querySelectorAll('.batch-conversation-checkbox:checked');
     if (checkboxes.length === 0) {
-        alert('请先选择要删除的对话');
+        alert(t('chat.conv.no_selected'));
         return;
     }
 
-    if (!confirm(`确定要删除选中的 ${checkboxes.length} 条对话吗？`)) {
+    if (!confirm(t('chat.conv.confirm_delete_selected').replace('{0}', checkboxes.length))) {
         return;
     }
 
@@ -5123,7 +5123,7 @@ async function deleteSelectedConversations() {
         loadConversationsWithGroups();
     } catch (error) {
         console.error('删除失败:', error);
-        alert('删除失败: ' + (error.message || '未知错误'));
+        alert(t('chat.conv.delete_failed').replace('{0}', error.message || ''));
     }
 }
 
@@ -5299,7 +5299,7 @@ async function createGroup(event) {
 
     const name = input.value.trim();
     if (!name) {
-        alert('请输入分组名称');
+        alert(t('chat.group.name_empty'));
         return;
     }
 
@@ -5312,15 +5312,15 @@ async function createGroup(event) {
             const response = await apiFetch('/api/groups');
             groups = await response.json();
         }
-        
+
         // 确保groups是有效数组
         if (!Array.isArray(groups)) {
             groups = [];
         }
-        
+
         const nameExists = groups.some(g => g.name === name);
         if (nameExists) {
-            alert('分组名称已存在，请使用其他名称');
+            alert(t('chat.group.name_exists'));
             return;
         }
     } catch (error) {
@@ -5346,7 +5346,7 @@ async function createGroup(event) {
         if (!response.ok) {
             const error = await response.json();
             if (error.error && error.error.includes('已存在')) {
-                alert('分组名称已存在，请使用其他名称');
+                alert(t('chat.group.name_exists'));
                 return;
             }
             throw new Error(error.error || '创建失败');
@@ -5467,7 +5467,7 @@ async function loadGroupConversations(groupId, searchQuery = '') {
         if (searchQuery) {
             list.innerHTML = '<div style="padding: 40px; text-align: center; color: var(--text-muted);">搜索中...</div>';
         } else {
-            list.innerHTML = '<div style="padding: 40px; text-align: center; color: var(--text-muted);">加载中...</div>';
+            list.innerHTML = '<div style="padding: 40px; text-align: center; color: var(--text-muted);">' + t('chat.attack.loading') + '</div>';
         }
 
         // 构建URL，如果有搜索关键词则添加search参数
@@ -5479,7 +5479,7 @@ async function loadGroupConversations(groupId, searchQuery = '') {
         const response = await apiFetch(url);
         if (!response.ok) {
             console.error(`Failed to load conversations for group ${groupId}:`, response.statusText);
-            list.innerHTML = '<div style="padding: 40px; text-align: center; color: var(--text-muted);">加载失败，请重试</div>';
+            list.innerHTML = '<div style="padding: 40px; text-align: center; color: var(--text-muted);">' + t('chat.conv.load_failed') + '</div>';
             return;
         }
         
@@ -5493,7 +5493,7 @@ async function loadGroupConversations(groupId, searchQuery = '') {
         // 验证返回的数据类型
         if (!Array.isArray(groupConvs)) {
             console.error(`Invalid response for group ${groupId}:`, groupConvs);
-            list.innerHTML = '<div style="padding: 40px; text-align: center; color: var(--text-muted);">数据格式错误</div>';
+            list.innerHTML = '<div style="padding: 40px; text-align: center; color: var(--text-muted);">' + t('chat.conv.data_error') + '</div>';
             return;
         }
         
@@ -5518,7 +5518,7 @@ async function loadGroupConversations(groupId, searchQuery = '') {
 
         if (groupConvs.length === 0) {
             if (searchQuery && searchQuery.trim()) {
-                list.innerHTML = '<div style="padding: 40px; text-align: center; color: var(--text-muted);">未找到匹配的对话</div>';
+                list.innerHTML = '<div style="padding: 40px; text-align: center; color: var(--text-muted);">' + t('chat.conv.no_results') + '</div>';
             } else {
                 list.innerHTML = '<div style="padding: 40px; text-align: center; color: var(--text-muted);">该分组暂无对话</div>';
             }
@@ -5672,7 +5672,7 @@ async function editGroup() {
         
         const nameExists = groups.some(g => g.name === trimmedName && g.id !== currentGroupId);
         if (nameExists) {
-            alert('分组名称已存在，请使用其他名称');
+            alert(t('chat.group.name_exists'));
             return;
         }
 
@@ -5690,7 +5690,7 @@ async function editGroup() {
         if (!updateResponse.ok) {
             const error = await updateResponse.json();
             if (error.error && error.error.includes('已存在')) {
-                alert('分组名称已存在，请使用其他名称');
+                alert(t('chat.group.name_exists'));
                 return;
             }
             throw new Error(error.error || '更新失败');
@@ -5712,7 +5712,7 @@ async function editGroup() {
 async function deleteGroup() {
     if (!currentGroupId) return;
 
-    if (!confirm('确定要删除此分组吗？分组中的对话不会被删除，但会从分组中移除。')) {
+    if (!confirm(t('chat.group.confirm_delete'))) {
         return;
     }
 
@@ -5782,7 +5782,7 @@ async function renameGroupFromContext() {
         
         const nameExists = groups.some(g => g.name === trimmedName && g.id !== groupId);
         if (nameExists) {
-            alert('分组名称已存在，请使用其他名称');
+            alert(t('chat.group.name_exists'));
             return;
         }
 
@@ -5800,7 +5800,7 @@ async function renameGroupFromContext() {
         if (!updateResponse.ok) {
             const error = await updateResponse.json();
             if (error.error && error.error.includes('已存在')) {
-                alert('分组名称已存在，请使用其他名称');
+                alert(t('chat.group.name_exists'));
                 return;
             }
             throw new Error(error.error || '更新失败');
@@ -5817,7 +5817,7 @@ async function renameGroupFromContext() {
         }
     } catch (error) {
         console.error('重命名分组失败:', error);
-        alert('重命名失败: ' + (error.message || '未知错误'));
+        alert(t('chat.rename.failed').replace('{0}', error.message || ''));
     }
 
     closeGroupContextMenu();
@@ -5856,7 +5856,7 @@ async function pinGroupFromContext() {
         loadGroups();
     } catch (error) {
         console.error('置顶分组失败:', error);
-        alert('置顶失败: ' + (error.message || '未知错误'));
+        alert(t('chat.pin.failed').replace('{0}', error.message || ''));
     }
 
     closeGroupContextMenu();
@@ -5867,7 +5867,7 @@ async function deleteGroupFromContext() {
     const groupId = contextMenuGroupId;
     if (!groupId) return;
 
-    if (!confirm('确定要删除此分组吗？分组中的对话不会被删除，但会从分组中移除。')) {
+    if (!confirm(t('chat.group.confirm_delete'))) {
         closeGroupContextMenu();
         return;
     }

--- a/web/static/js/dashboard.js
+++ b/web/static/js/dashboard.js
@@ -17,7 +17,7 @@ async function refreshDashboard() {
     setEl('dashboard-kpi-tools-calls', '…');
     setEl('dashboard-kpi-success-rate', '…');
     var chartPlaceholder = document.getElementById('dashboard-tools-pie-placeholder');
-    if (chartPlaceholder) { chartPlaceholder.style.removeProperty('display'); chartPlaceholder.textContent = '加载中…'; }
+    if (chartPlaceholder) { chartPlaceholder.style.removeProperty('display'); chartPlaceholder.textContent = t('dashboard.loading'); }
     var barChartEl = document.getElementById('dashboard-tools-bar-chart');
     if (barChartEl) { barChartEl.style.display = 'none'; barChartEl.innerHTML = ''; }
 
@@ -77,7 +77,7 @@ async function refreshDashboard() {
             setEl('dashboard-batch-pending', String(pending));
             setEl('dashboard-batch-running', String(running));
             setEl('dashboard-batch-done', String(done));
-            setEl('dashboard-batch-total', total > 0 ? `共 ${total} 个` : '暂无任务');
+            setEl('dashboard-batch-total', total > 0 ? `共 ${total} 个` : t('ui.empty.no_data'));
             
             // 更新进度条
             if (total > 0) {
@@ -120,7 +120,7 @@ async function refreshDashboard() {
             setEl('dashboard-kpi-tools-calls', String(totalCalls));
             var rateStr = totalCalls > 0 ? ((totalSuccess / totalCalls) * 100).toFixed(1) + '%' : '-';
             setEl('dashboard-kpi-success-rate', rateStr);
-            setEl('dashboard-tools-success-rate', rateStr !== '-' ? `成功率 ${rateStr}` : '-');
+            setEl('dashboard-tools-success-rate', rateStr !== '-' ? `${rateStr}` : '-');
             renderDashboardToolsBar(monitorRes);
         } else {
             setEl('dashboard-tools-count', '-');
@@ -138,7 +138,7 @@ async function refreshDashboard() {
         if (knowledgeRes && typeof knowledgeRes === 'object') {
             if (knowledgeRes.enabled === false) {
                 // 功能未启用：用状态标签展示，数值保持为 "-"
-                if (knowledgeStatusEl) knowledgeStatusEl.textContent = '未启用';
+                if (knowledgeStatusEl) knowledgeStatusEl.textContent = t('dashboard.status.not_enabled');
                 if (knowledgeItemsEl) knowledgeItemsEl.textContent = '-';
                 if (knowledgeCategoriesEl) knowledgeCategoriesEl.textContent = '-';
             } else {
@@ -149,9 +149,9 @@ async function refreshDashboard() {
                 // 根据数据量给个轻量状态文案
                 if (knowledgeStatusEl) {
                     if (items > 0 || categories > 0) {
-                        knowledgeStatusEl.textContent = '已启用';
+                        knowledgeStatusEl.textContent = t('dashboard.status.enabled');
                     } else {
-                        knowledgeStatusEl.textContent = '待配置';
+                        knowledgeStatusEl.textContent = t('dashboard.status.pending');
                     }
                 }
             }
@@ -172,15 +172,15 @@ async function refreshDashboard() {
             const statusEl = document.getElementById('dashboard-skills-status');
             if (statusEl) {
                 if (totalCalls === 0) {
-                    statusEl.textContent = '待使用';
+                    statusEl.textContent = t('dashboard.tool.pending');
                     statusEl.style.background = 'rgba(0, 0, 0, 0.05)';
                     statusEl.style.color = 'var(--text-secondary)';
                 } else if (totalCalls < 10) {
-                    statusEl.textContent = '活跃';
+                    statusEl.textContent = t('dashboard.tool.active');
                     statusEl.style.background = 'rgba(16, 185, 129, 0.1)';
                     statusEl.style.color = '#10b981';
                 } else {
-                    statusEl.textContent = '高频';
+                    statusEl.textContent = t('dashboard.tool.frequent');
                     statusEl.style.background = 'rgba(59, 130, 246, 0.1)';
                     statusEl.style.color = '#3b82f6';
                 }
@@ -200,7 +200,7 @@ async function refreshDashboard() {
         setEl('dashboard-kpi-tools-calls', '-');
         renderDashboardToolsBar(null);
         var ph = document.getElementById('dashboard-tools-pie-placeholder');
-        if (ph) { ph.style.removeProperty('display'); ph.textContent = '暂无调用数据'; }
+        if (ph) { ph.style.removeProperty('display'); ph.textContent = t('dashboard.no_call_data'); }
     }
 }
 
@@ -257,7 +257,7 @@ function renderDashboardToolsBar(monitorRes) {
 
     if (!monitorRes || typeof monitorRes !== 'object') {
         placeholder.style.removeProperty('display');
-        placeholder.textContent = '暂无调用数据';
+        placeholder.textContent = t('dashboard.no_call_data');
         barChartEl.style.display = 'none';
         barChartEl.innerHTML = '';
         return;
@@ -273,7 +273,7 @@ function renderDashboardToolsBar(monitorRes) {
 
     if (entries.length === 0) {
         placeholder.style.removeProperty('display');
-        placeholder.textContent = '暂无调用数据';
+        placeholder.textContent = t('dashboard.no_call_data');
         barChartEl.style.display = 'none';
         barChartEl.innerHTML = '';
         return;

--- a/web/static/js/info-collect.js
+++ b/web/static/js/info-collect.js
@@ -197,12 +197,12 @@ async function submitFofaSearch() {
     const full = !!els.full?.checked;
 
     if (!query) {
-        alert('请输入 FOFA 查询语法');
+        alert(t('fofa.alert.query_empty'));
         return;
     }
 
     saveFofaFormToStorage({ query, size, page, fields, full });
-    setFofaMeta('查询中...');
+    setFofaMeta(t('fofa.status.querying'));
     setFofaLoading(true);
 
     try {
@@ -219,9 +219,9 @@ async function submitFofaSearch() {
         renderFofaResults(result);
     } catch (e) {
         console.error('FOFA 查询失败:', e);
-        setFofaMeta('查询失败');
+        setFofaMeta(t('fofa.error.query_failed'));
         renderFofaResults({ query, fields: [], results: [], total: 0, page: 1, size: 0 });
-        alert('FOFA 查询失败: ' + (e && e.message ? e.message : String(e)));
+        alert(t('fofa.alert.query_failed2').replace('{0}', e && e.message ? e.message : String(e)));
     } finally {
         setFofaLoading(false);
     }
@@ -231,7 +231,7 @@ async function parseFofaNaturalLanguage() {
     const els = getFofaFormElements();
     const text = (els.nl?.value || '').trim();
     if (!text) {
-        alert('请输入自然语言描述');
+        alert(t('fofa.alert.lang_empty'));
         return;
     }
 
@@ -246,13 +246,13 @@ async function parseFofaNaturalLanguage() {
     setFofaParseLoading(true, 'AI 解析中...');
 
     // 持续提示：直到请求完成/取消/失败才消失
-    fofaParseToastHandle = showInlineToast('AI 解析中...（点击按钮可取消）', { duration: 0, id: 'fofa-parse-pending' });
+    fofaParseToastHandle = showInlineToast(t('fofa.ai.parsing') + '（点击按钮可取消）', { duration: 0, id: 'fofa-parse-pending' });
 
     // 如果超过一小段时间还没返回，再强调“仍在进行中”，降低误判为失败的概率
     fofaParseSlowTimer = setTimeout(() => {
         const status = document.getElementById('fofa-nl-status');
         if (status) {
-            status.textContent = 'AI 解析耗时较长，仍在处理中…';
+            status.textContent = t('fofa.ai.parsing_long');
             status.style.display = 'block';
         }
     }, 1800);
@@ -298,17 +298,17 @@ function setFofaParseLoading(loading, statusText) {
     const status = document.getElementById('fofa-nl-status');
     if (btn) {
         if (loading) {
-            if (!btn.dataset.originalText) btn.dataset.originalText = btn.textContent || 'AI 解析';
+            if (!btn.dataset.originalText) btn.dataset.originalText = btn.textContent || t('fofa.ai.parsing');
             btn.classList.add('btn-loading');
-            btn.textContent = '取消解析';
-            btn.title = '点击取消 AI 解析';
+            btn.textContent = t('ui.btn.cancel');
+            btn.title = t('fofa.btn.cancel_parse');
             btn.dataset.loading = '1';
             btn.setAttribute('aria-busy', 'true');
             btn.disabled = false;
         } else {
             btn.classList.remove('btn-loading');
             btn.textContent = btn.dataset.originalText || 'AI 解析';
-            btn.title = '将自然语言解析为 FOFA 查询语法';
+            btn.title = t('fofa.btn.start_parse');
             btn.disabled = false;
             delete btn.dataset.loading;
             btn.removeAttribute('aria-busy');
@@ -345,23 +345,23 @@ function showFofaParseModal(nlText, parsed) {
     modal.innerHTML = `
         <div class="modal-content" style="max-width: 900px;">
             <div class="modal-header">
-                <h2>AI 解析结果</h2>
-                <span class="modal-close" id="fofa-parse-modal-close" title="关闭">&times;</span>
+                <h2>${t('fofa.ai.result_title')}</h2>
+                <span class="modal-close" id="fofa-parse-modal-close" title="${t('ui.btn.close')}">&times;</span>
             </div>
             <div style="padding: 18px 28px; overflow: auto;">
                 <div class="form-group">
-                    <label>自然语言</label>
+                    <label>${t('fofa.ai.natural_lang')}</label>
                     <div class="muted" style="margin-top: 6px; white-space: pre-wrap;">${safeNL || '-'}</div>
                 </div>
 
                 <div class="form-group" style="margin-top: 14px;">
-                    <label for="fofa-parse-query">FOFA 查询语法（可编辑）</label>
+                    <label for="fofa-parse-query">${t('fofa.ai.fofa_syntax')}（可编辑）</label>
                     <textarea id="fofa-parse-query" class="info-collect-query-input" rows="2" placeholder='例如：app="Apache" && country="CN"'></textarea>
                     <small class="form-hint">请人工确认语法与范围无误后再执行查询。</small>
                 </div>
 
                 <div class="form-group" style="margin-top: 14px;">
-                    <label>提醒</label>
+                    <label>${t('fofa.ai.reminder')}</label>
                     <div style="background: #fff8e1; border: 1px solid #ffe8a3; border-radius: 10px; padding: 10px 12px;">
                         ${warningsHtml}
                     </div>
@@ -369,12 +369,12 @@ function showFofaParseModal(nlText, parsed) {
 
                 ${explanation ? `
                 <div class="form-group" style="margin-top: 14px;">
-                    <label>解析说明</label>
+                    <label>${t('fofa.ai.parse_notes')}</label>
                     <pre style="margin-top: 8px; white-space: pre-wrap; background: var(--bg-tertiary); border: 1px solid var(--border-color); border-radius: 10px; padding: 10px 12px; font-size: 13px;">${escapeHtml(explanation)}</pre>
                 </div>` : ''}
             </div>
             <div class="modal-footer" style="padding: 18px 28px;">
-                <button class="btn-secondary" type="button" id="fofa-parse-cancel">取消</button>
+                <button class="btn-secondary" type="button" id="fofa-parse-cancel">${t('ui.btn.cancel')}</button>
                 <button class="btn-secondary" type="button" id="fofa-parse-apply">填入查询框</button>
                 <button class="btn-primary" type="button" id="fofa-parse-apply-run">填入并查询</button>
             </div>
@@ -402,7 +402,7 @@ function showFofaParseModal(nlText, parsed) {
         const els = getFofaFormElements();
         const q = (queryTextarea?.value || '').trim();
         if (!q) {
-            showInlineToast('解析结果为空：请在弹窗中补充/修改 FOFA 查询语法', { duration: 2600 });
+            showInlineToast(t('fofa.ai.result_empty') + '：请在弹窗中补充/修改 FOFA 查询语法', { duration: 2600 });
             return;
         }
         if (els.query) {
@@ -444,7 +444,7 @@ function setFofaMeta(text) {
 function updateSelectedMeta() {
     const els = getFofaFormElements();
     if (els.selectedMeta) {
-        els.selectedMeta.textContent = `已选择 ${infoCollectState.selectedRowIndexes.size} 条`;
+        els.selectedMeta.textContent = t('fofa.label.selected').replace('{0}', infoCollectState.selectedRowIndexes.size);
     }
 }
 
@@ -454,7 +454,7 @@ function setFofaLoading(loading) {
     if (loading) {
         const fieldsCount = (document.getElementById('fofa-fields')?.value || '').split(',').filter(Boolean).length;
         const colspan = Math.max(1, fieldsCount + 1);
-        els.tbody.innerHTML = `<tr><td class="muted" style="padding: 16px;" colspan="${colspan}">加载中...</td></tr>`;
+        els.tbody.innerHTML = `<tr><td class="muted" style="padding: 16px;" colspan="${colspan}">${t('fofa.table.loading')}</td></tr>`;
     }
 }
 
@@ -490,7 +490,7 @@ function renderFofaResults(payload) {
     const size = typeof payload.size === 'number' ? payload.size : 0;
     const page = typeof payload.page === 'number' ? payload.page : 1;
 
-    setFofaMeta(`共 ${total} 条 · 本页 ${results.length} 条 · page=${page} · size=${size}`);
+    setFofaMeta(t('fofa.table.summary').replace('{0}', total).replace('{1}', results.length) + ` · page=${page} · size=${size}`);
 
     // 可见字段
     const visibleFields = fields.filter(f => !infoCollectState.hiddenFields.has(f));
@@ -500,7 +500,7 @@ function renderFofaResults(payload) {
 
     // 表头（左：勾选列；右：操作列固定）
     const headerCells = [
-        '<th class="info-collect-col-select"><input type="checkbox" id="fofa-select-all" title="全选/全不选"/></th>',
+        '<th class="info-collect-col-select"><input type="checkbox" id="fofa-select-all" title="' + t('fofa.btn.select_all') + '"/></th>',
         ...visibleFields.map(f => `<th>${escapeHtml(String(f))}</th>`),
         '<th class="info-collect-col-actions">操作</th>'
     ].join('');
@@ -509,7 +509,7 @@ function renderFofaResults(payload) {
     // 表体
     if (results.length === 0) {
         const colspan = Math.max(1, visibleFields.length + 2);
-        els.tbody.innerHTML = `<tr><td class="muted" style="padding: 16px;" colspan="${colspan}">暂无数据</td></tr>`;
+        els.tbody.innerHTML = `<tr><td class="muted" style="padding: 16px;" colspan="${colspan}">${t('ui.empty.no_data')}</td></tr>`;
         return;
     }
 
@@ -602,14 +602,14 @@ function normalizeHttpLink(raw) {
 function copyFofaTarget(target) {
     const text = (target || '').trim();
     if (!text) {
-        alert('没有可复制的目标');
+        alert(t('fofa.alert.no_targets'));
         return;
     }
     navigator.clipboard.writeText(text).then(() => {
         // 简单提示
-        showInlineToast('已复制目标');
+        showInlineToast(t('fofa.toast.copied'));
     }).catch(() => {
-        alert('复制失败，请手动复制：' + text);
+        alert(t('fofa.alert.copy_failed').replace('{0}', text));
     });
 }
 
@@ -707,7 +707,7 @@ function scanFofaRow(encodedRowJson, clickEvent) {
     const fields = (document.getElementById('fofa-fields')?.value || '').split(',').map(s => s.trim()).filter(Boolean);
     const target = inferTargetFromRow(row, fields);
     if (!target) {
-        alert('无法从该行推断扫描目标（建议在 fields 中包含 host/ip/port/domain）');
+        alert(t('fofa.alert.infer_failed'));
         return;
     }
 
@@ -745,7 +745,7 @@ function scanFofaRow(encodedRowJson, clickEvent) {
             if (typeof sendMessage === 'function') {
                 sendMessage();
             } else {
-                alert('未找到 sendMessage()，请刷新页面后重试');
+                alert(t('fofa.alert.no_send'));
             }
         } else {
             showInlineToast('已填入对话输入框，可编辑后发送');
@@ -910,7 +910,7 @@ function hideAllFofaColumns() {
 function exportFofaResults(format) {
     const p = infoCollectState.currentPayload;
     if (!p || !Array.isArray(p.results) || p.results.length === 0) {
-        alert('暂无可导出的结果');
+        alert(t('fofa.export.no_results'));
         return;
     }
 
@@ -936,7 +936,7 @@ function exportFofaResults(format) {
     if (format === 'xlsx') {
         // 使用 SheetJS 生成 XLSX（需在页面中引入 xlsx 库）
         if (typeof XLSX === 'undefined') {
-            alert('未加载 XLSX 库，请刷新页面后重试');
+            alert(t('fofa.export.no_xlsx'));
             return;
         }
         const aoa = [visibleFields].concat(p.results.map(row => {
@@ -945,7 +945,7 @@ function exportFofaResults(format) {
         }));
         const ws = XLSX.utils.aoa_to_sheet(aoa);
         const wb = XLSX.utils.book_new();
-        XLSX.utils.book_append_sheet(wb, ws, 'FOFA结果');
+        XLSX.utils.book_append_sheet(wb, ws, t('fofa.export.sheet_name'));
         XLSX.writeFile(wb, `fofa_results_${ts}.xlsx`);
         return;
     }
@@ -982,12 +982,12 @@ function downloadBlob(content, filename, mime) {
 async function batchScanSelectedFofaRows() {
     const p = infoCollectState.currentPayload;
     if (!p || !Array.isArray(p.results) || p.results.length === 0) {
-        alert('暂无结果');
+        alert(t('fofa.scan.no_results'));
         return;
     }
     const selected = Array.from(infoCollectState.selectedRowIndexes).sort((a, b) => a - b);
     if (selected.length === 0) {
-        alert('请先勾选需要扫描的行');
+        alert(t('fofa.scan.select_rows'));
         return;
     }
 
@@ -1009,11 +1009,11 @@ async function batchScanSelectedFofaRows() {
     });
 
     if (tasks.length === 0) {
-        alert('未能从所选行推断任何可扫描目标（建议 fields 中包含 host/ip/port/domain）');
+        alert(t('fofa.alert.no_scan_targets'));
         return;
     }
 
-    const title = (p.query ? `FOFA 批量扫描：${p.query}` : 'FOFA 批量扫描').slice(0, 80);
+    const title = (p.query ? `${t('fofa.scan.title')}：${p.query}` : t('fofa.scan.title')).slice(0, 80);
     try {
         // 不强制切换到“信息收集”角色：沿用当前已选角色；若为默认则传空字符串交给后端走默认逻辑
         let role = '';
@@ -1051,7 +1051,7 @@ async function batchScanSelectedFofaRows() {
         }
     } catch (e) {
         console.error('批量扫描失败:', e);
-        alert('批量扫描失败: ' + (e && e.message ? e.message : String(e)));
+        alert(t('fofa.alert.scan_failed').replace('{0}', e && e.message ? e.message : String(e)));
     }
 }
 
@@ -1065,8 +1065,8 @@ function showCellDetailModal(field, fullText) {
     modal.innerHTML = `
         <div class="info-collect-cell-modal-content" role="dialog" aria-modal="true">
             <div class="info-collect-cell-modal-header">
-                <div class="info-collect-cell-modal-title">${escapeHtml(field || '字段')}</div>
-                <button class="btn-icon" type="button" id="info-collect-cell-modal-close" title="关闭">
+                <div class="info-collect-cell-modal-title">${escapeHtml(field || '')}</div>
+                <button class="btn-icon" type="button" id="info-collect-cell-modal-close" title="${t('ui.btn.close')}">
                     <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                         <path d="M18 6L6 18M6 6l12 12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
                     </svg>
@@ -1076,8 +1076,8 @@ function showCellDetailModal(field, fullText) {
                 <pre class="info-collect-cell-modal-pre">${escapeHtml(fullText || '')}</pre>
             </div>
             <div class="info-collect-cell-modal-footer">
-                <button class="btn-secondary" type="button" id="info-collect-cell-modal-copy">复制</button>
-                <button class="btn-primary" type="button" id="info-collect-cell-modal-ok">关闭</button>
+                <button class="btn-secondary" type="button" id="info-collect-cell-modal-copy">${t('ui.btn.copy')}</button>
+                <button class="btn-primary" type="button" id="info-collect-cell-modal-ok">${t('ui.btn.close')}</button>
             </div>
         </div>
     `;
@@ -1091,7 +1091,7 @@ function showCellDetailModal(field, fullText) {
     document.getElementById('info-collect-cell-modal-close')?.addEventListener('click', close);
     document.getElementById('info-collect-cell-modal-ok')?.addEventListener('click', close);
     document.getElementById('info-collect-cell-modal-copy')?.addEventListener('click', () => {
-        navigator.clipboard.writeText(fullText || '').then(() => showInlineToast('已复制')).catch(() => alert('复制失败'));
+        navigator.clipboard.writeText(fullText || '').then(() => showInlineToast(t('fofa.toast.copied'))).catch(() => alert(t('fofa.alert.copy_failed2')));
     });
 
     // Esc 关闭

--- a/web/static/js/knowledge.js
+++ b/web/static/js/knowledge.js
@@ -38,8 +38,8 @@ async function loadKnowledgeCategories() {
                 container.innerHTML = `
                     <div class="empty-state" style="text-align: center; padding: 40px 20px;">
                         <div style="font-size: 48px; margin-bottom: 20px;">📚</div>
-                        <h3 style="margin-bottom: 10px; color: #666;">知识库功能未启用</h3>
-                        <p style="color: #999; margin-bottom: 20px;">${data.message || '请前往系统设置启用知识检索功能'}</p>
+                        <h3 style="margin-bottom: 10px; color: #666;">${t('knowledge.disabled')}</h3>
+                        <p style="color: #999; margin-bottom: 20px;">${data.message || t('knowledge.goto_settings')}</p>
                         <button onclick="switchToSettings()" style="
                             background: #007bff;
                             color: white;
@@ -48,19 +48,19 @@ async function loadKnowledgeCategories() {
                             border-radius: 5px;
                             cursor: pointer;
                             font-size: 14px;
-                        ">前往设置</button>
+                        ">${t('knowledge.goto_settings')}</button>
                     </div>
                 `;
             }
             return [];
         }
-        
+
         knowledgeCategories = data.categories || [];
         
         // 更新分类筛选下拉框
         const filterDropdown = document.getElementById('knowledge-category-filter-dropdown');
         if (filterDropdown) {
-            filterDropdown.innerHTML = '<div class="custom-select-option" data-value="" onclick="selectKnowledgeCategory(\'\')">全部</div>';
+            filterDropdown.innerHTML = '<div class="custom-select-option" data-value="" onclick="selectKnowledgeCategory(\'\')">'+t('knowledge.filter.all')+'</div>';
             knowledgeCategories.forEach(category => {
                 const option = document.createElement('div');
                 option.className = 'custom-select-option';
@@ -122,8 +122,8 @@ async function loadKnowledgeItems(category = '', page = 1, pageSize = 10) {
                 container.innerHTML = `
                     <div class="empty-state" style="text-align: center; padding: 40px 20px;">
                         <div style="font-size: 48px; margin-bottom: 20px;">📚</div>
-                        <h3 style="margin-bottom: 10px; color: #666;">知识库功能未启用</h3>
-                        <p style="color: #999; margin-bottom: 20px;">${data.message || '请前往系统设置启用知识检索功能'}</p>
+                        <h3 style="margin-bottom: 10px; color: #666;">${t('knowledge.disabled')}</h3>
+                        <p style="color: #999; margin-bottom: 20px;">${data.message || t('knowledge.goto_settings')}</p>
                         <button onclick="switchToSettings()" style="
                             background: #007bff;
                             color: white;
@@ -132,7 +132,7 @@ async function loadKnowledgeItems(category = '', page = 1, pageSize = 10) {
                             border-radius: 5px;
                             cursor: pointer;
                             font-size: 14px;
-                        ">前往设置</button>
+                        ">${t('knowledge.goto_settings')}</button>
                     </div>
                 `;
             }
@@ -174,7 +174,7 @@ function renderKnowledgeItemsByCategories(categoriesWithItems) {
     if (!container) return;
     
     if (categoriesWithItems.length === 0) {
-        container.innerHTML = '<div class="empty-state">暂无知识项</div>';
+        container.innerHTML = '<div class="empty-state">' + t('knowledge.empty') + '</div>';
         return;
     }
     
@@ -218,7 +218,7 @@ function renderKnowledgeItems(items) {
     if (!container) return;
     
     if (items.length === 0) {
-        container.innerHTML = '<div class="empty-state">暂无知识项</div>';
+        container.innerHTML = '<div class="empty-state">' + t('knowledge.empty') + '</div>';
         return;
     }
     
@@ -281,7 +281,7 @@ function renderKnowledgePagination() {
     html += `<button class="pagination-btn" onclick="loadKnowledgePage(${currentPage - 1})" ${currentPage <= 1 ? 'disabled style="opacity: 0.5; cursor: not-allowed;"' : ''}>上一页</button>`;
     
     // 页码显示（显示分类数）
-    html += `<span style="padding: 0 12px;">第 ${currentPage} 页，共 ${totalPages} 页（共 ${total} 个分类）</span>`;
+    html += `<span style="padding: 0 12px;">${t('knowledge.pagination.info').replace('{0}', currentPage).replace('{1}', totalPages).replace('{2}', total)}</span>`;
     
     // 下一页按钮
     html += `<button class="pagination-btn" onclick="loadKnowledgePage(${currentPage + 1})" ${currentPage >= totalPages ? 'disabled style="opacity: 0.5; cursor: not-allowed;"' : ''}>下一页</button>`;
@@ -403,15 +403,15 @@ function updateKnowledgeStats(data, categoryCount) {
     
     statsContainer.innerHTML = `
         <div class="knowledge-stat-item">
-            <span class="knowledge-stat-label">总分类数</span>
+            <span class="knowledge-stat-label">${t('knowledge.stats.categories')}</span>
             <span class="knowledge-stat-value">${totalCategories}</span>
         </div>
         <div class="knowledge-stat-item">
-            <span class="knowledge-stat-label">当前页分类</span>
+            <span class="knowledge-stat-label">${t('knowledge.stats.current_cats')}</span>
             <span class="knowledge-stat-value">${categoryCount} 个</span>
         </div>
         <div class="knowledge-stat-item">
-            <span class="knowledge-stat-label">当前页知识项</span>
+            <span class="knowledge-stat-label">${t('knowledge.stats.current_items')}</span>
             <span class="knowledge-stat-value">${currentPageItemCount} 项</span>
         </div>
     `;
@@ -487,7 +487,7 @@ async function updateIndexProgress() {
                 ">
                     <div style="display: flex; align-items: center; margin-bottom: 8px;">
                         <span style="font-size: 20px; margin-right: 8px;">❌</span>
-                        <span style="font-weight: bold; color: #c00;">索引构建失败</span>
+                        <span style="font-weight: bold; color: #c00;">${t('knowledge.index.failed')}</span>
                     </div>
                     <div style="color: #666; font-size: 14px; margin-bottom: 12px; line-height: 1.5;">
                         ${escapeHtml(lastError)}
@@ -523,7 +523,7 @@ async function updateIndexProgress() {
                 indexProgressInterval = null;
             }
             // 显示错误通知
-            showNotification('索引构建失败: ' + lastError.substring(0, 100), 'error');
+            showNotification(t('knowledge.index.failed') + ': ' + lastError.substring(0, 100), 'error');
             return;
         }
         
@@ -547,7 +547,7 @@ async function updateIndexProgress() {
                 <div class="knowledge-index-progress">
                     <div class="progress-header">
                         <span class="progress-icon">🔨</span>
-                        <span class="progress-text">正在重建索引：${rebuildCurrent}/${rebuildTotal} (${rebuildProgress.toFixed(1)}%) - 失败：${rebuildFailed}</span>
+                        <span class="progress-text">${t('knowledge.index.building')}：${rebuildCurrent}/${rebuildTotal} (${rebuildProgress.toFixed(1)}%) - 失败：${rebuildFailed}</span>
                     </div>
                     <div class="progress-bar-container">
                         <div class="progress-bar" style="width: ${rebuildProgress}%"></div>
@@ -570,7 +570,7 @@ async function updateIndexProgress() {
             progressContainer.innerHTML = `
                 <div class="knowledge-index-progress-complete">
                     <span class="progress-icon">✅</span>
-                    <span class="progress-text">索引构建完成 (${indexedItems}/${totalItems})</span>
+                    <span class="progress-text">${t('knowledge.index.complete')} (${indexedItems}/${totalItems})</span>
                 </div>
             `;
             // 完成后停止轮询
@@ -583,7 +583,7 @@ async function updateIndexProgress() {
                 <div class="knowledge-index-progress">
                     <div class="progress-header">
                         <span class="progress-icon">🔨</span>
-                        <span class="progress-text">正在构建索引: ${indexedItems}/${totalItems} (${progressPercent.toFixed(1)}%)</span>
+                        <span class="progress-text">${t('knowledge.index.progress').replace('{0}', `${indexedItems}/${totalItems} (${progressPercent.toFixed(1)}%)`)}</span>
                     </div>
                     <div class="progress-bar-container">
                         <div class="progress-bar" style="width: ${progressPercent}%"></div>
@@ -613,7 +613,7 @@ async function updateIndexProgress() {
                 ">
                     <div style="display: flex; align-items: center; margin-bottom: 8px;">
                         <span style="font-size: 20px; margin-right: 8px;">⚠️</span>
-                        <span style="font-weight: bold; color: #c00;">无法获取索引状态</span>
+                        <span style="font-weight: bold; color: #c00;">${t('knowledge.index.status_failed')}</span>
                     </div>
                     <div style="color: #666; font-size: 14px;">
                         无法连接到服务器获取索引状态，请检查网络连接或刷新页面。
@@ -648,7 +648,7 @@ function selectKnowledgeCategory(category) {
     const dropdown = document.getElementById('knowledge-category-filter-dropdown');
     
     if (trigger && wrapper && dropdown) {
-        const displayText = category || '全部';
+        const displayText = category || t('knowledge.filter.all');
         trigger.querySelector('span').textContent = displayText;
         wrapper.classList.remove('open');
         
@@ -758,8 +758,8 @@ async function searchKnowledgeItems() {
                 container.innerHTML = `
                     <div class="empty-state" style="text-align: center; padding: 40px 20px;">
                         <div style="font-size: 48px; margin-bottom: 20px;">📚</div>
-                        <h3 style="margin-bottom: 10px; color: #666;">知识库功能未启用</h3>
-                        <p style="color: #999; margin-bottom: 20px;">${data.message || '请前往系统设置启用知识检索功能'}</p>
+                        <h3 style="margin-bottom: 10px; color: #666;">${t('knowledge.disabled')}</h3>
+                        <p style="color: #999; margin-bottom: 20px;">${data.message || t('knowledge.goto_settings')}</p>
                         <button onclick="switchToSettings()" style="
                             background: #007bff;
                             color: white;
@@ -768,7 +768,7 @@ async function searchKnowledgeItems() {
                             border-radius: 5px;
                             cursor: pointer;
                             font-size: 14px;
-                        ">前往设置</button>
+                        ">${t('knowledge.goto_settings')}</button>
                     </div>
                 `;
             }
@@ -866,7 +866,7 @@ async function rebuildKnowledgeIndex() {
         if (!confirm('确定要重建索引吗？这可能需要一些时间。')) {
             return;
         }
-        showNotification('正在重建索引...', 'info');
+        showNotification(t('knowledge.index.building') + '...', 'info');
         
         // 先停止现有的轮询
         if (indexProgressInterval) {
@@ -882,7 +882,7 @@ async function rebuildKnowledgeIndex() {
                 <div class="knowledge-index-progress">
                     <div class="progress-header">
                         <span class="progress-icon">🔨</span>
-                        <span class="progress-text">正在重建索引: 准备中...</span>
+                        <span class="progress-text">${t('knowledge.index.building')}: 准备中...</span>
                     </div>
                     <div class="progress-bar-container">
                         <div class="progress-bar" style="width: 0%"></div>
@@ -919,7 +919,7 @@ async function rebuildKnowledgeIndex() {
 // 显示添加知识项模态框
 function showAddKnowledgeItemModal() {
     currentEditingItemId = null;
-    document.getElementById('knowledge-item-modal-title').textContent = '添加知识';
+    document.getElementById('knowledge-item-modal-title').textContent = t('knowledge.modal.add');
     document.getElementById('knowledge-item-category').value = '';
     document.getElementById('knowledge-item-title').value = '';
     document.getElementById('knowledge-item-content').value = '';
@@ -936,7 +936,7 @@ async function editKnowledgeItem(id) {
         const item = await response.json();
         
         currentEditingItemId = id;
-        document.getElementById('knowledge-item-modal-title').textContent = '编辑知识';
+        document.getElementById('knowledge-item-modal-title').textContent = t('knowledge.modal.edit');
         document.getElementById('knowledge-item-category').value = item.category;
         document.getElementById('knowledge-item-title').value = item.title;
         document.getElementById('knowledge-item-content').value = item.content;
@@ -1057,7 +1057,7 @@ async function saveKnowledgeItem() {
                 const wrapper = document.getElementById('knowledge-category-filter-wrapper');
                 const dropdown = document.getElementById('knowledge-category-filter-dropdown');
                 if (trigger && wrapper && dropdown) {
-                    trigger.querySelector('span').textContent = newItemCategory || '全部';
+                    trigger.querySelector('span').textContent = newItemCategory || t('knowledge.filter.all');
                     dropdown.querySelectorAll('.custom-select-option').forEach(opt => {
                         opt.classList.remove('selected');
                         if (opt.getAttribute('data-value') === newItemCategory) {
@@ -1108,7 +1108,7 @@ async function saveKnowledgeItem() {
 
 // 删除知识项
 async function deleteKnowledgeItem(id) {
-    if (!confirm('确定要删除这个知识项吗？')) {
+    if (!confirm(t('knowledge.confirm.delete_item'))) {
         return;
     }
     
@@ -1326,7 +1326,7 @@ function renderRetrievalLogs(logs) {
     updateRetrievalStats(logs);
     
     if (logs.length === 0) {
-        container.innerHTML = '<div class="empty-state">暂无检索记录</div>';
+        container.innerHTML = '<div class="empty-state">' + t('knowledge.retrieval.empty') + '</div>';
         retrievalLogsData = [];
         return;
     }
@@ -1403,7 +1403,7 @@ function renderRetrievalLogs(logs) {
                     <div class="retrieval-log-details-grid">
                         ${log.conversationId ? `
                             <div class="retrieval-log-detail-item">
-                                <span class="detail-label">对话ID</span>
+                                <span class="detail-label">${t('knowledge.label.conv_id')}</span>
                                 <code class="detail-value" title="点击复制" onclick="navigator.clipboard.writeText('${escapeHtml(log.conversationId)}'); this.title='已复制!'; setTimeout(() => this.title='点击复制', 2000);" style="cursor: pointer;">${escapeHtml(log.conversationId)}</code>
                             </div>
                         ` : ''}
@@ -1480,11 +1480,11 @@ function updateRetrievalStats(logs) {
     
     statsContainer.innerHTML = `
         <div class="retrieval-stat-item">
-            <span class="retrieval-stat-label">总检索次数</span>
+            <span class="retrieval-stat-label">${t('knowledge.stats.total_retrievals')}</span>
             <span class="retrieval-stat-value">${totalLogs}</span>
         </div>
         <div class="retrieval-stat-item">
-            <span class="retrieval-stat-label">成功检索</span>
+            <span class="retrieval-stat-label">${t('knowledge.stats.success_retrievals')}</span>
             <span class="retrieval-stat-value text-success">${successfulLogs}</span>
         </div>
         <div class="retrieval-stat-item">
@@ -1591,7 +1591,7 @@ function refreshRetrievalLogs() {
 
 // 删除检索日志
 async function deleteRetrievalLog(id, index) {
-    if (!confirm('确定要删除这条检索记录吗？')) {
+    if (!confirm(t('knowledge.confirm.delete_record'))) {
         return;
     }
     
@@ -1713,11 +1713,11 @@ function updateRetrievalStatsAfterDelete() {
     
     statsContainer.innerHTML = `
         <div class="retrieval-stat-item">
-            <span class="retrieval-stat-label">总检索次数</span>
+            <span class="retrieval-stat-label">${t('knowledge.stats.total_retrievals')}</span>
             <span class="retrieval-stat-value">${totalLogs}</span>
         </div>
         <div class="retrieval-stat-item">
-            <span class="retrieval-stat-label">成功检索</span>
+            <span class="retrieval-stat-label">${t('knowledge.stats.success_retrievals')}</span>
             <span class="retrieval-stat-value text-success">${successfulLogs}</span>
         </div>
         <div class="retrieval-stat-item">
@@ -1866,7 +1866,7 @@ function showRetrievalLogDetailsModal(log, retrievedItems) {
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 12px;">
                         ${log.conversationId ? `
                             <div style="padding: 12px; background: var(--bg-secondary); border-radius: 6px;">
-                                <div style="font-size: 0.875rem; color: var(--text-secondary); margin-bottom: 4px;">对话ID</div>
+                                <div style="font-size: 0.875rem; color: var(--text-secondary); margin-bottom: 4px;">${t('knowledge.label.conv_id')}</div>
                                 <code style="font-size: 0.8125rem; color: var(--text-primary); word-break: break-all; cursor: pointer;" 
                                       onclick="navigator.clipboard.writeText('${escapeHtml(log.conversationId)}'); this.title='已复制!'; setTimeout(() => this.title='点击复制', 2000);" 
                                       title="点击复制">${escapeHtml(log.conversationId)}</code>

--- a/web/static/js/monitor.js
+++ b/web/static/js/monitor.js
@@ -96,10 +96,10 @@ function addProgressMessage() {
     bubble.className = 'message-bubble progress-container';
     bubble.innerHTML = `
         <div class="progress-header">
-            <span class="progress-title">🔍 渗透测试进行中...</span>
+            <span class="progress-title">${t('monitor.status.running')}</span>
             <div class="progress-actions">
-                <button class="progress-stop" id="${id}-stop-btn" onclick="cancelProgressTask('${id}')">停止任务</button>
-                <button class="progress-toggle" onclick="toggleProgressDetails('${id}')">收起详情</button>
+                <button class="progress-stop" id="${id}-stop-btn" onclick="cancelProgressTask('${id}')">${t('monitor.btn.stop_task')}</button>
+                <button class="progress-toggle" onclick="toggleProgressDetails('${id}')">${t('monitor.btn.collapse')}</button>
             </div>
         </div>
         <div class="progress-timeline expanded" id="${id}-timeline"></div>
@@ -123,10 +123,10 @@ function toggleProgressDetails(progressId) {
     
     if (timeline.classList.contains('expanded')) {
         timeline.classList.remove('expanded');
-        toggleBtn.textContent = '展开详情';
+        toggleBtn.textContent = t('monitor.btn.expand');
     } else {
         timeline.classList.add('expanded');
-        toggleBtn.textContent = '收起详情';
+        toggleBtn.textContent = t('monitor.btn.collapse');
     }
 }
 
@@ -143,7 +143,7 @@ function collapseAllProgressDetails(assistantMessageId, progressId) {
                 timeline.classList.remove('expanded');
                 const btn = document.querySelector(`#${assistantMessageId} .process-detail-btn`);
                 if (btn) {
-                    btn.innerHTML = '<span>展开详情</span>';
+                    btn.innerHTML = `<span>${t('monitor.btn.expand')}</span>`;
                 }
             }
         }
@@ -158,11 +158,11 @@ function collapseAllProgressDetails(assistantMessageId, progressId) {
         if (timeline) {
             timeline.classList.remove('expanded');
             if (toggleBtn) {
-                toggleBtn.textContent = '展开详情';
+                toggleBtn.textContent = t('monitor.btn.expand');
             }
         }
     });
-    
+
     // 折叠原始的进度消息（如果还存在）
     if (progressId) {
         const progressTimeline = document.getElementById(progressId + '-timeline');
@@ -170,7 +170,7 @@ function collapseAllProgressDetails(assistantMessageId, progressId) {
         if (progressTimeline) {
             progressTimeline.classList.remove('expanded');
             if (progressToggleBtn) {
-                progressToggleBtn.textContent = '展开详情';
+                progressToggleBtn.textContent = t('monitor.btn.expand');
             }
         }
     }
@@ -246,10 +246,10 @@ function integrateProgressToMCPSection(progressId, assistantMessageId) {
     // 设置详情内容（如果有错误，默认折叠；否则默认折叠）
     detailsContainer.innerHTML = `
         <div class="process-details-content">
-            ${hasContent ? `<div class="progress-timeline" id="${detailsId}-timeline">${timelineHTML}</div>` : '<div class="progress-timeline-empty">暂无过程详情</div>'}
+            ${hasContent ? `<div class="progress-timeline" id="${detailsId}-timeline">${timelineHTML}</div>` : `<div class="progress-timeline-empty">${t('monitor.label.no_details')}</div>`}
         </div>
     `;
-    
+
     // 确保初始状态是折叠的（默认折叠，特别是错误时）
     if (hasContent) {
         const timeline = document.getElementById(detailsId + '-timeline');
@@ -257,11 +257,11 @@ function integrateProgressToMCPSection(progressId, assistantMessageId) {
             // 如果有错误，确保折叠；否则也默认折叠
             timeline.classList.remove('expanded');
         }
-        
+
         // 更新按钮文本为"展开详情"（因为默认折叠）
         const processDetailBtn = buttonsContainer.querySelector('.process-detail-btn');
         if (processDetailBtn) {
-            processDetailBtn.innerHTML = '<span>展开详情</span>';
+            processDetailBtn.innerHTML = `<span>${t('monitor.btn.expand')}</span>`;
         }
     }
     
@@ -282,19 +282,19 @@ function toggleProcessDetails(progressId, assistantMessageId) {
     if (content && timeline) {
         if (timeline.classList.contains('expanded')) {
             timeline.classList.remove('expanded');
-            if (btn) btn.innerHTML = '<span>展开详情</span>';
+            if (btn) btn.innerHTML = `<span>${t('monitor.btn.expand')}</span>`;
         } else {
             timeline.classList.add('expanded');
-            if (btn) btn.innerHTML = '<span>收起详情</span>';
+            if (btn) btn.innerHTML = `<span>${t('monitor.btn.collapse')}</span>`;
         }
     } else if (timeline) {
         // 如果只有timeline，直接切换
         if (timeline.classList.contains('expanded')) {
             timeline.classList.remove('expanded');
-            if (btn) btn.innerHTML = '<span>展开详情</span>';
+            if (btn) btn.innerHTML = `<span>${t('monitor.btn.expand')}</span>`;
         } else {
             timeline.classList.add('expanded');
-            if (btn) btn.innerHTML = '<span>收起详情</span>';
+            if (btn) btn.innerHTML = `<span>${t('monitor.btn.collapse')}</span>`;
         }
     }
     
@@ -319,7 +319,7 @@ async function cancelProgressTask(progressId) {
                 stopBtn.disabled = false;
             }, 1500);
         }
-        alert('任务信息尚未同步，请稍后再试。');
+        alert(t('monitor.alert.not_synced'));
         return;
     }
 
@@ -330,7 +330,7 @@ async function cancelProgressTask(progressId) {
     markProgressCancelling(progressId);
     if (stopBtn) {
         stopBtn.disabled = true;
-        stopBtn.textContent = '取消中...';
+        stopBtn.textContent = t('ui.status.loading');
     }
 
     try {
@@ -338,10 +338,10 @@ async function cancelProgressTask(progressId) {
         loadActiveTasks();
     } catch (error) {
         console.error('取消任务失败:', error);
-        alert('取消任务失败: ' + error.message);
+        alert(t('monitor.alert.cancel_failed').replace('{0}', error.message));
         if (stopBtn) {
             stopBtn.disabled = false;
-            stopBtn.textContent = '停止任务';
+            stopBtn.textContent = t('monitor.btn.stop_task');
         }
         const currentState = progressTaskState.get(progressId);
         if (currentState) {
@@ -391,15 +391,15 @@ function convertProgressToDetails(progressId, assistantMessageId) {
     // 如果有错误，默认折叠；否则默认展开
     const shouldExpand = !hasError;
     const expandedClass = shouldExpand ? 'expanded' : '';
-    const toggleText = shouldExpand ? '收起详情' : '展开详情';
-    
+    const toggleText = shouldExpand ? t('monitor.btn.collapse') : t('monitor.btn.expand');
+
     // 总是显示详情组件，即使没有内容也显示
     bubble.innerHTML = `
         <div class="progress-header">
             <span class="progress-title">📋 渗透测试详情</span>
             ${hasContent ? `<button class="progress-toggle" onclick="toggleProgressDetails('${detailsId}')">${toggleText}</button>` : ''}
         </div>
-        ${hasContent ? `<div class="progress-timeline ${expandedClass}" id="${detailsId}-timeline">${timelineHTML}</div>` : '<div class="progress-timeline-empty">暂无过程详情（可能执行过快或未触发详细事件）</div>'}
+        ${hasContent ? `<div class="progress-timeline ${expandedClass}" id="${detailsId}-timeline">${timelineHTML}</div>` : `<div class="progress-timeline-empty">${t('monitor.label.no_details')}</div>`}
     `;
     
     contentWrapper.appendChild(bubble);
@@ -484,7 +484,7 @@ function handleStreamEvent(event, progressElement, progressId,
         case 'tool_calls_detected':
             // 工具调用检测
             addTimelineItem(timeline, 'tool_calls_detected', {
-                title: `🔧 检测到 ${event.data?.count || 0} 个工具调用`,
+                title: t('monitor.label.tool_calls').replace('{0}', event.data?.count || 0),
                 message: event.message,
                 data: event.data
             });
@@ -500,7 +500,7 @@ function handleStreamEvent(event, progressElement, progressId,
             
             // 添加工具调用项，并标记为执行中
             const toolCallItemId = addTimelineItem(timeline, 'tool_call', {
-                title: `🔧 调用工具: ${escapeHtml(toolName)} (${index}/${total})`,
+                title: t('monitor.label.calling_tool').replace('{0}', escapeHtml(toolName)).replace('{1}', index).replace('{2}', total),
                 message: event.message,
                 data: toolInfo,
                 expanded: false
@@ -552,15 +552,15 @@ function handleStreamEvent(event, progressElement, progressId,
         case 'cancelled':
             // 显示错误
             addTimelineItem(timeline, 'cancelled', {
-                title: '⛔ 任务已取消',
+                title: t('monitor.label.cancelled'),
                 message: event.message,
                 data: event.data
             });
-            
+
             // 更新进度标题为取消状态
             const cancelTitle = document.querySelector(`#${progressId} .progress-title`);
             if (cancelTitle) {
-                cancelTitle.textContent = '⛔ 任务已取消';
+                cancelTitle.textContent = t('monitor.label.cancelled');
             }
             
             // 更新进度容器为已完成状态（添加completed类）
@@ -670,15 +670,15 @@ function handleStreamEvent(event, progressElement, progressId,
         case 'error':
             // 显示错误
             addTimelineItem(timeline, 'error', {
-                title: '❌ 错误',
+                title: t('monitor.label.error'),
                 message: event.message,
                 data: event.data
             });
-            
+
             // 更新进度标题为错误状态
             const errorTitle = document.querySelector(`#${progressId} .progress-title`);
             if (errorTitle) {
-                errorTitle.textContent = '❌ 执行失败';
+                errorTitle.textContent = t('monitor.label.error');
             }
             
             // 更新进度容器为已完成状态（添加completed类）
@@ -743,7 +743,7 @@ function handleStreamEvent(event, progressElement, progressId,
             // 完成，更新进度标题（如果进度消息还存在）
             const doneTitle = document.querySelector(`#${progressId} .progress-title`);
             if (doneTitle) {
-                doneTitle.textContent = '✅ 渗透测试完成';
+                doneTitle.textContent = t('monitor.label.completed');
             }
             // 更新对话ID
             if (event.data && event.data.conversationId) {
@@ -897,7 +897,7 @@ function addTimelineItem(timeline, type, options) {
     } else if (type === 'cancelled') {
         content += `
             <div class="timeline-item-content">
-                ${escapeHtml(options.message || '任务已取消')}
+                ${escapeHtml(options.message || t('monitor.label.cancelled'))}
             </div>
         `;
     }
@@ -983,7 +983,7 @@ function renderActiveTasks(tasks) {
             </div>
             <div class="active-task-actions">
                 ${timeText ? `<span class="active-task-time">${timeText}</span>` : ''}
-                ${!isFinalStatus ? '<button class="active-task-cancel">停止任务</button>' : ''}
+                ${!isFinalStatus ? `<button class="active-task-cancel">${t('monitor.btn.stop_task')}</button>` : ''}
             </div>
         `;
 
@@ -1014,7 +1014,7 @@ async function cancelActiveTask(conversationId, button) {
         loadActiveTasks();
     } catch (error) {
         console.error('取消任务失败:', error);
-        alert('取消任务失败: ' + error.message);
+        alert(t('monitor.alert.cancel_failed').replace('{0}', error.message));
         button.disabled = false;
         button.textContent = originalText;
     }
@@ -1138,10 +1138,10 @@ async function refreshMonitorPanel(page = null) {
     } catch (error) {
         console.error('刷新监控面板失败:', error);
         if (statsContainer) {
-            statsContainer.innerHTML = `<div class="monitor-error">无法加载统计信息：${escapeHtml(error.message)}</div>`;
+            statsContainer.innerHTML = `<div class="monitor-error">${t('monitor.error.load_stats').replace('{0}', escapeHtml(error.message))}</div>`;
         }
         if (execContainer) {
-            execContainer.innerHTML = `<div class="monitor-error">无法加载执行记录：${escapeHtml(error.message)}</div>`;
+            execContainer.innerHTML = `<div class="monitor-error">${t('monitor.error.load_records').replace('{0}', escapeHtml(error.message))}</div>`;
         }
     }
 }
@@ -1215,10 +1215,10 @@ async function refreshMonitorPanelWithFilter(statusFilter = 'all', toolFilter = 
     } catch (error) {
         console.error('刷新监控面板失败:', error);
         if (statsContainer) {
-            statsContainer.innerHTML = `<div class="monitor-error">无法加载统计信息：${escapeHtml(error.message)}</div>`;
+            statsContainer.innerHTML = `<div class="monitor-error">${t('monitor.error.load_stats').replace('{0}', escapeHtml(error.message))}</div>`;
         }
         if (execContainer) {
-            execContainer.innerHTML = `<div class="monitor-error">无法加载执行记录：${escapeHtml(error.message)}</div>`;
+            execContainer.innerHTML = `<div class="monitor-error">${t('monitor.error.load_records').replace('{0}', escapeHtml(error.message))}</div>`;
         }
     }
 }
@@ -1232,7 +1232,7 @@ function renderMonitorStats(statsMap = {}, lastFetchedAt = null) {
 
     const entries = Object.values(statsMap);
     if (entries.length === 0) {
-        container.innerHTML = '<div class="monitor-empty">暂无统计数据</div>';
+        container.innerHTML = '<div class="monitor-empty">' + t('monitor.no_data') + '</div>';
         return;
     }
 
@@ -1253,7 +1253,7 @@ function renderMonitorStats(statsMap = {}, lastFetchedAt = null) {
 
     const successRate = totals.total > 0 ? ((totals.success / totals.total) * 100).toFixed(1) : '0.0';
     const lastUpdatedText = lastFetchedAt ? lastFetchedAt.toLocaleString('zh-CN') : 'N/A';
-    const lastCallText = totals.lastCallTime ? totals.lastCallTime.toLocaleString('zh-CN') : '暂无调用';
+    const lastCallText = totals.lastCallTime ? totals.lastCallTime.toLocaleString('zh-CN') : t('monitor.label.no_calls');
 
     let html = `
         <div class="monitor-stat-card">
@@ -1308,9 +1308,9 @@ function renderMonitorExecutions(executions = [], statusFilter = 'all') {
         const currentToolFilter = toolFilter ? toolFilter.value : 'all';
         const hasFilter = (statusFilter && statusFilter !== 'all') || (currentToolFilter && currentToolFilter !== 'all');
         if (hasFilter) {
-            container.innerHTML = '<div class="monitor-empty">当前筛选条件下暂无记录</div>';
+            container.innerHTML = '<div class="monitor-empty">' + t('monitor.no_data') + '</div>';
         } else {
-            container.innerHTML = '<div class="monitor-empty">暂无执行记录</div>';
+            container.innerHTML = '<div class="monitor-empty">' + t('monitor.no_data') + '</div>';
         }
         // 隐藏批量操作栏
         const batchActions = document.getElementById('monitor-batch-actions');
@@ -1342,8 +1342,8 @@ function renderMonitorExecutions(executions = [], statusFilter = 'all') {
                     <td>${duration}</td>
                     <td>
                         <div class="monitor-execution-actions">
-                            <button class="btn-secondary" onclick="showMCPDetail('${executionId}')">查看详情</button>
-                            <button class="btn-secondary btn-delete" onclick="deleteExecution('${executionId}')" title="删除此执行记录">删除</button>
+                            <button class="btn-secondary" onclick="showMCPDetail('${executionId}')">${t('ui.btn.view')}</button>
+                            <button class="btn-secondary btn-delete" onclick="deleteExecution('${executionId}')" title="${t('ui.btn.delete')}">${t('ui.btn.delete')}</button>
                         </div>
                     </td>
                 </tr>
@@ -1418,7 +1418,7 @@ function renderMonitorPagination() {
     
     pagination.innerHTML = `
         <div class="pagination-info">
-            <span>显示 ${startItem}-${endItem} / 共 ${total} 条记录</span>
+            <span>${t('ui.pagination.showing').replace('{0}', startItem).replace('{1}', endItem).replace('{2}', total)}</span>
             <label class="pagination-page-size">
                 每页显示
                 <select id="monitor-page-size" onchange="changeMonitorPageSize()">
@@ -1430,11 +1430,11 @@ function renderMonitorPagination() {
             </label>
         </div>
         <div class="pagination-controls">
-            <button class="btn-secondary" onclick="refreshMonitorPanel(1)" ${page === 1 || total === 0 ? 'disabled' : ''}>首页</button>
-            <button class="btn-secondary" onclick="refreshMonitorPanel(${page - 1})" ${page === 1 || total === 0 ? 'disabled' : ''}>上一页</button>
-            <span class="pagination-page">第 ${page} / ${totalPages || 1} 页</span>
-            <button class="btn-secondary" onclick="refreshMonitorPanel(${page + 1})" ${page >= totalPages || total === 0 ? 'disabled' : ''}>下一页</button>
-            <button class="btn-secondary" onclick="refreshMonitorPanel(${totalPages || 1})" ${page >= totalPages || total === 0 ? 'disabled' : ''}>末页</button>
+            <button class="btn-secondary" onclick="refreshMonitorPanel(1)" ${page === 1 || total === 0 ? 'disabled' : ''}>${t('ui.pagination.first')}</button>
+            <button class="btn-secondary" onclick="refreshMonitorPanel(${page - 1})" ${page === 1 || total === 0 ? 'disabled' : ''}>${t('ui.pagination.prev')}</button>
+            <span class="pagination-page">${t('ui.pagination.page').replace('{0}', page).replace('{1}', totalPages || 1)}</span>
+            <button class="btn-secondary" onclick="refreshMonitorPanel(${page + 1})" ${page >= totalPages || total === 0 ? 'disabled' : ''}>${t('ui.pagination.next')}</button>
+            <button class="btn-secondary" onclick="refreshMonitorPanel(${totalPages || 1})" ${page >= totalPages || total === 0 ? 'disabled' : ''}>${t('ui.pagination.last')}</button>
         </div>
     `;
     
@@ -1451,7 +1451,7 @@ async function deleteExecution(executionId) {
     }
     
     // 确认删除
-    if (!confirm('确定要删除此执行记录吗？此操作不可恢复。')) {
+    if (!confirm(t('monitor.confirm.delete_record'))) {
         return;
     }
     
@@ -1469,10 +1469,10 @@ async function deleteExecution(executionId) {
         const currentPage = monitorState.pagination.page;
         await refreshMonitorPanel(currentPage);
         
-        alert('执行记录已删除');
+        alert(t('monitor.message.deleted'));
     } catch (error) {
         console.error('删除执行记录失败:', error);
-        alert('删除执行记录失败: ' + error.message);
+        alert(t('monitor.alert.delete_failed').replace('{0}', error.message));
     }
 }
 
@@ -1547,7 +1547,7 @@ function deselectAllExecutions() {
 async function batchDeleteExecutions() {
     const checkboxes = document.querySelectorAll('.monitor-execution-checkbox:checked');
     if (checkboxes.length === 0) {
-        alert('请先选择要删除的执行记录');
+        alert(t('monitor.alert.no_selected'));
         return;
     }
     
@@ -1555,7 +1555,7 @@ async function batchDeleteExecutions() {
     const count = ids.length;
     
     // 确认删除
-    if (!confirm(`确定要删除选中的 ${count} 条执行记录吗？此操作不可恢复。`)) {
+    if (!confirm(t('monitor.confirm.delete_selected').replace('{0}', count))) {
         return;
     }
     
@@ -1580,10 +1580,10 @@ async function batchDeleteExecutions() {
         const currentPage = monitorState.pagination.page;
         await refreshMonitorPanel(currentPage);
         
-        alert(`成功删除 ${deletedCount} 条执行记录`);
+        alert(t('monitor.message.batch_deleted') + ` ${deletedCount} 条`);
     } catch (error) {
         console.error('批量删除执行记录失败:', error);
-        alert('批量删除执行记录失败: ' + error.message);
+        alert(t('monitor.alert.batch_delete_failed').replace('{0}', error.message));
     }
 }
 

--- a/web/static/js/roles.js
+++ b/web/static/js/roles.js
@@ -45,7 +45,7 @@ async function loadRoles() {
     try {
         const response = await apiFetch('/api/roles');
         if (!response.ok) {
-            throw new Error('加载角色失败');
+            throw new Error(t('role.error.load_failed'));
         }
         const data = await response.json();
         roles = data.roles || [];
@@ -54,7 +54,7 @@ async function loadRoles() {
         return roles;
     } catch (error) {
         console.error('加载角色失败:', error);
-        showNotification('加载角色失败: ' + error.message, 'error');
+        showNotification(t('role.error.load_failed') + ': ' + error.message, 'error');
         return [];
     }
 }
@@ -112,7 +112,7 @@ function updateRoleSelectorDisplay() {
     } else {
         // 默认角色
         roleSelectorIcon.textContent = '🔵';
-        roleSelectorText.textContent = '默认';
+        roleSelectorText.textContent = t('role.label.default_name');
     }
 }
 
@@ -260,7 +260,7 @@ async function refreshRoles() {
     }
     // 始终更新侧边栏角色选择列表
     renderRoleSelectionSidebar();
-    showNotification('已刷新', 'success');
+    showNotification(t('role.message.refreshed'), 'success');
 }
 
 // 渲染角色列表
@@ -279,8 +279,8 @@ function renderRolesList() {
     }
 
     if (filteredRoles.length === 0) {
-        rolesList.innerHTML = '<div class="empty-state">' + 
-            (rolesSearchKeyword ? '没有找到匹配的角色' : '暂无角色') + 
+        rolesList.innerHTML = '<div class="empty-state">' +
+            (rolesSearchKeyword ? t('role.label.no_results') : t('role.no_data')) +
             '</div>';
         return;
     }
@@ -310,7 +310,7 @@ function renderRolesList() {
         let toolsDisplay = '';
         let toolsCount = 0;
         if (role.name === '默认') {
-            toolsDisplay = '使用所有工具';
+            toolsDisplay = t('role.label.use_all_tools');
         } else if (role.tools && role.tools.length > 0) {
             toolsCount = role.tools.length;
             // 显示前5个工具名称
@@ -328,7 +328,7 @@ function renderRolesList() {
             toolsCount = role.mcps.length;
             toolsDisplay = `等 ${toolsCount} 个`;
         } else {
-            toolsDisplay = '使用所有工具';
+            toolsDisplay = t('role.label.use_all_tools');
         }
 
         return `
@@ -339,17 +339,17 @@ function renderRolesList() {
                     ${escapeHtml(role.name)}
                 </h3>
                 <span class="role-card-badge ${role.enabled !== false ? 'enabled' : 'disabled'}">
-                    ${role.enabled !== false ? '已启用' : '已禁用'}
+                    ${role.enabled !== false ? t('ui.btn.enabled') : t('ui.btn.disabled')}
                 </span>
             </div>
             <div class="role-card-description">${escapeHtml(role.description || '无描述')}</div>
             <div class="role-card-tools">
-                <span class="role-card-tools-label">工具:</span>
+                <span class="role-card-tools-label">${t('role.label.tools')}</span>
                 <span class="role-card-tools-value">${toolsDisplay}</span>
             </div>
             <div class="role-card-actions">
-                <button class="btn-secondary btn-small" onclick="editRole('${escapeHtml(role.name)}')">编辑</button>
-                ${role.name !== '默认' ? `<button class="btn-secondary btn-small btn-danger" onclick="deleteRole('${escapeHtml(role.name)}')">删除</button>` : ''}
+                <button class="btn-secondary btn-small" onclick="editRole('${escapeHtml(role.name)}')">${t('ui.btn.edit')}</button>
+                ${role.name !== '默认' ? `<button class="btn-secondary btn-small btn-danger" onclick="deleteRole('${escapeHtml(role.name)}')">${t('ui.btn.delete')}</button>` : ''}
             </div>
         </div>
     `;
@@ -519,7 +519,7 @@ function renderRoleToolsList() {
     listContainer.innerHTML = '';
     
     if (allRoleTools.length === 0) {
-        listContainer.innerHTML = '<div class="tools-empty">暂无工具</div>';
+        listContainer.innerHTML = '<div class="tools-empty">' + t('role.label.no_tools') + '</div>';
         toolsList.appendChild(listContainer);
         return;
     }
@@ -544,8 +544,8 @@ function renderRoleToolsList() {
         let externalBadge = '';
         if (toolState.is_external || tool.is_external) {
             const externalMcpName = toolState.external_mcp || tool.external_mcp || '';
-            const badgeText = externalMcpName ? `外部 (${escapeHtml(externalMcpName)})` : '外部';
-            const badgeTitle = externalMcpName ? `外部MCP工具 - 来源：${escapeHtml(externalMcpName)}` : '外部MCP工具';
+            const badgeText = externalMcpName ? t('role.label.external_tool').replace('{0}', escapeHtml(externalMcpName)) : t('role.label.external_tool').replace(' ({0})', '');
+            const badgeTitle = externalMcpName ? `${t('role.label.external_mcp')} - ${escapeHtml(externalMcpName)}` : t('role.label.external_mcp');
             externalBadge = `<span class="external-tool-badge" title="${badgeTitle}">${badgeText}</span>`;
         }
         
@@ -594,14 +594,14 @@ function renderRoleToolsPagination() {
     
     pagination.innerHTML = `
         <div class="pagination-info">
-            显示 ${startItem}-${endItem} / 共 ${total} 个工具${roleToolsSearchKeyword ? ` (搜索: "${escapeHtml(roleToolsSearchKeyword)}")` : ''}
+            ${t('role.label.tool_count').replace('{0}', startItem).replace('{1}', endItem).replace('{2}', total)}${roleToolsSearchKeyword ? ` (搜索: "${escapeHtml(roleToolsSearchKeyword)}")` : ''}
         </div>
         <div class="pagination-controls">
-            <button class="btn-secondary" onclick="loadRoleTools(1, '${escapeHtml(roleToolsSearchKeyword)}')" ${page === 1 ? 'disabled' : ''}>首页</button>
-            <button class="btn-secondary" onclick="loadRoleTools(${page - 1}, '${escapeHtml(roleToolsSearchKeyword)}')" ${page === 1 ? 'disabled' : ''}>上一页</button>
-            <span class="pagination-page">第 ${page} / ${totalPages} 页</span>
-            <button class="btn-secondary" onclick="loadRoleTools(${page + 1}, '${escapeHtml(roleToolsSearchKeyword)}')" ${page === totalPages ? 'disabled' : ''}>下一页</button>
-            <button class="btn-secondary" onclick="loadRoleTools(${totalPages}, '${escapeHtml(roleToolsSearchKeyword)}')" ${page === totalPages ? 'disabled' : ''}>末页</button>
+            <button class="btn-secondary" onclick="loadRoleTools(1, '${escapeHtml(roleToolsSearchKeyword)}')" ${page === 1 ? 'disabled' : ''}>${t('ui.pagination.first')}</button>
+            <button class="btn-secondary" onclick="loadRoleTools(${page - 1}, '${escapeHtml(roleToolsSearchKeyword)}')" ${page === 1 ? 'disabled' : ''}>${t('ui.pagination.prev')}</button>
+            <span class="pagination-page">${t('ui.pagination.page').replace('{0}', page).replace('{1}', totalPages)}</span>
+            <button class="btn-secondary" onclick="loadRoleTools(${page + 1}, '${escapeHtml(roleToolsSearchKeyword)}')" ${page === totalPages ? 'disabled' : ''}>${t('ui.pagination.next')}</button>
+            <button class="btn-secondary" onclick="loadRoleTools(${totalPages}, '${escapeHtml(roleToolsSearchKeyword)}')" ${page === totalPages ? 'disabled' : ''}>${t('ui.pagination.last')}</button>
         </div>
     `;
     
@@ -836,7 +836,7 @@ async function showAddRoleModal() {
     const modal = document.getElementById('role-modal');
     if (!modal) return;
 
-    document.getElementById('role-modal-title').textContent = '添加角色';
+    document.getElementById('role-modal-title').textContent = t('role.btn.create');
     document.getElementById('role-name').value = '';
     document.getElementById('role-name').disabled = false;
     document.getElementById('role-description').value = '';
@@ -916,14 +916,14 @@ async function showAddRoleModal() {
 async function editRole(roleName) {
     const role = roles.find(r => r.name === roleName);
     if (!role) {
-        showNotification('角色不存在', 'error');
+        showNotification(t('role.error.not_exists'), 'error');
         return;
     }
 
     const modal = document.getElementById('role-modal');
     if (!modal) return;
 
-    document.getElementById('role-modal-title').textContent = '编辑角色';
+    document.getElementById('role-modal-title').textContent = t('role.btn.edit');
     document.getElementById('role-name').value = role.name;
     document.getElementById('role-name').disabled = true; // 编辑时不允许修改名称
     document.getElementById('role-description').value = role.description || '';
@@ -1184,7 +1184,7 @@ async function loadAllToolsToStateMap() {
 async function saveRole() {
     const name = document.getElementById('role-name').value.trim();
     if (!name) {
-        showNotification('角色名称不能为空', 'error');
+        showNotification(t('role.error.name_empty'), 'error');
         return;
     }
 
@@ -1225,7 +1225,7 @@ async function saveRole() {
         // 如果是首次添加角色且没有选择工具，默认使用全部工具
         if (isFirstUserRole && allSelectedTools.length === 0) {
             roleUsesAllTools = true;
-            showNotification('检测到这是首次添加角色且未选择工具，将默认使用全部工具', 'info');
+            showNotification(t('role.info.first_role_all_tools'), 'info');
         } else if (roleUsesAllTools) {
             // 如果当前使用所有工具，需要检查用户是否取消了一些工具
             // 检查状态映射中是否有未选中的已启用工具
@@ -1338,29 +1338,29 @@ async function saveRole() {
                 toolNames = toolNames.substring(0, 100) + '...';
             }
             showNotification(
-                `${isEdit ? '角色已更新' : '角色已创建'}，但已过滤 ${disabledTools.length} 个未在MCP管理中启用的工具：${toolNames}。请先在"MCP管理"中启用这些工具，然后再在角色中配置。`,
+                `${isEdit ? t('role.message.updated') : t('role.message.created')}，但已过滤 ${disabledTools.length} 个未在MCP管理中启用的工具：${toolNames}。请先在"MCP管理"中启用这些工具，然后再在角色中配置。`,
                 'warning'
             );
         } else {
-            showNotification(isEdit ? '角色已更新' : '角色已创建', 'success');
+            showNotification(isEdit ? t('role.message.updated') : t('role.message.created'), 'success');
         }
         
         closeRoleModal();
         await refreshRoles();
     } catch (error) {
         console.error('保存角色失败:', error);
-        showNotification('保存角色失败: ' + error.message, 'error');
+        showNotification(t('role.error.save_failed') + ': ' + error.message, 'error');
     }
 }
 
 // 删除角色
 async function deleteRole(roleName) {
     if (roleName === '默认') {
-        showNotification('不能删除默认角色', 'error');
+        showNotification(t('role.error.cannot_delete_default'), 'error');
         return;
     }
 
-    if (!confirm(`确定要删除角色"${roleName}"吗？此操作不可撤销。`)) {
+    if (!confirm(t('role.confirm.delete').replace('{0}', roleName))) {
         return;
     }
 
@@ -1374,7 +1374,7 @@ async function deleteRole(roleName) {
             throw new Error(error.error || '删除角色失败');
         }
 
-        showNotification('角色已删除', 'success');
+        showNotification(t('role.message.deleted'), 'success');
         
         // 如果删除的是当前选中的角色,切换到默认角色
         if (currentRole === roleName) {
@@ -1384,7 +1384,7 @@ async function deleteRole(roleName) {
         await refreshRoles();
     } catch (error) {
         console.error('删除角色失败:', error);
-        showNotification('删除角色失败: ' + error.message, 'error');
+        showNotification(t('role.error.delete_failed') + ': ' + error.message, 'error');
     }
 }
 
@@ -1487,8 +1487,8 @@ function renderRoleSkills() {
     }
 
     if (filteredSkills.length === 0) {
-        skillsList.innerHTML = '<div class="skills-empty">' + 
-            (roleSkillsSearchKeyword ? '没有找到匹配的skills' : '暂无可用skills') + 
+        skillsList.innerHTML = '<div class="skills-empty">' +
+            (roleSkillsSearchKeyword ? t('role.label.skills_no_results') : t('ui.empty.no_data')) +
             '</div>';
         updateRoleSkillsStats();
         return;
@@ -1594,7 +1594,7 @@ function updateRoleSkillsStats() {
         filteredSkills.includes(skill)
     ).length;
 
-    statsEl.textContent = `已选择 ${selectedCount} / ${filteredSkills.length}`;
+    statsEl.textContent = t('role.label.skills_selected').replace('{0}', selectedCount).replace('{1}', filteredSkills.length);
 }
 
 // HTML转义函数

--- a/web/static/js/router.js
+++ b/web/static/js/router.js
@@ -1,6 +1,13 @@
 // 页面路由管理
 let currentPage = 'dashboard';
 
+// i18n helper - reads from window.I18N injected by Go template
+function t(key, ...args) {
+    let msg = (window.I18N && window.I18N[key]) || key;
+    args.forEach((arg, i) => { msg = msg.replace('{' + i + '}', arg); });
+    return msg;
+}
+
 // 初始化路由
 function initRouter() {
     // 从URL hash读取页面（如果有）

--- a/web/static/js/settings.js
+++ b/web/static/js/settings.js
@@ -96,9 +96,9 @@ async function loadConfig(loadTools = true) {
     try {
         const response = await apiFetch('/api/config');
         if (!response.ok) {
-            throw new Error('获取配置失败');
+            throw new Error(t('settings.error.load_failed'));
         }
-        
+
         currentConfig = await response.json();
         
         // 填充OpenAI配置
@@ -269,7 +269,7 @@ async function loadToolsList(page = 1, searchKeyword = '') {
     // 显示加载状态
     if (toolsList) {
         // 清空整个容器，包括可能存在的分页控件
-        toolsList.innerHTML = '<div class="tools-list-items"><div class="loading" style="padding: 20px; text-align: center; color: var(--text-muted);">⏳ 正在加载工具列表...</div></div>';
+        toolsList.innerHTML = '<div class="tools-list-items"><div class="loading" style="padding: 20px; text-align: center; color: var(--text-muted);">' + t('settings.tools.loading') + '</div></div>';
     }
     
     try {
@@ -292,9 +292,9 @@ async function loadToolsList(page = 1, searchKeyword = '') {
         clearTimeout(timeoutId);
         
         if (!response.ok) {
-            throw new Error('获取工具列表失败');
+            throw new Error(t('settings.tools.load_failed'));
         }
-        
+
         const result = await response.json();
         allTools = result.tools || [];
         toolsPagination = {
@@ -303,7 +303,7 @@ async function loadToolsList(page = 1, searchKeyword = '') {
             total: result.total || 0,
             totalPages: result.total_pages || 1
         };
-        
+
         // 初始化工具状态映射（如果工具不在映射中，使用服务器返回的状态）
         allTools.forEach(tool => {
             const toolKey = getToolKey(tool);
@@ -316,16 +316,16 @@ async function loadToolsList(page = 1, searchKeyword = '') {
                 });
             }
         });
-        
+
         renderToolsList();
         renderToolsPagination();
     } catch (error) {
         console.error('加载工具列表失败:', error);
         if (toolsList) {
             const isTimeout = error.name === 'AbortError' || error.message.includes('timeout');
-            const errorMsg = isTimeout 
-                ? '加载工具列表超时，可能是外部MCP连接较慢。请点击"刷新"按钮重试，或检查外部MCP连接状态。'
-                : `加载工具列表失败: ${escapeHtml(error.message)}`;
+            const errorMsg = isTimeout
+                ? t('settings.tools.load_failed')
+                : t('settings.tools.load_failed') + ': ' + escapeHtml(error.message);
             toolsList.innerHTML = `<div class="error" style="padding: 20px; text-align: center;">${errorMsg}</div>`;
         }
     }
@@ -399,7 +399,7 @@ function renderToolsList() {
     listContainer.innerHTML = '';
     
     if (allTools.length === 0) {
-        listContainer.innerHTML = '<div class="empty">暂无工具</div>';
+        listContainer.innerHTML = '<div class="empty">' + t('settings.tools.no_tools') + '</div>';
         if (!toolsList.contains(listContainer)) {
             toolsList.appendChild(listContainer);
         }
@@ -483,7 +483,7 @@ function renderToolsPagination() {
     const savedPageSize = getToolsPageSize();
     pagination.innerHTML = `
         <div class="pagination-info">
-            显示 ${startItem}-${endItem} / 共 ${total} 个工具${toolsSearchKeyword ? ` (搜索: "${escapeHtml(toolsSearchKeyword)}")` : ''}
+            ${t('settings.tools.showing').replace('{0}', startItem).replace('{1}', endItem).replace('{2}', total)}${toolsSearchKeyword ? ` (搜索: "${escapeHtml(toolsSearchKeyword)}")` : ''}
         </div>
         <div class="pagination-page-size">
             <label for="tools-page-size-pagination">每页:</label>
@@ -909,7 +909,7 @@ async function applySettings() {
             throw new Error(error.error || '应用配置失败');
         }
         
-        alert('配置已成功应用！');
+        alert(t('settings.applied'));
         closeSettings();
     } catch (error) {
         console.error('应用配置失败:', error);
@@ -926,7 +926,7 @@ async function saveToolsConfig() {
         // 获取当前配置（只获取工具部分）
         const response = await apiFetch('/api/config');
         if (!response.ok) {
-            throw new Error('获取配置失败');
+            throw new Error(t('settings.error.load_failed'));
         }
         
         const currentConfig = await response.json();
@@ -1079,7 +1079,7 @@ async function changePassword() {
     }
 
     if (hasError) {
-        alert('请正确填写当前密码和新密码，新密码至少 8 位且需要两次输入一致。');
+        alert(t('settings.password.validation'));
         return;
     }
 
@@ -1173,7 +1173,7 @@ function renderExternalMCPList(servers) {
     if (!list) return;
     
     if (Object.keys(servers).length === 0) {
-        list.innerHTML = '<div class="empty">📋 暂无外部MCP配置<br><span style="font-size: 0.875rem; margin-top: 8px; display: block;">点击"添加外部MCP"按钮开始配置</span></div>';
+        list.innerHTML = '<div class="empty">' + t('settings.mcp.no_config') + '</div>';
         return;
     }
     
@@ -1184,10 +1184,10 @@ function renderExternalMCPList(servers) {
                            status === 'connecting' ? 'status-connecting' :
                            status === 'error' ? 'status-error' :
                            status === 'disabled' ? 'status-disabled' : 'status-disconnected';
-        const statusText = status === 'connected' ? '已连接' : 
-                          status === 'connecting' ? '连接中...' :
-                          status === 'error' ? '连接失败' :
-                          status === 'disabled' ? '已禁用' : '未连接';
+        const statusText = status === 'connected' ? t('settings.mcp.status.connected') :
+                          status === 'connecting' ? t('settings.mcp.status.connecting') :
+                          status === 'error' ? t('settings.mcp.status.failed') :
+                          status === 'disabled' ? t('settings.mcp.status.disabled') : t('settings.mcp.status.failed');
         const transport = server.config.transport || (server.config.command ? 'stdio' : 'http');
         const transportIcon = transport === 'stdio' ? '⚙️' : '🌐';
         
@@ -1200,12 +1200,12 @@ function renderExternalMCPList(servers) {
                     </div>
                     <div class="external-mcp-item-actions">
                         ${status === 'connected' || status === 'disconnected' || status === 'error' ? 
-                            `<button class="btn-small" id="btn-toggle-${escapeHtml(name)}" onclick="toggleExternalMCP('${escapeHtml(name)}', '${status}')" title="${status === 'connected' ? '停止连接' : '启动连接'}">
-                                ${status === 'connected' ? '⏸ 停止' : '▶ 启动'}
-                            </button>` : 
-                            status === 'connecting' ? 
+                            `<button class="btn-small" id="btn-toggle-${escapeHtml(name)}" onclick="toggleExternalMCP('${escapeHtml(name)}', '${status}')" title="${status === 'connected' ? t('settings.mcp.btn.stop') : t('settings.mcp.btn.start')}">
+                                ${status === 'connected' ? '⏸ ' + t('settings.mcp.btn.stop') : '▶ ' + t('settings.mcp.btn.start')}
+                            </button>` :
+                            status === 'connecting' ?
                             `<button class="btn-small" id="btn-toggle-${escapeHtml(name)}" disabled style="opacity: 0.6; cursor: not-allowed;">
-                                ⏳ 连接中...
+                                ⏳ ${t('settings.mcp.btn.connecting')}
                             </button>` : ''}
                         <button class="btn-small" onclick="editExternalMCP('${escapeHtml(name)}')" title="编辑配置" ${status === 'connecting' ? 'disabled' : ''}>✏️ 编辑</button>
                         <button class="btn-small btn-danger" onclick="deleteExternalMCP('${escapeHtml(name)}')" title="删除配置" ${status === 'connecting' ? 'disabled' : ''}>🗑 删除</button>
@@ -1227,7 +1227,7 @@ function renderExternalMCPList(servers) {
                     </div>` : server.tool_count === 0 && status === 'connected' ? `
                     <div>
                         <strong>工具数量</strong>
-                        <span style="color: var(--text-muted);">暂无工具</span>
+                        <span style="color: var(--text-muted);">${t('settings.tools.no_tools')}</span>
                     </div>` : ''}
                     ${server.config.description ? `
                     <div>
@@ -1268,17 +1268,17 @@ function renderExternalMCPStats(stats) {
     const connected = stats.connected || 0;
     
     statsEl.innerHTML = `
-        <span title="总配置数">📊 总数: <strong>${total}</strong></span>
-        <span title="已启用的配置数">✅ 已启用: <strong>${enabled}</strong></span>
-        <span title="已停用的配置数">⏸ 已停用: <strong>${disabled}</strong></span>
-        <span title="当前已连接的配置数">🔗 已连接: <strong>${connected}</strong></span>
+        <span>📊 ${t('settings.mcp.stats.total')} <strong>${total}</strong></span>
+        <span>✅ ${t('settings.mcp.stats.enabled')} <strong>${enabled}</strong></span>
+        <span>⏸ ${t('settings.mcp.stats.disabled')} <strong>${disabled}</strong></span>
+        <span>🔗 ${t('settings.mcp.stats.connected')} <strong>${connected}</strong></span>
     `;
 }
 
 // 显示添加外部MCP模态框
 function showAddExternalMCPModal() {
     currentEditingMCPName = null;
-    document.getElementById('external-mcp-modal-title').textContent = '添加外部MCP';
+    document.getElementById('external-mcp-modal-title').textContent = t('settings.mcp.modal.add');
     document.getElementById('external-mcp-json').value = '';
     document.getElementById('external-mcp-json-error').style.display = 'none';
     document.getElementById('external-mcp-json-error').textContent = '';
@@ -1303,7 +1303,7 @@ async function editExternalMCP(name) {
         const server = await response.json();
         currentEditingMCPName = name;
         
-        document.getElementById('external-mcp-modal-title').textContent = '编辑外部MCP';
+        document.getElementById('external-mcp-modal-title').textContent = t('settings.mcp.modal.edit');
         
         // 将配置转换为对象格式（key为名称）
         const config = { ...server.config };
@@ -1337,7 +1337,7 @@ function formatExternalMCPJSON() {
     try {
         const jsonStr = jsonTextarea.value.trim();
         if (!jsonStr) {
-            errorDiv.textContent = 'JSON不能为空';
+            errorDiv.textContent = t('settings.mcp.error.json_empty');
             errorDiv.style.display = 'block';
             jsonTextarea.classList.add('error');
             return;
@@ -1349,7 +1349,7 @@ function formatExternalMCPJSON() {
         errorDiv.style.display = 'none';
         jsonTextarea.classList.remove('error');
     } catch (error) {
-        errorDiv.textContent = 'JSON格式错误: ' + error.message;
+        errorDiv.textContent = t('settings.mcp.error.json_invalid').replace('{0}', error.message);
         errorDiv.style.display = 'block';
         jsonTextarea.classList.add('error');
     }
@@ -1390,7 +1390,7 @@ async function saveExternalMCP() {
     const errorDiv = document.getElementById('external-mcp-json-error');
     
     if (!jsonStr) {
-        errorDiv.textContent = 'JSON配置不能为空';
+        errorDiv.textContent = t('settings.mcp.error.config_empty');
         errorDiv.style.display = 'block';
         jsonTextarea.classList.add('error');
         jsonTextarea.focus();
@@ -1401,7 +1401,7 @@ async function saveExternalMCP() {
     try {
         configObj = JSON.parse(jsonStr);
     } catch (error) {
-        errorDiv.textContent = 'JSON格式错误: ' + error.message;
+        errorDiv.textContent = t('settings.mcp.error.json_invalid').replace('{0}', error.message);
         errorDiv.style.display = 'block';
         jsonTextarea.classList.add('error');
         jsonTextarea.focus();
@@ -1410,7 +1410,7 @@ async function saveExternalMCP() {
     
     // 验证必须是对象格式
     if (typeof configObj !== 'object' || Array.isArray(configObj) || configObj === null) {
-        errorDiv.textContent = '配置错误: 必须是JSON对象格式，key为配置名称，value为配置内容';
+        errorDiv.textContent = t('settings.mcp.error.not_object');
         errorDiv.style.display = 'block';
         jsonTextarea.classList.add('error');
         return;
@@ -1419,7 +1419,7 @@ async function saveExternalMCP() {
     // 获取所有配置名称
     const names = Object.keys(configObj);
     if (names.length === 0) {
-        errorDiv.textContent = '配置错误: 至少需要一个配置项';
+        errorDiv.textContent = t('settings.mcp.error.no_items');
         errorDiv.style.display = 'block';
         jsonTextarea.classList.add('error');
         return;
@@ -1428,7 +1428,7 @@ async function saveExternalMCP() {
     // 验证每个配置
     for (const name of names) {
         if (!name || name.trim() === '') {
-            errorDiv.textContent = '配置错误: 配置名称不能为空';
+            errorDiv.textContent = t('settings.mcp.error.name_empty');
             errorDiv.style.display = 'block';
             jsonTextarea.classList.add('error');
             return;
@@ -1436,7 +1436,7 @@ async function saveExternalMCP() {
         
         const config = configObj[name];
         if (typeof config !== 'object' || Array.isArray(config) || config === null) {
-            errorDiv.textContent = `配置错误: "${name}" 的配置必须是对象`;
+            errorDiv.textContent = t('settings.mcp.error.item_not_object').replace('{0}', name);
             errorDiv.style.display = 'block';
             jsonTextarea.classList.add('error');
             return;
@@ -1448,28 +1448,28 @@ async function saveExternalMCP() {
         // 验证配置内容
         const transport = config.transport || (config.command ? 'stdio' : config.url ? 'http' : '');
         if (!transport) {
-            errorDiv.textContent = `配置错误: "${name}" 需要指定command（stdio模式）或url（http/sse模式）`;
+            errorDiv.textContent = t('settings.mcp.error.no_transport').replace('{0}', name);
             errorDiv.style.display = 'block';
             jsonTextarea.classList.add('error');
             return;
         }
         
         if (transport === 'stdio' && !config.command) {
-            errorDiv.textContent = `配置错误: "${name}" stdio模式需要command字段`;
+            errorDiv.textContent = t('settings.mcp.error.stdio_cmd').replace('{0}', name);
             errorDiv.style.display = 'block';
             jsonTextarea.classList.add('error');
             return;
         }
         
         if (transport === 'http' && !config.url) {
-            errorDiv.textContent = `配置错误: "${name}" http模式需要url字段`;
+            errorDiv.textContent = t('settings.mcp.error.http_url').replace('{0}', name);
             errorDiv.style.display = 'block';
             jsonTextarea.classList.add('error');
             return;
         }
         
         if (transport === 'sse' && !config.url) {
-            errorDiv.textContent = `配置错误: "${name}" sse模式需要url字段`;
+            errorDiv.textContent = t('settings.mcp.error.sse_url').replace('{0}', name);
             errorDiv.style.display = 'block';
             jsonTextarea.classList.add('error');
             return;
@@ -1484,7 +1484,7 @@ async function saveExternalMCP() {
         // 如果是编辑模式，只更新当前编辑的配置
         if (currentEditingMCPName) {
             if (!configObj[currentEditingMCPName]) {
-                errorDiv.textContent = `配置错误: 编辑模式下，JSON必须包含配置名称 "${currentEditingMCPName}"`;
+                errorDiv.textContent = t('settings.mcp.error.edit_missing');
                 errorDiv.style.display = 'block';
                 jsonTextarea.classList.add('error');
                 return;
@@ -1528,10 +1528,10 @@ async function saveExternalMCP() {
         }
         // 轮询几次以拉取后端异步更新的工具数量（无固定延迟，拿到即停）
         pollExternalMCPToolCount(null, 5);
-        alert('保存成功');
+        alert(t('mcp.message.updated'));
     } catch (error) {
         console.error('保存外部MCP失败:', error);
-        errorDiv.textContent = '保存失败: ' + error.message;
+        errorDiv.textContent = t('settings.mcp.error.save_failed').replace('{0}', error.message);
         errorDiv.style.display = 'block';
         jsonTextarea.classList.add('error');
     }
@@ -1539,7 +1539,7 @@ async function saveExternalMCP() {
 
 // 删除外部MCP
 async function deleteExternalMCP(name) {
-    if (!confirm(`确定要删除外部MCP "${name}" 吗？`)) {
+    if (!confirm(t('settings.mcp.confirm.delete').replace('{0}', name))) {
         return;
     }
     
@@ -1558,7 +1558,7 @@ async function deleteExternalMCP(name) {
         if (typeof window !== 'undefined' && typeof window.refreshMentionTools === 'function') {
             window.refreshMentionTools();
         }
-        alert('删除成功');
+        alert(t('mcp.message.deleted'));
     } catch (error) {
         console.error('删除外部MCP失败:', error);
         alert('删除失败: ' + error.message);
@@ -1576,7 +1576,7 @@ async function toggleExternalMCP(name, currentStatus) {
         button.disabled = true;
         button.style.opacity = '0.6';
         button.style.cursor = 'not-allowed';
-        button.innerHTML = '⏳ 连接中...';
+        button.innerHTML = '⏳ ' + t('settings.mcp.btn.connecting');
     }
     
     try {
@@ -1633,7 +1633,7 @@ async function toggleExternalMCP(name, currentStatus) {
             button.disabled = false;
             button.style.opacity = '1';
             button.style.cursor = 'pointer';
-            button.innerHTML = '▶ 启动';
+            button.innerHTML = '▶ ' + t('settings.mcp.btn.start');
         }
         
         // 刷新状态

--- a/web/static/js/skills.js
+++ b/web/static/js/skills.js
@@ -93,8 +93,8 @@ function renderSkillsList() {
     const filteredSkills = skillsList;
 
     if (filteredSkills.length === 0) {
-        skillsListEl.innerHTML = '<div class="empty-state">' + 
-            (skillsSearchKeyword ? '没有找到匹配的skills' : '暂无skills，点击"创建Skill"创建第一个skill') + 
+        skillsListEl.innerHTML = '<div class="empty-state">' +
+            (skillsSearchKeyword ? t('skill.label.no_results') : t('skill.label.no_skills')) +
             '</div>';
         // 搜索时隐藏分页
         const paginationContainer = document.getElementById('skills-pagination');
@@ -112,9 +112,9 @@ function renderSkillsList() {
                     <div class="skill-card-description">${escapeHtml(skill.description || '无描述')}</div>
                 </div>
                 <div class="skill-card-actions">
-                    <button class="btn-secondary btn-small" onclick="viewSkill('${escapeHtml(skill.name)}')">查看</button>
-                    <button class="btn-secondary btn-small" onclick="editSkill('${escapeHtml(skill.name)}')">编辑</button>
-                    <button class="btn-secondary btn-small btn-danger" onclick="deleteSkill('${escapeHtml(skill.name)}')">删除</button>
+                    <button class="btn-secondary btn-small" onclick="viewSkill('${escapeHtml(skill.name)}')">${t('skill.btn.view')}</button>
+                    <button class="btn-secondary btn-small" onclick="editSkill('${escapeHtml(skill.name)}')">${t('skill.btn.edit')}</button>
+                    <button class="btn-secondary btn-small btn-danger" onclick="deleteSkill('${escapeHtml(skill.name)}')">${t('ui.btn.delete')}</button>
                 </div>
             </div>
         `;
@@ -157,9 +157,9 @@ function renderSkillsPagination() {
     // 左侧：显示范围信息和每页数量选择器（参考MCP样式）
     paginationHTML += `
         <div class="pagination-info">
-            <span>显示 ${start}-${end} / 共 ${total} 条</span>
+            <span>${t('ui.pagination.showing').replace('{0}', start).replace('{1}', end).replace('{2}', total)}</span>
             <label class="pagination-page-size">
-                每页显示
+                ${t('ui.pagination.per_page')}
                 <select id="skills-page-size-pagination" onchange="changeSkillsPageSize()">
                     <option value="10" ${pageSize === 10 ? 'selected' : ''}>10</option>
                     <option value="20" ${pageSize === 20 ? 'selected' : ''}>20</option>
@@ -173,11 +173,11 @@ function renderSkillsPagination() {
     // 右侧：分页按钮（参考MCP样式：首页、上一页、第X/Y页、下一页、末页）
     paginationHTML += `
         <div class="pagination-controls">
-            <button class="btn-secondary" onclick="loadSkills(1, ${pageSize})" ${currentPage === 1 || total === 0 ? 'disabled' : ''}>首页</button>
-            <button class="btn-secondary" onclick="loadSkills(${currentPage - 1}, ${pageSize})" ${currentPage === 1 || total === 0 ? 'disabled' : ''}>上一页</button>
-            <span class="pagination-page">第 ${currentPage} / ${totalPages || 1} 页</span>
-            <button class="btn-secondary" onclick="loadSkills(${currentPage + 1}, ${pageSize})" ${currentPage >= totalPages || total === 0 ? 'disabled' : ''}>下一页</button>
-            <button class="btn-secondary" onclick="loadSkills(${totalPages || 1}, ${pageSize})" ${currentPage >= totalPages || total === 0 ? 'disabled' : ''}>末页</button>
+            <button class="btn-secondary" onclick="loadSkills(1, ${pageSize})" ${currentPage === 1 || total === 0 ? 'disabled' : ''}>${t('ui.pagination.first')}</button>
+            <button class="btn-secondary" onclick="loadSkills(${currentPage - 1}, ${pageSize})" ${currentPage === 1 || total === 0 ? 'disabled' : ''}>${t('ui.pagination.prev')}</button>
+            <span class="pagination-page">${t('ui.pagination.page').replace('{0}', currentPage).replace('{1}', totalPages || 1)}</span>
+            <button class="btn-secondary" onclick="loadSkills(${currentPage + 1}, ${pageSize})" ${currentPage >= totalPages || total === 0 ? 'disabled' : ''}>${t('ui.pagination.next')}</button>
+            <button class="btn-secondary" onclick="loadSkills(${totalPages || 1}, ${pageSize})" ${currentPage >= totalPages || total === 0 ? 'disabled' : ''}>${t('ui.pagination.last')}</button>
         </div>
     `;
     
@@ -340,7 +340,7 @@ function showAddSkillModal() {
     const modal = document.getElementById('skill-modal');
     if (!modal) return;
 
-    document.getElementById('skill-modal-title').textContent = '添加Skill';
+    document.getElementById('skill-modal-title').textContent = t('skill.modal.add');
     document.getElementById('skill-name').value = '';
     document.getElementById('skill-name').disabled = false;
     document.getElementById('skill-description').value = '';
@@ -362,7 +362,7 @@ async function editSkill(skillName) {
         const modal = document.getElementById('skill-modal');
         if (!modal) return;
 
-        document.getElementById('skill-modal-title').textContent = '编辑Skill';
+        document.getElementById('skill-modal-title').textContent = t('skill.modal.edit');
         document.getElementById('skill-name').value = skill.name;
         document.getElementById('skill-name').disabled = true; // 编辑时不允许修改名称
         document.getElementById('skill-description').value = skill.description || '';
@@ -393,19 +393,19 @@ async function viewSkill(skillName) {
         modal.innerHTML = `
             <div class="modal-content" style="max-width: 900px; max-height: 90vh;">
                 <div class="modal-header">
-                    <h2>查看Skill: ${escapeHtml(skill.name)}</h2>
+                    <h2>${t('skill.modal.view').replace('{0}', escapeHtml(skill.name))}</h2>
                     <span class="modal-close" onclick="closeSkillViewModal()">&times;</span>
                 </div>
                 <div class="modal-body" style="overflow-y: auto; max-height: calc(90vh - 120px);">
-                    ${skill.description ? `<div style="margin-bottom: 16px;"><strong>描述:</strong> ${escapeHtml(skill.description)}</div>` : ''}
-                    <div style="margin-bottom: 8px;"><strong>路径:</strong> ${escapeHtml(skill.path || '')}</div>
-                    <div style="margin-bottom: 16px;"><strong>修改时间:</strong> ${escapeHtml(skill.mod_time || '')}</div>
-                    <div style="margin-bottom: 8px;"><strong>内容:</strong></div>
+                    ${skill.description ? `<div style="margin-bottom: 16px;"><strong>${t('skill.label.description')}</strong> ${escapeHtml(skill.description)}</div>` : ''}
+                    <div style="margin-bottom: 8px;"><strong>${t('skill.label.path')}</strong> ${escapeHtml(skill.path || '')}</div>
+                    <div style="margin-bottom: 16px;"><strong>${t('skill.label.mod_time')}</strong> ${escapeHtml(skill.mod_time || '')}</div>
+                    <div style="margin-bottom: 8px;"><strong>${t('skill.label.content')}</strong></div>
                     <pre style="background: #f5f5f5; padding: 16px; border-radius: 4px; overflow-x: auto; white-space: pre-wrap; word-wrap: break-word;">${escapeHtml(skill.content || '')}</pre>
                 </div>
                 <div class="modal-footer">
-                    <button class="btn-secondary" onclick="closeSkillViewModal()">关闭</button>
-                    <button class="btn-primary" onclick="editSkill('${escapeHtml(skill.name)}'); closeSkillViewModal();">编辑</button>
+                    <button class="btn-secondary" onclick="closeSkillViewModal()">${t('ui.btn.close')}</button>
+                    <button class="btn-primary" onclick="editSkill('${escapeHtml(skill.name)}'); closeSkillViewModal();">${t('skill.btn.edit')}</button>
                 </div>
             </div>
         `;
@@ -443,18 +443,18 @@ async function saveSkill() {
     const content = document.getElementById('skill-content').value.trim();
 
     if (!name) {
-        showNotification('skill名称不能为空', 'error');
+        showNotification(t('skill.error.name_empty'), 'error');
         return;
     }
 
     if (!content) {
-        showNotification('skill内容不能为空', 'error');
+        showNotification(t('skill.error.content_empty'), 'error');
         return;
     }
 
     // 验证skill名称
     if (!/^[a-zA-Z0-9_-]+$/.test(name)) {
-        showNotification('skill名称只能包含字母、数字、连字符和下划线', 'error');
+        showNotification(t('skill.error.name_invalid'), 'error');
         return;
     }
 
@@ -462,7 +462,7 @@ async function saveSkill() {
     const saveBtn = document.querySelector('#skill-modal .btn-primary');
     if (saveBtn) {
         saveBtn.disabled = true;
-        saveBtn.textContent = '保存中...';
+        saveBtn.textContent = t('ui.status.loading');
     }
 
     try {
@@ -487,7 +487,7 @@ async function saveSkill() {
             throw new Error(error.error || '保存skill失败');
         }
 
-        showNotification(isEdit ? 'skill已更新' : 'skill已创建', 'success');
+        showNotification(isEdit ? t('skill.message.updated') : t('skill.message.created'), 'success');
         closeSkillModal();
         await loadSkills(skillsPagination.currentPage, skillsPagination.pageSize);
     } catch (error) {
@@ -497,7 +497,7 @@ async function saveSkill() {
         isSavingSkill = false;
         if (saveBtn) {
             saveBtn.disabled = false;
-            saveBtn.textContent = '保存';
+            saveBtn.textContent = t('ui.btn.save');
         }
     }
 }
@@ -518,10 +518,10 @@ async function deleteSkill(skillName) {
     }
 
     // 构建确认消息
-    let confirmMessage = `确定要删除skill "${skillName}" 吗？此操作不可恢复。`;
+    let confirmMessage = t('skill.confirm.delete').replace('{0}', skillName);
     if (boundRoles.length > 0) {
         const rolesList = boundRoles.join('、');
-        confirmMessage = `确定要删除skill "${skillName}" 吗？\n\n⚠️ 该skill当前已被以下 ${boundRoles.length} 个角色绑定：\n${rolesList}\n\n删除后，系统将自动从这些角色中移除该skill的绑定。\n\n此操作不可恢复，是否继续？`;
+        confirmMessage = t('skill.confirm.delete').replace('{0}', skillName) + '\n\n' + t('skill.confirm.delete_bound').replace('{0}', boundRoles.length) + '：\n' + rolesList + '\n\n删除后，系统将自动从这些角色中移除该skill的绑定。\n\n此操作不可恢复，是否继续？';
     }
 
     if (!confirm(confirmMessage)) {
@@ -539,10 +539,10 @@ async function deleteSkill(skillName) {
         }
 
         const data = await response.json();
-        let successMessage = 'skill已删除';
+        let successMessage = t('skill.message.deleted');
         if (data.affected_roles && data.affected_roles.length > 0) {
             const rolesList = data.affected_roles.join('、');
-            successMessage = `skill已删除，已自动从 ${data.affected_roles.length} 个角色中移除绑定：${rolesList}`;
+            successMessage = `${t('skill.message.deleted')}，已自动从 ${data.affected_roles.length} 个角色中移除绑定：${rolesList}`;
         }
         showNotification(successMessage, 'success');
         
@@ -604,23 +604,23 @@ function renderSkillsMonitor() {
         
         statsEl.innerHTML = `
             <div class="monitor-stat-card">
-                <div class="monitor-stat-label">总Skills数</div>
+                <div class="monitor-stat-label">${t('skill.stats.total')}</div>
                 <div class="monitor-stat-value">${skillsStats.total}</div>
             </div>
             <div class="monitor-stat-card">
-                <div class="monitor-stat-label">总调用次数</div>
+                <div class="monitor-stat-label">${t('skill.stats.total_calls')}</div>
                 <div class="monitor-stat-value">${skillsStats.totalCalls}</div>
             </div>
             <div class="monitor-stat-card">
-                <div class="monitor-stat-label">成功调用</div>
+                <div class="monitor-stat-label">${t('skill.stats.success')}</div>
                 <div class="monitor-stat-value" style="color: #28a745;">${skillsStats.totalSuccess}</div>
             </div>
             <div class="monitor-stat-card">
-                <div class="monitor-stat-label">失败调用</div>
+                <div class="monitor-stat-label">${t('skill.stats.failed')}</div>
                 <div class="monitor-stat-value" style="color: #dc3545;">${skillsStats.totalFailed}</div>
             </div>
             <div class="monitor-stat-card">
-                <div class="monitor-stat-label">成功率</div>
+                <div class="monitor-stat-label">${t('skill.stats.rate')}</div>
                 <div class="monitor-stat-value">${successRate}%</div>
             </div>
         `;
@@ -634,7 +634,7 @@ function renderSkillsMonitor() {
     
     // 如果没有统计数据，显示空状态
     if (stats.length === 0) {
-        monitorListEl.innerHTML = '<div class="monitor-empty">暂无Skills调用记录</div>';
+        monitorListEl.innerHTML = '<div class="monitor-empty">' + t('skill.no_data') + '</div>';
         return;
     }
 
@@ -652,12 +652,12 @@ function renderSkillsMonitor() {
         <table class="monitor-table">
             <thead>
                 <tr>
-                    <th style="text-align: left !important;">Skill名称</th>
-                    <th style="text-align: center;">总调用</th>
-                    <th style="text-align: center;">成功</th>
-                    <th style="text-align: center;">失败</th>
-                    <th style="text-align: center;">成功率</th>
-                    <th style="text-align: left;">最后调用时间</th>
+                    <th style="text-align: left !important;">${t('skill.stats.col_name')}</th>
+                    <th style="text-align: center;">${t('skill.stats.col_total')}</th>
+                    <th style="text-align: center;">${t('skill.stats.col_success')}</th>
+                    <th style="text-align: center;">${t('skill.stats.col_failed')}</th>
+                    <th style="text-align: center;">${t('skill.stats.col_rate')}</th>
+                    <th style="text-align: left;">${t('skill.stats.col_last')}</th>
                 </tr>
             </thead>
             <tbody>
@@ -692,7 +692,7 @@ async function refreshSkillsMonitor() {
 
 // 清空skills统计数据
 async function clearSkillsStats() {
-    if (!confirm('确定要清空所有Skills统计数据吗？此操作不可恢复。')) {
+    if (!confirm(t('skill.confirm.clear_stats'))) {
         return;
     }
 
@@ -706,7 +706,7 @@ async function clearSkillsStats() {
             throw new Error(error.error || '清空统计数据失败');
         }
 
-        showNotification('已清空所有Skills统计数据', 'success');
+        showNotification(t('skill.message.stats_cleared'), 'success');
         // 重新加载统计数据
         await loadSkillsMonitor();
     } catch (error) {

--- a/web/static/js/tasks.js
+++ b/web/static/js/tasks.js
@@ -83,7 +83,7 @@ function updateCompletedTasksHistory(currentTasks) {
             
             tasksState.completedTasksHistory.push({
                 conversationId: task.conversationId,
-                message: task.message || '未命名任务',
+                message: task.message || t('task.label.unnamed'),
                 startedAt: task.startedAt,
                 status: finalStatus,
                 completedAt: new Date().toISOString()
@@ -106,7 +106,7 @@ async function loadTasks() {
     const listContainer = document.getElementById('tasks-list');
     if (!listContainer) return;
     
-    listContainer.innerHTML = '<div class="loading-spinner">加载中...</div>';
+    listContainer.innerHTML = '<div class="loading-spinner">' + t('ui.status.loading') + '</div>';
 
     try {
         // 并行加载运行中的任务和已完成的任务历史
@@ -149,7 +149,7 @@ async function loadTasks() {
             tasksState.completedTasksHistory = [
                 ...completedTasks.map(t => ({
                     conversationId: t.conversationId,
-                    message: t.message || '未命名任务',
+                    message: t.message || t('task.label.unnamed'),
                     startedAt: t.startedAt,
                     status: t.status || 'completed',
                     completedAt: t.completedAt || new Date().toISOString()
@@ -359,12 +359,12 @@ function renderTasks(tasks) {
 
     // 状态映射
     const statusMap = {
-        'running': { text: '执行中', class: 'task-status-running' },
-        'cancelling': { text: '取消中', class: 'task-status-cancelling' },
-        'failed': { text: '执行失败', class: 'task-status-failed' },
-        'timeout': { text: '执行超时', class: 'task-status-timeout' },
-        'cancelled': { text: '已取消', class: 'task-status-cancelled' },
-        'completed': { text: '已完成', class: 'task-status-completed' }
+        'running': { text: t('task.status.running'), class: 'task-status-running' },
+        'cancelling': { text: t('task.status.cancelling'), class: 'task-status-cancelling' },
+        'failed': { text: t('task.status.failed'), class: 'task-status-failed' },
+        'timeout': { text: t('task.status.timeout'), class: 'task-status-timeout' },
+        'cancelled': { text: t('task.status.cancelled'), class: 'task-status-cancelled' },
+        'completed': { text: t('task.status.completed'), class: 'task-status-completed' }
     };
 
     // 分离当前任务和历史任务
@@ -382,8 +382,8 @@ function renderTasks(tasks) {
     if (historyTasks.length > 0) {
         html += `<div class="tasks-history-section">
             <div class="tasks-history-header">
-                <span class="tasks-history-title">📜 最近完成的任务（最近24小时）</span>
-                <button class="btn-secondary btn-small" onclick="clearTasksHistory()">清空历史</button>
+                <span class="tasks-history-title">${t('task.label.recent')}</span>
+                <button class="btn-secondary btn-small" onclick="clearTasksHistory()">${t('task.btn.clear_history')}</button>
             </div>
             ${historyTasks.map(task => renderTaskItem(task, statusMap, true)).join('')}
         </div>`;
@@ -406,7 +406,7 @@ function renderTaskItem(task, statusMap, isHistory = false) {
             minute: '2-digit',
             second: '2-digit'
         })
-        : '未知时间';
+        : t('ui.empty.no_data');
     
     const completedText = completedTime && !isNaN(completedTime.getTime())
         ? completedTime.toLocaleString('zh-CN', { 
@@ -439,20 +439,20 @@ function renderTaskItem(task, statusMap, isHistory = false) {
                     ` : '<div class="task-checkbox-placeholder"></div>'}
                     <span class="task-status ${status.class}">${status.text}</span>
                     ${isHistory ? '<span class="task-history-badge" title="历史记录">📜</span>' : ''}
-                    <span class="task-message" title="${escapeHtml(task.message || '未命名任务')}">${escapeHtml(task.message || '未命名任务')}</span>
+                    <span class="task-message" title="${escapeHtml(task.message || t('task.label.unnamed'))}">${escapeHtml(task.message || t('task.label.unnamed'))}</span>
                 </div>
                 <div class="task-actions">
                     ${duration ? `<span class="task-duration" title="执行时长">⏱ ${duration}</span>` : ''}
                     <span class="task-time" title="${isHistory && completedText ? '完成时间' : '开始时间'}">
                         ${isHistory && completedText ? completedText : timeText}
                     </span>
-                    ${canCancel ? `<button class="btn-secondary btn-small" onclick="cancelTask('${task.conversationId}', this)">取消任务</button>` : ''}
+                    ${canCancel ? `<button class="btn-secondary btn-small" onclick="cancelTask('${task.conversationId}', this)">${t('ui.btn.cancel')}</button>` : ''}
                     ${task.conversationId ? `<button class="btn-secondary btn-small" onclick="viewConversation('${task.conversationId}')">查看对话</button>` : ''}
                 </div>
             </div>
             ${task.conversationId ? `
                 <div class="task-details">
-                    <span class="task-id-label">对话ID:</span>
+                    <span class="task-id-label">${t('task.label.conv_id')}</span>
                     <span class="task-id-value" title="点击复制" onclick="copyTaskId('${task.conversationId}')">${escapeHtml(task.conversationId)}</span>
                 </div>
             ` : ''}
@@ -462,7 +462,7 @@ function renderTaskItem(task, statusMap, isHistory = false) {
 
 // 清空任务历史
 function clearTasksHistory() {
-    if (!confirm('确定要清空所有任务历史记录吗？')) {
+    if (!confirm(t('task.confirm.clear_history'))) {
         return;
     }
     tasksState.completedTasksHistory = [];
@@ -509,7 +509,7 @@ async function batchCancelTasks() {
     const selected = Array.from(tasksState.selectedTasks);
     if (selected.length === 0) return;
     
-    if (!confirm(`确定要取消 ${selected.length} 个任务吗？`)) {
+    if (!confirm(t('task.confirm.cancel_selected').replace('{0}', selected.length))) {
         return;
     }
     
@@ -545,9 +545,9 @@ async function batchCancelTasks() {
     
     // 显示结果
     if (failCount > 0) {
-        alert(`批量取消完成：成功 ${successCount} 个，失败 ${failCount} 个`);
+        alert(t('task.alert.cancel_result').replace('{0}', successCount).replace('{1}', failCount));
     } else {
-        alert(`成功取消 ${successCount} 个任务`);
+        alert(t('task.alert.cancel_success').replace('{0}', successCount));
     }
 }
 
@@ -571,7 +571,7 @@ async function cancelTask(conversationId, button) {
     
     const originalText = button.textContent;
     button.disabled = true;
-    button.textContent = '取消中...';
+    button.textContent = t('task.status.cancelling') + '...';
 
     try {
         const response = await apiFetch('/api/agent-loop/cancel', {
@@ -738,7 +738,7 @@ async function showBatchImportModal() {
             try {
                 const loadedRoles = await loadRoles();
                 // 清空现有选项（除了默认选项）
-                roleSelect.innerHTML = '<option value="">默认</option>';
+                roleSelect.innerHTML = '<option value="">' + t('task.role.default') + '</option>';
                 
                 // 添加已启用的角色
                 const sortedRoles = loadedRoles.sort((a, b) => {
@@ -808,14 +808,14 @@ async function createBatchQueue() {
     
     const text = input.value.trim();
     if (!text) {
-        alert('请输入至少一个任务');
+        alert(t('task.alert.empty_input'));
         return;
     }
     
     // 按行分割任务
     const tasks = text.split('\n').map(line => line.trim()).filter(line => line !== '');
     if (tasks.length === 0) {
-        alert('没有有效的任务');
+        alert(t('task.alert.no_valid'));
         return;
     }
     
@@ -964,7 +964,7 @@ function renderBatchQueues() {
     const queues = batchQueuesState.queues;
     
     if (queues.length === 0) {
-        list.innerHTML = '<div class="tasks-empty"><p>当前没有批量任务队列</p></div>';
+        list.innerHTML = '<div class="tasks-empty"><p>' + t('task.no_data') + '</p></div>';
         if (pagination) pagination.style.display = 'none';
         return;
     }
@@ -976,11 +976,11 @@ function renderBatchQueues() {
     
     list.innerHTML = queues.map(queue => {
         const statusMap = {
-            'pending': { text: '待执行', class: 'batch-queue-status-pending' },
-            'running': { text: '执行中', class: 'batch-queue-status-running' },
-            'paused': { text: '已暂停', class: 'batch-queue-status-paused' },
-            'completed': { text: '已完成', class: 'batch-queue-status-completed' },
-            'cancelled': { text: '已取消', class: 'batch-queue-status-cancelled' }
+            'pending': { text: t('task.queue.status.pending'), class: 'batch-queue-status-pending' },
+            'running': { text: t('task.queue.status.running'), class: 'batch-queue-status-running' },
+            'paused': { text: t('task.queue.status.paused'), class: 'batch-queue-status-paused' },
+            'completed': { text: t('task.queue.status.completed'), class: 'batch-queue-status-completed' },
+            'cancelled': { text: t('task.queue.status.cancelled'), class: 'batch-queue-status-cancelled' }
         };
         
         const status = statusMap[queue.status] || { text: queue.status, class: 'batch-queue-status-unknown' };
@@ -1012,8 +1012,8 @@ function renderBatchQueues() {
         // 显示角色信息（使用正确的角色图标）
         const loadedRoles = batchQueuesState.loadedRoles || [];
         const roleIcon = getRoleIconForDisplay(queue.role, loadedRoles);
-        const roleName = queue.role && queue.role !== '' ? queue.role : '默认';
-        const roleDisplay = `<span class="batch-queue-role" style="margin-right: 8px;" title="角色: ${escapeHtml(roleName)}">${roleIcon} ${escapeHtml(roleName)}</span>`;
+        const roleName = queue.role && queue.role !== '' ? queue.role : t('task.label.role');
+        const roleDisplay = `<span class="batch-queue-role" style="margin-right: 8px;" title="${t('task.label.role')}: ${escapeHtml(roleName)}">${roleIcon} ${escapeHtml(roleName)}</span>`;
         
         return `
             <div class="batch-queue-item" data-queue-id="${queue.id}" onclick="showBatchQueueDetail('${queue.id}')">
@@ -1022,8 +1022,8 @@ function renderBatchQueues() {
                         ${titleDisplay}
                         ${roleDisplay}
                         <span class="batch-queue-status ${status.class}">${status.text}</span>
-                        <span class="batch-queue-id">队列ID: ${escapeHtml(queue.id)}</span>
-                        <span class="batch-queue-time">创建时间: ${new Date(queue.createdAt).toLocaleString('zh-CN')}</span>
+                        <span class="batch-queue-id">${t('task.label.queue_id')} ${escapeHtml(queue.id)}</span>
+                        <span class="batch-queue-time">${t('task.label.created_at')} ${new Date(queue.createdAt).toLocaleString('zh-CN')}</span>
                     </div>
                     <div class="batch-queue-progress">
                         <div class="batch-queue-progress-bar">
@@ -1198,7 +1198,7 @@ async function showBatchQueueDetail(queueId) {
         
         if (title) {
             // textContent 本身会做转义；这里不要再 escapeHtml，否则会把 && 显示成 &amp;...（看起来像“变形/乱码”）
-            title.textContent = queue.title ? `批量任务队列 - ${String(queue.title)}` : '批量任务队列';
+            title.textContent = queue.title ? `${t('task.title')} - ${String(queue.title)}` : t('task.title');
         }
         
         // 更新按钮显示
@@ -1226,20 +1226,20 @@ async function showBatchQueueDetail(queueId) {
         
         // 队列状态映射
         const queueStatusMap = {
-            'pending': { text: '待执行', class: 'batch-queue-status-pending' },
-            'running': { text: '执行中', class: 'batch-queue-status-running' },
-            'paused': { text: '已暂停', class: 'batch-queue-status-paused' },
-            'completed': { text: '已完成', class: 'batch-queue-status-completed' },
-            'cancelled': { text: '已取消', class: 'batch-queue-status-cancelled' }
+            'pending': { text: t('task.queue.status.pending'), class: 'batch-queue-status-pending' },
+            'running': { text: t('task.queue.status.running'), class: 'batch-queue-status-running' },
+            'paused': { text: t('task.queue.status.paused'), class: 'batch-queue-status-paused' },
+            'completed': { text: t('task.queue.status.completed'), class: 'batch-queue-status-completed' },
+            'cancelled': { text: t('task.queue.status.cancelled'), class: 'batch-queue-status-cancelled' }
         };
-        
+
         // 任务状态映射
         const taskStatusMap = {
-            'pending': { text: '待执行', class: 'batch-task-status-pending' },
-            'running': { text: '执行中', class: 'batch-task-status-running' },
-            'completed': { text: '已完成', class: 'batch-task-status-completed' },
-            'failed': { text: '失败', class: 'batch-task-status-failed' },
-            'cancelled': { text: '已取消', class: 'batch-task-status-cancelled' }
+            'pending': { text: t('task.queue.status.pending'), class: 'batch-task-status-pending' },
+            'running': { text: t('task.queue.status.running'), class: 'batch-task-status-running' },
+            'completed': { text: t('task.queue.status.completed'), class: 'batch-task-status-completed' },
+            'failed': { text: t('task.status.failed'), class: 'batch-task-status-failed' },
+            'cancelled': { text: t('task.queue.status.cancelled'), class: 'batch-task-status-cancelled' }
         };
         
         // 获取角色信息（如果队列有角色配置）
@@ -1266,26 +1266,26 @@ async function showBatchQueueDetail(queueId) {
                 }
             }
             roleDisplay = `<div class="detail-item">
-                <span class="detail-label">角色</span>
+                <span class="detail-label">${t('task.label.role')}</span>
                 <span class="detail-value">${roleIcon} ${escapeHtml(roleName)}</span>
             </div>`;
         } else {
             // 默认角色
             roleDisplay = `<div class="detail-item">
-                <span class="detail-label">角色</span>
-                <span class="detail-value">🔵 默认</span>
+                <span class="detail-label">${t('task.label.role')}</span>
+                <span class="detail-value">🔵 ${t('task.label.role')}</span>
             </div>`;
         }
         
         content.innerHTML = `
             <div class="batch-queue-detail-info">
                 ${queue.title ? `<div class="detail-item">
-                    <span class="detail-label">任务标题</span>
+                    <span class="detail-label">${t('task.title')}</span>
                     <span class="detail-value">${escapeHtml(queue.title)}</span>
                 </div>` : ''}
                 ${roleDisplay}
                 <div class="detail-item">
-                    <span class="detail-label">队列ID</span>
+                    <span class="detail-label">${t('task.label.queue_id')}</span>
                     <span class="detail-value"><code>${escapeHtml(queue.id)}</code></span>
                 </div>
                 <div class="detail-item">
@@ -1293,7 +1293,7 @@ async function showBatchQueueDetail(queueId) {
                     <span class="detail-value"><span class="batch-queue-status ${queueStatusMap[queue.status]?.class || ''}">${queueStatusMap[queue.status]?.text || queue.status}</span></span>
                 </div>
                 <div class="detail-item">
-                    <span class="detail-label">创建时间</span>
+                    <span class="detail-label">${t('task.label.created_at')}</span>
                     <span class="detail-value">${new Date(queue.createdAt).toLocaleString('zh-CN')}</span>
                 </div>
                 ${queue.startedAt ? `<div class="detail-item">
@@ -1305,12 +1305,12 @@ async function showBatchQueueDetail(queueId) {
                     <span class="detail-value">${new Date(queue.completedAt).toLocaleString('zh-CN')}</span>
                 </div>` : ''}
                 <div class="detail-item">
-                    <span class="detail-label">任务总数</span>
+                    <span class="detail-label">${t('task.label.task_list')}</span>
                     <span class="detail-value">${queue.tasks.length}</span>
                 </div>
             </div>
             <div class="batch-queue-tasks-list">
-                <h4>任务列表</h4>
+                <h4>${t('task.label.task_list')}</h4>
                 ${queue.tasks.map((task, index) => {
                     const taskStatus = taskStatusMap[task.status] || { text: task.status, class: 'batch-task-status-unknown' };
                     const canEdit = queue.status === 'pending' && task.status === 'pending';
@@ -1376,7 +1376,7 @@ async function pauseBatchQueue() {
     const queueId = batchQueuesState.currentQueueId;
     if (!queueId) return;
     
-    if (!confirm('确定要暂停这个批量任务队列吗？当前正在执行的任务将被停止，后续任务将保留待执行状态。')) {
+    if (!confirm(t('task.confirm.pause_queue'))) {
         return;
     }
     
@@ -1404,7 +1404,7 @@ async function deleteBatchQueue() {
     const queueId = batchQueuesState.currentQueueId;
     if (!queueId) return;
     
-    if (!confirm('确定要删除这个批量任务队列吗？此操作不可恢复。')) {
+    if (!confirm(t('task.confirm.delete_queue'))) {
         return;
     }
     
@@ -1430,7 +1430,7 @@ async function deleteBatchQueue() {
 async function deleteBatchQueueFromList(queueId) {
     if (!queueId) return;
     
-    if (!confirm('确定要删除这个批量任务队列吗？此操作不可恢复。')) {
+    if (!confirm(t('task.confirm.delete_queue'))) {
         return;
     }
     
@@ -1599,7 +1599,7 @@ async function saveBatchTask() {
     const messageInput = document.getElementById('edit-task-message');
     
     if (!queueId || !taskId) {
-        alert('任务信息不完整');
+        alert(t('task.alert.incomplete'));
         return;
     }
     
@@ -1610,7 +1610,7 @@ async function saveBatchTask() {
     
     const message = messageInput.value.trim();
     if (!message) {
-        alert('任务消息不能为空');
+        alert(t('task.alert.message_empty'));
         return;
     }
     
@@ -1717,7 +1717,7 @@ async function saveAddBatchTask() {
     
     const message = messageInput.value.trim();
     if (!message) {
-        alert('任务消息不能为空');
+        alert(t('task.alert.message_empty'));
         return;
     }
     
@@ -1779,7 +1779,7 @@ function deleteBatchTaskFromElement(button) {
         ? decodedMessage.substring(0, 50) + '...' 
         : decodedMessage;
     
-    if (!confirm(`确定要删除这个任务吗？\n\n任务内容: ${displayMessage}\n\n此操作不可恢复。`)) {
+    if (!confirm(t('task.confirm.delete_task'))) {
         return;
     }
     
@@ -1789,7 +1789,7 @@ function deleteBatchTaskFromElement(button) {
 // 删除批量任务
 async function deleteBatchTask(queueId, taskId) {
     if (!queueId || !taskId) {
-        alert('任务信息不完整');
+        alert(t('task.alert.incomplete'));
         return;
     }
     

--- a/web/static/js/terminal.js
+++ b/web/static/js/terminal.js
@@ -26,7 +26,7 @@
         return terminals[0] || null;
     }
 
-    var WELCOME_LINE = 'CyberStrikeAI 终端 - 真实 Shell 会话，直接输入命令；Ctrl+L 清屏\r\n';
+    var WELCOME_LINE = t('terminal.welcome');
 
     function writePrompt(tab) {
         // 提示符交由后端 Shell 自行输出，这里仅保留占位函数，避免旧代码报错
@@ -121,19 +121,19 @@
             ws.onclose = function () {
                 tab.running = false;
                 if (tab.term) {
-                    tab.term.writeln('\r\n\x1b[2m[会话已关闭]\x1b[0m');
+                    tab.term.writeln('\r\n\x1b[2m' + t('terminal.session_closed') + '\x1b[0m');
                 }
             };
 
             ws.onerror = function () {
                 tab.running = false;
                 if (tab.term) {
-                    tab.term.writeln('\r\n\x1b[31m[终端连接出错]\x1b[0m');
+                    tab.term.writeln('\r\n\x1b[31m' + t('terminal.connect_error') + '\x1b[0m');
                 }
             };
         } catch (e) {
             if (tab.term) {
-                tab.term.writeln('\r\n\x1b[31m[无法连接终端服务: ' + String(e) + ']\x1b[0m');
+                tab.term.writeln('\r\n\x1b[31m' + t('terminal.connect_failed') + ' ' + String(e) + ']\x1b[0m');
             }
         }
     }
@@ -188,7 +188,7 @@
             if (term) term.focus();
         });
         container.setAttribute('tabindex', '0');
-        container.title = '点击此处后输入命令';
+        container.title = t('terminal.hint');
 
         function sendToWS(data) {
             ensureTerminalWS(tab);
@@ -253,12 +253,12 @@
         tabDiv.setAttribute('data-tab-id', String(id));
         var label = document.createElement('span');
         label.className = 'terminal-tab-label';
-        label.textContent = '终端 ' + id;
+        label.textContent = t('terminal.tab_label').replace('{0}', id);
         label.onclick = function () { switchTerminalTab(id); };
         var closeBtn = document.createElement('button');
         closeBtn.type = 'button';
         closeBtn.className = 'terminal-tab-close';
-        closeBtn.title = '关闭';
+        closeBtn.title = t('ui.btn.close_tab');
         closeBtn.textContent = '×';
         closeBtn.onclick = function (e) { e.stopPropagation(); removeTerminalTab(id); };
         tabDiv.appendChild(label);
@@ -340,7 +340,7 @@
                 var t = terminals[i];
                 tabDivs[i].setAttribute('data-tab-id', String(t.id));
                 var lbl = tabDivs[i].querySelector('.terminal-tab-label');
-                if (lbl) lbl.textContent = '终端 ' + t.id;
+                if (lbl) lbl.textContent = t('terminal.tab_label').replace('{0}', t.id);
                 if (lbl) lbl.onclick = (function (tid) { return function () { switchTerminalTab(tid); }; })(t.id);
                 var cb = tabDivs[i].querySelector('.terminal-tab-close');
                 if (cb) cb.onclick = (function (tid) { return function (e) { e.stopPropagation(); removeTerminalTab(tid); }; })(t.id);
@@ -377,7 +377,10 @@
         inited = true;
 
         if (typeof Terminal === 'undefined') {
-            container1.innerHTML = '<p class="terminal-error">未加载 xterm.js，请刷新页面或检查网络。</p>';
+            const errP = document.createElement('p');
+            errP.className = 'terminal-error';
+            errP.textContent = t('terminal.load_error');
+            container1.appendChild(errP);
             return;
         }
 

--- a/web/static/js/vulnerability.js
+++ b/web/static/js/vulnerability.js
@@ -82,7 +82,7 @@ function updateVulnerabilityStats(stats) {
 // 加载漏洞列表
 async function loadVulnerabilities(page = null) {
     const listContainer = document.getElementById('vulnerabilities-list');
-    listContainer.innerHTML = '<div class="loading-spinner">加载中...</div>';
+    listContainer.innerHTML = '<div class="loading-spinner">' + t('ui.status.loading') + '</div>';
 
     try {
         // 检查apiFetch是否可用
@@ -158,12 +158,12 @@ function renderVulnerabilities(vulnerabilities) {
     
     // 处理空值情况
     if (!vulnerabilities || !Array.isArray(vulnerabilities)) {
-        listContainer.innerHTML = '<div class="empty-state">暂无漏洞记录</div>';
+        listContainer.innerHTML = '<div class="empty-state">' + t('vuln.no_data') + '</div>';
         return;
     }
     
     if (vulnerabilities.length === 0) {
-        listContainer.innerHTML = '<div class="empty-state">暂无漏洞记录</div>';
+        listContainer.innerHTML = '<div class="empty-state">' + t('vuln.no_data') + '</div>';
         // 清空分页信息
         const paginationContainer = document.getElementById('vulnerability-pagination');
         if (paginationContainer) {
@@ -175,18 +175,18 @@ function renderVulnerabilities(vulnerabilities) {
     const html = vulnerabilities.map(vuln => {
         const severityClass = `severity-${vuln.severity}`;
         const severityText = {
-            'critical': '严重',
-            'high': '高危',
-            'medium': '中危',
-            'low': '低危',
-            'info': '信息'
+            'critical': t('vuln.severity.critical'),
+            'high': t('vuln.severity.high'),
+            'medium': t('vuln.severity.medium'),
+            'low': t('vuln.severity.low'),
+            'info': t('vuln.severity.info')
         }[vuln.severity] || vuln.severity;
 
         const statusText = {
-            'open': '待处理',
-            'confirmed': '已确认',
-            'fixed': '已修复',
-            'false_positive': '误报'
+            'open': t('vuln.status.pending'),
+            'confirmed': t('vuln.status.confirmed'),
+            'fixed': t('vuln.status.resolved'),
+            'false_positive': t('vuln.status.false_positive')
         }[vuln.status] || vuln.status;
 
         const createdDate = new Date(vuln.created_at).toLocaleString('zh-CN');
@@ -208,20 +208,20 @@ function renderVulnerabilities(vulnerabilities) {
                         </div>
                     </div>
                     <div class="vulnerability-actions" onclick="event.stopPropagation();">
-                        <button class="btn-ghost" onclick="downloadVulnerabilityAsMarkdown('${vuln.id}', event)" title="下载Markdown">
+                        <button class="btn-ghost" onclick="downloadVulnerabilityAsMarkdown('${vuln.id}', event)" title="${t('vuln.btn.download_md')}">
                             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                                 <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                                 <polyline points="7 10 12 15 17 10" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                                 <line x1="12" y1="15" x2="12" y2="3" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                             </svg>
                         </button>
-                        <button class="btn-ghost" onclick="editVulnerability('${vuln.id}')" title="编辑">
+                        <button class="btn-ghost" onclick="editVulnerability('${vuln.id}')" title="${t('ui.btn.edit')}">
                             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                                 <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                                 <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                             </svg>
                         </button>
-                        <button class="btn-ghost" onclick="deleteVulnerability('${vuln.id}')" title="删除">
+                        <button class="btn-ghost" onclick="deleteVulnerability('${vuln.id}')" title="${t('ui.btn.delete')}">
                             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                                 <path d="M3 6h18M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2m3 0v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6h14z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                             </svg>
@@ -231,14 +231,14 @@ function renderVulnerabilities(vulnerabilities) {
                 <div class="vulnerability-content" id="content-${vuln.id}" style="display: none;">
                     ${vuln.description ? `<div class="vulnerability-description">${escapeHtml(vuln.description)}</div>` : ''}
                     <div class="vulnerability-details">
-                        <div class="detail-item"><strong>漏洞ID:</strong> <code>${escapeHtml(vuln.id)}</code></div>
-                        ${vuln.type ? `<div class="detail-item"><strong>类型:</strong> ${escapeHtml(vuln.type)}</div>` : ''}
-                        ${vuln.target ? `<div class="detail-item"><strong>目标:</strong> ${escapeHtml(vuln.target)}</div>` : ''}
-                        <div class="detail-item"><strong>会话ID:</strong> <code>${escapeHtml(vuln.conversation_id)}</code></div>
+                        <div class="detail-item"><strong>${t('vuln.label.id')}</strong> <code>${escapeHtml(vuln.id)}</code></div>
+                        ${vuln.type ? `<div class="detail-item"><strong>${t('vuln.label.type')}</strong> ${escapeHtml(vuln.type)}</div>` : ''}
+                        ${vuln.target ? `<div class="detail-item"><strong>${t('vuln.label.target')}</strong> ${escapeHtml(vuln.target)}</div>` : ''}
+                        <div class="detail-item"><strong>${t('vuln.label.session_id')}</strong> <code>${escapeHtml(vuln.conversation_id)}</code></div>
                     </div>
-                    ${vuln.proof ? `<div class="vulnerability-proof"><strong>证明:</strong><pre>${escapeHtml(vuln.proof)}</pre></div>` : ''}
-                    ${vuln.impact ? `<div class="vulnerability-impact"><strong>影响:</strong> ${escapeHtml(vuln.impact)}</div>` : ''}
-                    ${vuln.recommendation ? `<div class="vulnerability-recommendation"><strong>修复建议:</strong> ${escapeHtml(vuln.recommendation)}</div>` : ''}
+                    ${vuln.proof ? `<div class="vulnerability-proof"><strong>${t('vuln.label.proof')}</strong><pre>${escapeHtml(vuln.proof)}</pre></div>` : ''}
+                    ${vuln.impact ? `<div class="vulnerability-impact"><strong>${t('vuln.label.impact')}</strong> ${escapeHtml(vuln.impact)}</div>` : ''}
+                    ${vuln.recommendation ? `<div class="vulnerability-recommendation"><strong>${t('vuln.label.recommendation')}</strong> ${escapeHtml(vuln.recommendation)}</div>` : ''}
                 </div>
             </div>
         `;
@@ -271,9 +271,9 @@ function renderVulnerabilityPagination() {
     // 左侧：显示范围信息和每页数量选择器（参考Skills样式）
     paginationHTML += `
         <div class="pagination-info">
-            <span>显示 ${start}-${end} / 共 ${total} 条</span>
+            <span>${t('ui.pagination.showing').replace('{0}', start).replace('{1}', end).replace('{2}', total)}</span>
             <label class="pagination-page-size">
-                每页显示
+                ${t('ui.pagination.per_page')}
                 <select id="vulnerability-page-size-pagination" onchange="changeVulnerabilityPageSize()">
                     <option value="10" ${pageSize === 10 ? 'selected' : ''}>10</option>
                     <option value="20" ${pageSize === 20 ? 'selected' : ''}>20</option>
@@ -287,11 +287,11 @@ function renderVulnerabilityPagination() {
     // 右侧：分页按钮（参考Skills样式：首页、上一页、第X/Y页、下一页、末页）
     paginationHTML += `
         <div class="pagination-controls">
-            <button class="btn-secondary" onclick="loadVulnerabilities(1)" ${currentPage === 1 || total === 0 ? 'disabled' : ''}>首页</button>
-            <button class="btn-secondary" onclick="loadVulnerabilities(${currentPage - 1})" ${currentPage === 1 || total === 0 ? 'disabled' : ''}>上一页</button>
-            <span class="pagination-page">第 ${currentPage} / ${totalPages || 1} 页</span>
-            <button class="btn-secondary" onclick="loadVulnerabilities(${currentPage + 1})" ${currentPage >= totalPages || total === 0 ? 'disabled' : ''}>下一页</button>
-            <button class="btn-secondary" onclick="loadVulnerabilities(${totalPages || 1})" ${currentPage >= totalPages || total === 0 ? 'disabled' : ''}>末页</button>
+            <button class="btn-secondary" onclick="loadVulnerabilities(1)" ${currentPage === 1 || total === 0 ? 'disabled' : ''}>${t('ui.pagination.first')}</button>
+            <button class="btn-secondary" onclick="loadVulnerabilities(${currentPage - 1})" ${currentPage === 1 || total === 0 ? 'disabled' : ''}>${t('ui.pagination.prev')}</button>
+            <span class="pagination-page">${t('ui.pagination.page').replace('{0}', currentPage).replace('{1}', totalPages || 1)}</span>
+            <button class="btn-secondary" onclick="loadVulnerabilities(${currentPage + 1})" ${currentPage >= totalPages || total === 0 ? 'disabled' : ''}>${t('ui.pagination.next')}</button>
+            <button class="btn-secondary" onclick="loadVulnerabilities(${totalPages || 1})" ${currentPage >= totalPages || total === 0 ? 'disabled' : ''}>${t('ui.pagination.last')}</button>
         </div>
     `;
     
@@ -328,7 +328,7 @@ async function changeVulnerabilityPageSize() {
 // 显示添加漏洞模态框
 function showAddVulnerabilityModal() {
     currentVulnerabilityId = null;
-    document.getElementById('vulnerability-modal-title').textContent = '添加漏洞';
+    document.getElementById('vulnerability-modal-title').textContent = t('vuln.modal.add');
     
     // 清空表单
     document.getElementById('vulnerability-conversation-id').value = '';
@@ -353,7 +353,7 @@ async function editVulnerability(id) {
 
         const vuln = await response.json();
         currentVulnerabilityId = id;
-        document.getElementById('vulnerability-modal-title').textContent = '编辑漏洞';
+        document.getElementById('vulnerability-modal-title').textContent = t('vuln.modal.edit');
 
         // 填充表单
         document.getElementById('vulnerability-conversation-id').value = vuln.conversation_id || '';
@@ -430,7 +430,7 @@ async function saveVulnerability() {
 
 // 删除漏洞
 async function deleteVulnerability(id) {
-    if (!confirm('确定要删除此漏洞吗？')) {
+    if (!confirm(t('vuln.confirm.delete'))) {
         return;
     }
 
@@ -529,18 +529,18 @@ function escapeHtml(text) {
 // 将漏洞格式化为Markdown
 function formatVulnerabilityAsMarkdown(vuln) {
     const severityText = {
-        'critical': '严重',
-        'high': '高危',
-        'medium': '中危',
-        'low': '低危',
-        'info': '信息'
+        'critical': t('vuln.severity.critical'),
+        'high': t('vuln.severity.high'),
+        'medium': t('vuln.severity.medium'),
+        'low': t('vuln.severity.low'),
+        'info': t('vuln.severity.info')
     }[vuln.severity] || vuln.severity;
 
     const statusText = {
-        'open': '待处理',
-        'confirmed': '已确认',
-        'fixed': '已修复',
-        'false_positive': '误报'
+        'open': t('vuln.status.pending'),
+        'confirmed': t('vuln.status.confirmed'),
+        'fixed': t('vuln.status.resolved'),
+        'false_positive': t('vuln.status.false_positive')
     }[vuln.status] || vuln.status;
 
     const createdDate = new Date(vuln.created_at).toLocaleString('zh-CN');
@@ -548,34 +548,34 @@ function formatVulnerabilityAsMarkdown(vuln) {
 
     let markdown = `# ${vuln.title}\n\n`;
     
-    markdown += `## 基本信息\n\n`;
-    markdown += `- **漏洞ID**: \`${vuln.id}\`\n`;
+    markdown += `${t('vuln.export.basic_info')}\n\n`;
+    markdown += `- **${t('vuln.label.id')}** \`${vuln.id}\`\n`;
     markdown += `- **严重程度**: ${severityText}\n`;
     markdown += `- **状态**: ${statusText}\n`;
     if (vuln.type) {
-        markdown += `- **类型**: ${vuln.type}\n`;
+        markdown += `- **${t('vuln.label.type')}** ${vuln.type}\n`;
     }
     if (vuln.target) {
-        markdown += `- **目标**: ${vuln.target}\n`;
+        markdown += `- **${t('vuln.label.target')}** ${vuln.target}\n`;
     }
-    markdown += `- **会话ID**: \`${vuln.conversation_id}\`\n`;
+    markdown += `- **${t('vuln.label.session_id')}** \`${vuln.conversation_id}\`\n`;
     markdown += `- **创建时间**: ${createdDate}\n`;
     markdown += `- **更新时间**: ${updatedDate}\n\n`;
 
     if (vuln.description) {
-        markdown += `## 描述\n\n${vuln.description}\n\n`;
+        markdown += `${t('vuln.export.description')}\n\n${vuln.description}\n\n`;
     }
 
     if (vuln.proof) {
-        markdown += `## 证明（POC）\n\n\`\`\`\n${vuln.proof}\n\`\`\`\n\n`;
+        markdown += `${t('vuln.export.proof')}\n\n\`\`\`\n${vuln.proof}\n\`\`\`\n\n`;
     }
 
     if (vuln.impact) {
-        markdown += `## 影响\n\n${vuln.impact}\n\n`;
+        markdown += `${t('vuln.export.impact')}\n\n${vuln.impact}\n\n`;
     }
 
     if (vuln.recommendation) {
-        markdown += `## 修复建议\n\n${vuln.recommendation}\n\n`;
+        markdown += `${t('vuln.export.recommendation')}\n\n${vuln.recommendation}\n\n`;
     }
 
     return markdown;
@@ -620,8 +620,8 @@ async function downloadVulnerabilityAsMarkdown(id, event) {
         if (event && event.target) {
             const button = event.target.closest('button');
             if (button) {
-                const originalTitle = button.title || '下载Markdown';
-                button.title = '下载成功！';
+                const originalTitle = button.title || t('vuln.btn.download_md');
+                button.title = t('vuln.export.download_success');
                 setTimeout(() => {
                     button.title = originalTitle;
                 }, 2000);

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -10,20 +10,21 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/xterm@4.19.0/css/xterm.css">
 </head>
 <body>
+    <script>window.I18N = {{.I18NJson}};</script>
     <div id="login-overlay" class="login-overlay" style="display: none;">
         <div class="login-card">
             <div class="login-brand">
-                <h2>登录 CyberStrikeAI</h2>
-                <p class="login-subtitle">请输入配置中的访问密码</p>
+                <h2>{{t "login.title"}}</h2>
+                <p class="login-subtitle">{{t "login.subtitle"}}</p>
             </div>
             <form id="login-form" class="login-form">
                 <div class="form-group">
-                    <label for="login-password">密码</label>
-                    <input type="password" id="login-password" placeholder="输入登录密码" required autocomplete="current-password" />
+                    <label for="login-password">{{t "login.password_label"}}</label>
+                    <input type="password" id="login-password" placeholder="{{t "login.password_placeholder"}}" required autocomplete="current-password" />
                 </div>
                 <div id="login-error" class="login-error" role="alert" style="display: none;"></div>
                 <button type="submit" class="btn-primary login-submit">
-                    <span>登录</span>
+                    <span>{{t "login.submit"}}</span>
                 </button>
             </form>
         </div>
@@ -32,18 +33,18 @@
     <div class="container">
         <header>
             <div class="header-content">
-                <div class="logo header-logo-link" onclick="switchPage('dashboard')" role="button" title="返回仪表盘">
+                <div class="logo header-logo-link" onclick="switchPage('dashboard')" role="button" title="{{t "nav.dashboard"}}">
                     <img src="/static/logo.png" alt="CyberStrikeAI Logo" style="width: 32px; height: 32px; margin-right: 8px;">
                     <h1>CyberStrikeAI</h1>
-                    <span class="version-badge" title="当前版本">{{.Version}}</span>
+                    <span class="version-badge" title="{{t "nav.version_title"}}">{{.Version}}</span>
                 </div>
                 <div class="header-right">
                     <div class="header-actions">
-                        <button class="openapi-doc-btn" onclick="window.open('/api-docs', '_blank')" title="OpenAPI 文档">
-                            <span>API 文档</span>
+                        <button class="openapi-doc-btn" onclick="window.open('/api-docs', '_blank')" title="{{t "nav.api_docs_title"}}">
+                            <span>{{t "nav.api_docs"}}</span>
                         </button>
                         <div class="user-menu-container">
-                            <button class="user-avatar-btn" onclick="toggleUserMenu()" title="用户菜单">
+                            <button class="user-avatar-btn" onclick="toggleUserMenu()" title="{{t "nav.user_menu"}}">
                                 <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                                     <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                                     <circle cx="12" cy="7" r="4" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
@@ -56,7 +57,7 @@
                                         <polyline points="16 17 21 12 16 7" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                                         <line x1="21" y1="12" x2="9" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                                     </svg>
-                                    <span>退出登录</span>
+                                    <span>{{t "nav.logout"}}</span>
                                 </div>
                             </div>
                         </div>
@@ -68,56 +69,56 @@
         <div class="main-layout">
             <!-- 主侧边栏 -->
             <aside class="main-sidebar" id="main-sidebar">
-                <div class="sidebar-collapse-btn" onclick="toggleSidebar()" title="折叠/展开侧边栏">
+                <div class="sidebar-collapse-btn" onclick="toggleSidebar()" title="{{t "nav.sidebar_toggle"}}">
                     <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                         <path d="M15 18l-6-6 6-6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                     </svg>
                 </div>
                 <nav class="main-sidebar-nav">
                     <div class="nav-item" data-page="dashboard">
-                        <div class="nav-item-content" data-title="仪表盘" onclick="switchPage('dashboard')">
+                        <div class="nav-item-content" data-title="{{t "nav.dashboard"}}" onclick="switchPage('dashboard')">
                             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                                 <rect x="3" y="3" width="7" height="9"></rect>
                                 <rect x="14" y="3" width="7" height="5"></rect>
                                 <rect x="14" y="12" width="7" height="9"></rect>
                                 <rect x="3" y="16" width="7" height="5"></rect>
                             </svg>
-                            <span>仪表盘</span>
+                            <span>{{t "nav.dashboard"}}</span>
                         </div>
                     </div>
                     <div class="nav-item" data-page="chat">
-                        <div class="nav-item-content" data-title="对话" onclick="switchPage('chat')">
+                        <div class="nav-item-content" data-title="{{t "nav.chat"}}" onclick="switchPage('chat')">
                             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                                 <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path>
                             </svg>
-                            <span>对话</span>
+                            <span>{{t "nav.chat"}}</span>
                         </div>
                     </div>
                     <div class="nav-item" data-page="info-collect">
-                        <div class="nav-item-content" data-title="信息收集" onclick="switchPage('info-collect')">
+                        <div class="nav-item-content" data-title="{{t "nav.info_collect"}}" onclick="switchPage('info-collect')">
                             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                                 <circle cx="11" cy="11" r="8"></circle>
                                 <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
                             </svg>
-                            <span>信息收集</span>
+                            <span>{{t "nav.info_collect"}}</span>
                         </div>
                     </div>
                     <div class="nav-item" data-page="tasks">
-                        <div class="nav-item-content" data-title="任务管理" onclick="switchPage('tasks')">
+                        <div class="nav-item-content" data-title="{{t "nav.tasks"}}" onclick="switchPage('tasks')">
                             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                                 <path d="M9 11l3 3L22 4"></path>
                                 <path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"></path>
                             </svg>
-                            <span>任务管理</span>
+                            <span>{{t "nav.tasks"}}</span>
                         </div>
                     </div>
                     <div class="nav-item" data-page="vulnerabilities">
-                        <div class="nav-item-content" data-title="漏洞管理" onclick="switchPage('vulnerabilities')">
+                        <div class="nav-item-content" data-title="{{t "nav.vulnerability"}}" onclick="switchPage('vulnerabilities')">
                             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                                 <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path>
                                 <path d="M9 12l2 2 4-4"></path>
                             </svg>
-                            <span>漏洞管理</span>
+                            <span>{{t "nav.vulnerability"}}</span>
                         </div>
                     </div>
                     <div class="nav-item nav-item-has-submenu" data-page="mcp">
@@ -132,35 +133,35 @@
                         </div>
                         <div class="nav-submenu">
                             <div class="nav-submenu-item" data-page="mcp-monitor" onclick="switchPage('mcp-monitor')">
-                                <span>MCP状态监控</span>
+                                <span>{{t "nav.mcp_monitor"}}</span>
                             </div>
                             <div class="nav-submenu-item" data-page="mcp-management" onclick="switchPage('mcp-management')">
-                                <span>MCP管理</span>
+                                <span>{{t "nav.mcp_management"}}</span>
                             </div>
                         </div>
                     </div>
                     <div class="nav-item nav-item-has-submenu" data-page="knowledge">
-                        <div class="nav-item-content" data-title="知识" onclick="toggleSubmenu('knowledge')">
+                        <div class="nav-item-content" data-title="{{t "nav.knowledge"}}" onclick="toggleSubmenu('knowledge')">
                             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                                 <path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"></path>
                                 <path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"></path>
                             </svg>
-                            <span>知识</span>
+                            <span>{{t "nav.knowledge"}}</span>
                             <svg class="submenu-arrow" width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                                 <path d="M9 18l6-6-6-6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                             </svg>
                         </div>
                         <div class="nav-submenu">
                             <div class="nav-submenu-item" data-page="knowledge-retrieval-logs" onclick="switchPage('knowledge-retrieval-logs')">
-                                <span>检索历史</span>
+                                <span>{{t "nav.knowledge_retrieval_logs"}}</span>
                             </div>
                             <div class="nav-submenu-item" data-page="knowledge-management" onclick="switchPage('knowledge-management')">
-                                <span>知识管理</span>
+                                <span>{{t "nav.knowledge_management"}}</span>
                             </div>
                         </div>
                     </div>
                     <div class="nav-item nav-item-has-submenu" data-page="skills">
-                        <div class="nav-item-content" data-title="Skills" onclick="toggleSubmenu('skills')">
+                        <div class="nav-item-content" data-title="{{t "nav.skills"}}" onclick="toggleSubmenu('skills')">
                             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                                 <path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z"></path>
                                 <polyline points="14 2 14 8 20 8"></polyline>
@@ -168,46 +169,46 @@
                                 <line x1="16" y1="17" x2="8" y2="17"></line>
                                 <polyline points="10 9 9 9 8 9"></polyline>
                             </svg>
-                            <span>Skills</span>
+                            <span>{{t "nav.skills"}}</span>
                             <svg class="submenu-arrow" width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                                 <path d="M9 18l6-6-6-6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                             </svg>
                         </div>
                         <div class="nav-submenu">
                             <div class="nav-submenu-item" data-page="skills-monitor" onclick="switchPage('skills-monitor')">
-                                <span>Skills状态监控</span>
+                                <span>{{t "nav.skills_monitor"}}</span>
                             </div>
                             <div class="nav-submenu-item" data-page="skills-management" onclick="switchPage('skills-management')">
-                                <span>Skills管理</span>
+                                <span>{{t "nav.skills_management"}}</span>
                             </div>
                         </div>
                     </div>
                     <div class="nav-item nav-item-has-submenu" data-page="roles">
-                        <div class="nav-item-content" data-title="角色" onclick="toggleSubmenu('roles')">
+                        <div class="nav-item-content" data-title="{{t "nav.roles"}}" onclick="toggleSubmenu('roles')">
                             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                                 <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path>
                                 <circle cx="9" cy="7" r="4"></circle>
                                 <path d="M23 21v-2a4 4 0 0 0-3-3.87"></path>
                                 <path d="M16 3.13a4 4 0 0 1 0 7.75"></path>
                             </svg>
-                            <span>角色</span>
+                            <span>{{t "nav.roles"}}</span>
                             <svg class="submenu-arrow" width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                                 <path d="M9 18l6-6-6-6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                             </svg>
                         </div>
                         <div class="nav-submenu">
                             <div class="nav-submenu-item" data-page="roles-management" onclick="switchPage('roles-management')">
-                                <span>角色管理</span>
+                                <span>{{t "nav.roles_management"}}</span>
                             </div>
                         </div>
                     </div>
                     <div class="nav-item" data-page="settings">
-                        <div class="nav-item-content" data-title="系统设置" onclick="switchPage('settings')">
+                        <div class="nav-item-content" data-title="{{t "nav.settings"}}" onclick="switchPage('settings')">
                             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                                 <circle cx="12" cy="12" r="3"></circle>
                                 <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"></path>
                             </svg>
-                            <span>系统设置</span>
+                            <span>{{t "nav.settings"}}</span>
                         </div>
                     </div>
                 </nav>
@@ -219,24 +220,24 @@
                 <div id="page-dashboard" class="page active">
                     <div class="dashboard-page">
                         <div class="page-header">
-                            <h2>仪表盘</h2>
+                            <h2>{{t "dashboard.title"}}</h2>
                             <div class="page-header-actions">
-                                <button class="btn-secondary" onclick="refreshDashboard()" title="刷新数据">刷新</button>
+                                <button class="btn-secondary" onclick="refreshDashboard()" title="{{t "ui.btn.refresh"}}">{{t "ui.btn.refresh"}}</button>
                             </div>
                         </div>
                         <div class="dashboard-content">
                             <!-- 第一行：核心 KPI（仪表盘最佳实践：关键指标置顶） -->
                             <div class="dashboard-kpi-row" id="dashboard-cards">
-                                <div class="dashboard-kpi-card" role="button" tabindex="0" onclick="switchPage('tasks')" onkeydown="if(event.key==='Enter'||event.key===' ') { event.preventDefault(); switchPage('tasks'); }" title="点击查看任务管理"> <div class="dashboard-kpi-value" id="dashboard-running-tasks">-</div><div class="dashboard-kpi-label">运行中任务</div></div>
-                                <div class="dashboard-kpi-card" role="button" tabindex="0" onclick="switchPage('vulnerabilities')" onkeydown="if(event.key==='Enter'||event.key===' ') { event.preventDefault(); switchPage('vulnerabilities'); }" title="点击查看漏洞管理"><div class="dashboard-kpi-value" id="dashboard-vuln-total">-</div><div class="dashboard-kpi-label">漏洞总数</div></div>
-                                <div class="dashboard-kpi-card" role="button" tabindex="0" onclick="switchPage('mcp-monitor')" onkeydown="if(event.key==='Enter'||event.key===' ') { event.preventDefault(); switchPage('mcp-monitor'); }" title="点击查看 MCP 监控"><div class="dashboard-kpi-value" id="dashboard-kpi-tools-calls">-</div><div class="dashboard-kpi-label">工具调用次数</div></div>
-                                <div class="dashboard-kpi-card" role="button" tabindex="0" onclick="switchPage('mcp-monitor')" onkeydown="if(event.key==='Enter'||event.key===' ') { event.preventDefault(); switchPage('mcp-monitor'); }" title="点击查看 MCP 监控"><div class="dashboard-kpi-value" id="dashboard-kpi-success-rate">-</div><div class="dashboard-kpi-label">工具执行成功率</div></div>
+                                <div class="dashboard-kpi-card" role="button" tabindex="0" onclick="switchPage('tasks')" onkeydown="if(event.key==='Enter'||event.key===' ') { event.preventDefault(); switchPage('tasks'); }" title="{{t "dashboard.kpi.click_tasks"}}"> <div class="dashboard-kpi-value" id="dashboard-running-tasks">-</div><div class="dashboard-kpi-label">{{t "dashboard.kpi.running_tasks"}}</div></div>
+                                <div class="dashboard-kpi-card" role="button" tabindex="0" onclick="switchPage('vulnerabilities')" onkeydown="if(event.key==='Enter'||event.key===' ') { event.preventDefault(); switchPage('vulnerabilities'); }" title="{{t "dashboard.kpi.click_vulns"}}"><div class="dashboard-kpi-value" id="dashboard-vuln-total">-</div><div class="dashboard-kpi-label">{{t "dashboard.kpi.vuln_total"}}</div></div>
+                                <div class="dashboard-kpi-card" role="button" tabindex="0" onclick="switchPage('mcp-monitor')" onkeydown="if(event.key==='Enter'||event.key===' ') { event.preventDefault(); switchPage('mcp-monitor'); }" title="{{t "dashboard.kpi.click_mcp"}}"><div class="dashboard-kpi-value" id="dashboard-kpi-tools-calls">-</div><div class="dashboard-kpi-label">{{t "dashboard.kpi.tool_calls"}}</div></div>
+                                <div class="dashboard-kpi-card" role="button" tabindex="0" onclick="switchPage('mcp-monitor')" onkeydown="if(event.key==='Enter'||event.key===' ') { event.preventDefault(); switchPage('mcp-monitor'); }" title="{{t "dashboard.kpi.click_mcp"}}"><div class="dashboard-kpi-value" id="dashboard-kpi-success-rate">-</div><div class="dashboard-kpi-label">{{t "dashboard.kpi.tool_success_rate"}}</div></div>
                             </div>
                             <!-- 两列主内容区 -->
                             <div class="dashboard-grid">
                                 <div class="dashboard-main">
                                     <section class="dashboard-section dashboard-section-chart">
-                                        <h3 class="dashboard-section-title">漏洞严重程度分布</h3>
+                                        <h3 class="dashboard-section-title">{{t "dashboard.section.vuln_severity"}}</h3>
                                         <div class="dashboard-chart-wrap">
                                             <div class="dashboard-stacked-bar" id="dashboard-stacked-bar">
                                                 <span class="dashboard-bar-seg seg-critical" id="dashboard-bar-critical" style="width: 0%"></span>
@@ -246,39 +247,39 @@
                                                 <span class="dashboard-bar-seg seg-info" id="dashboard-bar-info" style="width: 0%"></span>
                                             </div>
                                             <div class="dashboard-legend" id="dashboard-vuln-bars">
-                                                <div class="dashboard-legend-item"><span class="dashboard-legend-dot critical"></span><span class="dashboard-legend-label">严重</span><span class="dashboard-legend-value" id="dashboard-severity-critical">0</span></div>
-                                                <div class="dashboard-legend-item"><span class="dashboard-legend-dot high"></span><span class="dashboard-legend-label">高危</span><span class="dashboard-legend-value" id="dashboard-severity-high">0</span></div>
-                                                <div class="dashboard-legend-item"><span class="dashboard-legend-dot medium"></span><span class="dashboard-legend-label">中危</span><span class="dashboard-legend-value" id="dashboard-severity-medium">0</span></div>
-                                                <div class="dashboard-legend-item"><span class="dashboard-legend-dot low"></span><span class="dashboard-legend-label">低危</span><span class="dashboard-legend-value" id="dashboard-severity-low">0</span></div>
-                                                <div class="dashboard-legend-item"><span class="dashboard-legend-dot info"></span><span class="dashboard-legend-label">信息</span><span class="dashboard-legend-value" id="dashboard-severity-info">0</span></div>
+                                                <div class="dashboard-legend-item"><span class="dashboard-legend-dot critical"></span><span class="dashboard-legend-label">{{t "vuln.severity.critical"}}</span><span class="dashboard-legend-value" id="dashboard-severity-critical">0</span></div>
+                                                <div class="dashboard-legend-item"><span class="dashboard-legend-dot high"></span><span class="dashboard-legend-label">{{t "vuln.severity.high"}}</span><span class="dashboard-legend-value" id="dashboard-severity-high">0</span></div>
+                                                <div class="dashboard-legend-item"><span class="dashboard-legend-dot medium"></span><span class="dashboard-legend-label">{{t "vuln.severity.medium"}}</span><span class="dashboard-legend-value" id="dashboard-severity-medium">0</span></div>
+                                                <div class="dashboard-legend-item"><span class="dashboard-legend-dot low"></span><span class="dashboard-legend-label">{{t "vuln.severity.low"}}</span><span class="dashboard-legend-value" id="dashboard-severity-low">0</span></div>
+                                                <div class="dashboard-legend-item"><span class="dashboard-legend-dot info"></span><span class="dashboard-legend-label">{{t "vuln.severity.info"}}</span><span class="dashboard-legend-value" id="dashboard-severity-info">0</span></div>
                                             </div>
                                         </div>
                                     </section>
                                     <section class="dashboard-section dashboard-section-overview">
-                                        <h3 class="dashboard-section-title">运行概览</h3>
+                                        <h3 class="dashboard-section-title">{{t "dashboard.section.run_overview"}}</h3>
                                         <div class="dashboard-overview-list">
                                             <div class="dashboard-overview-item dashboard-overview-item-batch" role="button" tabindex="0" onclick="switchPage('tasks')" onkeydown="if(event.key==='Enter'||event.key===' ') { event.preventDefault(); switchPage('tasks'); }">
                                                 <span class="dashboard-overview-icon dashboard-overview-icon-batch" aria-hidden="true"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg></span>
                                                 <div class="dashboard-overview-content">
                                                     <div class="dashboard-overview-header">
-                                                        <span class="dashboard-overview-label">批量任务队列</span>
+                                                        <span class="dashboard-overview-label">{{t "dashboard.overview.batch_queue"}}</span>
                                                         <span class="dashboard-overview-total" id="dashboard-batch-total">-</span>
                                                     </div>
                                                     <div class="dashboard-overview-stats">
                                                         <span class="dashboard-overview-stat dashboard-overview-stat-pending">
                                                             <span class="dashboard-overview-stat-badge badge-pending"></span>
                                                             <span class="dashboard-overview-stat-value" id="dashboard-batch-pending">-</span>
-                                                            <span class="dashboard-overview-stat-label">待执行</span>
+                                                            <span class="dashboard-overview-stat-label">{{t "dashboard.overview.pending"}}</span>
                                                         </span>
                                                         <span class="dashboard-overview-stat dashboard-overview-stat-running">
                                                             <span class="dashboard-overview-stat-badge badge-running"></span>
                                                             <span class="dashboard-overview-stat-value" id="dashboard-batch-running">-</span>
-                                                            <span class="dashboard-overview-stat-label">执行中</span>
+                                                            <span class="dashboard-overview-stat-label">{{t "dashboard.overview.running"}}</span>
                                                         </span>
                                                         <span class="dashboard-overview-stat dashboard-overview-stat-done">
                                                             <span class="dashboard-overview-stat-badge badge-done"></span>
                                                             <span class="dashboard-overview-stat-value" id="dashboard-batch-done">-</span>
-                                                            <span class="dashboard-overview-stat-label">已完成</span>
+                                                            <span class="dashboard-overview-stat-label">{{t "dashboard.overview.done"}}</span>
                                                         </span>
                                                     </div>
                                                     <div class="dashboard-overview-progress">
@@ -294,15 +295,15 @@
                                                 <span class="dashboard-overview-icon dashboard-overview-icon-tools" aria-hidden="true"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/></svg></span>
                                                 <div class="dashboard-overview-content">
                                                     <div class="dashboard-overview-header">
-                                                        <span class="dashboard-overview-label">工具调用</span>
+                                                        <span class="dashboard-overview-label">{{t "dashboard.overview.tool_calls"}}</span>
                                                         <span class="dashboard-overview-success-rate" id="dashboard-tools-success-rate">-</span>
                                                     </div>
                                                     <div class="dashboard-overview-value-group">
                                                         <span class="dashboard-overview-value-large" id="dashboard-tools-calls">-</span>
-                                                        <span class="dashboard-overview-value-unit">次调用</span>
+                                                        <span class="dashboard-overview-value-unit">{{t "dashboard.overview.calls_unit"}}</span>
                                                         <span class="dashboard-overview-value-separator">·</span>
                                                         <span class="dashboard-overview-value-normal" id="dashboard-tools-count">-</span>
-                                                        <span class="dashboard-overview-value-unit">个工具</span>
+                                                        <span class="dashboard-overview-value-unit">{{t "dashboard.overview.tools_unit"}}</span>
                                                     </div>
                                                 </div>
                                             </div>
@@ -310,15 +311,15 @@
                                                 <span class="dashboard-overview-icon dashboard-overview-icon-knowledge" aria-hidden="true"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"></path><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"></path></svg></span>
                                                 <div class="dashboard-overview-content">
                                                     <div class="dashboard-overview-header">
-                                                        <span class="dashboard-overview-label">知识</span>
+                                                        <span class="dashboard-overview-label">{{t "dashboard.overview.knowledge"}}</span>
                                                         <span class="dashboard-overview-status" id="dashboard-knowledge-status">-</span>
                                                     </div>
                                                     <div class="dashboard-overview-value-group">
                                                         <span class="dashboard-overview-value-large" id="dashboard-knowledge-items">-</span>
-                                                        <span class="dashboard-overview-value-unit">项知识</span>
+                                                        <span class="dashboard-overview-value-unit">{{t "dashboard.overview.knowledge_items_unit"}}</span>
                                                         <span class="dashboard-overview-value-separator">·</span>
                                                         <span class="dashboard-overview-value-normal" id="dashboard-knowledge-categories">-</span>
-                                                        <span class="dashboard-overview-value-unit">个分类</span>
+                                                        <span class="dashboard-overview-value-unit">{{t "dashboard.overview.knowledge_categories_unit"}}</span>
                                                     </div>
                                                 </div>
                                             </div>
@@ -331,33 +332,33 @@
                                                     </div>
                                                     <div class="dashboard-overview-value-group">
                                                         <span class="dashboard-overview-value-large" id="dashboard-skills-calls">-</span>
-                                                        <span class="dashboard-overview-value-unit">次调用</span>
+                                                        <span class="dashboard-overview-value-unit">{{t "dashboard.overview.skills_calls_unit"}}</span>
                                                         <span class="dashboard-overview-value-separator">·</span>
                                                         <span class="dashboard-overview-value-normal" id="dashboard-skills-count">-</span>
-                                                        <span class="dashboard-overview-value-unit">个 Skill</span>
+                                                        <span class="dashboard-overview-value-unit">{{t "dashboard.overview.skills_count_unit"}}</span>
                                                     </div>
                                                 </div>
                                             </div>
                                         </div>
                                     </section>
                                     <section class="dashboard-section dashboard-section-quick dashboard-quick-inline">
-                                        <h3 class="dashboard-section-title">快捷入口</h3>
+                                        <h3 class="dashboard-section-title">{{t "dashboard.section.quick_links"}}</h3>
                                         <div class="dashboard-quick-links dashboard-quick-links-row">
-                                            <a class="dashboard-quick-link" onclick="switchPage('chat')"><span class="dashboard-quick-icon"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path></svg></span><span>对话</span></a>
-                                            <a class="dashboard-quick-link" onclick="switchPage('tasks')"><span class="dashboard-quick-icon"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 11l3 3L22 4"></path><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"></path></svg></span><span>任务管理</span></a>
-                                            <a class="dashboard-quick-link" onclick="switchPage('vulnerabilities')"><span class="dashboard-quick-icon"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path></svg></span><span>漏洞管理</span></a>
-                                            <a class="dashboard-quick-link" onclick="switchPage('mcp-management')"><span class="dashboard-quick-icon"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"></path></svg></span><span>MCP 管理</span></a>
-                                            <a class="dashboard-quick-link" onclick="switchPage('knowledge-management')"><span class="dashboard-quick-icon"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"></path><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"></path></svg></span><span>知识管理</span></a>
-                                            <a class="dashboard-quick-link" onclick="switchPage('skills-management')"><span class="dashboard-quick-icon"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z"></path><polyline points="14 2 14 8 20 8"></polyline></svg></span><span>Skills 管理</span></a>
-                                            <a class="dashboard-quick-link" onclick="switchPage('roles-management')"><span class="dashboard-quick-icon"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path><circle cx="9" cy="7" r="4"></circle><path d="M23 21v-2a4 4 0 0 0-3-3.87"></path><path d="M16 3.13a4 4 0 0 1 0 7.75"></path></svg></span><span>角色管理</span></a>
+                                            <a class="dashboard-quick-link" onclick="switchPage('chat')"><span class="dashboard-quick-icon"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path></svg></span><span>{{t "dashboard.quick.chat"}}</span></a>
+                                            <a class="dashboard-quick-link" onclick="switchPage('tasks')"><span class="dashboard-quick-icon"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 11l3 3L22 4"></path><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"></path></svg></span><span>{{t "dashboard.quick.tasks"}}</span></a>
+                                            <a class="dashboard-quick-link" onclick="switchPage('vulnerabilities')"><span class="dashboard-quick-icon"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path></svg></span><span>{{t "dashboard.quick.vulns"}}</span></a>
+                                            <a class="dashboard-quick-link" onclick="switchPage('mcp-management')"><span class="dashboard-quick-icon"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"></path></svg></span><span>{{t "dashboard.quick.mcp"}}</span></a>
+                                            <a class="dashboard-quick-link" onclick="switchPage('knowledge-management')"><span class="dashboard-quick-icon"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"></path><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"></path></svg></span><span>{{t "dashboard.quick.knowledge"}}</span></a>
+                                            <a class="dashboard-quick-link" onclick="switchPage('skills-management')"><span class="dashboard-quick-icon"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z"></path><polyline points="14 2 14 8 20 8"></polyline></svg></span><span>{{t "dashboard.quick.skills"}}</span></a>
+                                            <a class="dashboard-quick-link" onclick="switchPage('roles-management')"><span class="dashboard-quick-icon"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path><circle cx="9" cy="7" r="4"></circle><path d="M23 21v-2a4 4 0 0 0-3-3.87"></path><path d="M16 3.13a4 4 0 0 1 0 7.75"></path></svg></span><span>{{t "dashboard.quick.roles"}}</span></a>
                                         </div>
                                     </section>
                                 </div>
                                 <div class="dashboard-side">
                                     <section class="dashboard-section dashboard-section-tools">
-                                        <h3 class="dashboard-section-title">工具执行次数</h3>
+                                        <h3 class="dashboard-section-title">{{t "dashboard.section.tool_exec_count"}}</h3>
                                         <div class="dashboard-tools-chart-wrap">
-                                            <div class="dashboard-tools-chart-placeholder" id="dashboard-tools-pie-placeholder">暂无数据</div>
+                                            <div class="dashboard-tools-chart-placeholder" id="dashboard-tools-pie-placeholder">{{t "dashboard.no_data"}}</div>
                                             <div class="dashboard-tools-bar-chart" id="dashboard-tools-bar-chart"></div>
                                         </div>
                                     </section>
@@ -369,12 +370,12 @@
                                         <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path></svg>
                                     </div>
                                     <div class="dashboard-cta-copy">
-                                        <p class="dashboard-cta-text">开始你的安全之旅</p>
-                                        <p class="dashboard-cta-sub">在对话中描述目标，AI 将协助执行扫描与漏洞分析</p>
+                                        <p class="dashboard-cta-text">{{t "dashboard.cta.title"}}</p>
+                                        <p class="dashboard-cta-sub">{{t "dashboard.cta.subtitle"}}</p>
                                     </div>
                                 </div>
                                 <button class="dashboard-cta-btn" onclick="switchPage('chat')">
-                                    <span>前往对话</span>
+                                    <span>{{t "dashboard.cta.btn"}}</span>
                                     <span class="dashboard-cta-btn-arrow" aria-hidden="true"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M5 12h14M12 5l7 7-7 7"/></svg></span>
                                 </button>
                             </div>
@@ -389,17 +390,17 @@
                         <aside class="conversation-sidebar">
                             <div class="sidebar-header">
                                 <button class="new-chat-btn" onclick="startNewConversation()">
-                                    <span>+</span> 新对话
+                                    <span>+</span> {{t "chat.sidebar.new"}}
                                 </button>
                             </div>
                             <div class="sidebar-content">
                                 <!-- 全局搜索 -->
                                 <div class="conversation-search-box" style="margin-bottom: 16px; margin-top: 16px;">
-                                    <input type="text" id="conversation-search-input" placeholder="搜索历史记录..." 
+                                    <input type="text" id="conversation-search-input" placeholder="{{t "chat.sidebar.search_placeholder"}}" 
                                            oninput="handleConversationSearch(this.value)" 
                                            onkeypress="if(event.key === 'Enter') handleConversationSearch(this.value)" />
                                     <button class="conversation-search-clear" id="conversation-search-clear" 
-                                            onclick="clearConversationSearch()" style="display: none;" title="清除搜索">
+                                            onclick="clearConversationSearch()" style="display: none;" title="{{t "chat.sidebar.clear_search"}}">
                                         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                                             <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
                                             <path d="M15 9l-6 6M9 9l6 6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
@@ -410,8 +411,8 @@
                                 <!-- 对话分组 -->
                                 <div class="conversation-groups-section">
                                     <div class="section-header">
-                                        <span class="section-title">对话分组</span>
-                                        <button class="add-group-btn" onclick="showCreateGroupModal()" title="新建分组">
+                                        <span class="section-title">{{t "chat.sidebar.groups_title"}}</span>
+                                        <button class="add-group-btn" onclick="showCreateGroupModal()" title="{{t "chat.sidebar.new_group"}}">
                                             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                                                 <path d="M12 5v14M5 12h14" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                                             </svg>
@@ -423,8 +424,8 @@
                                 <!-- 最近对话 -->
                                 <div class="recent-conversations-section">
                                     <div class="section-header">
-                                        <span class="section-title">最近对话</span>
-                                        <button class="batch-manage-btn" onclick="showBatchManageModal()" title="批量管理">
+                                        <span class="section-title">{{t "chat.sidebar.recent_title"}}</span>
+                                        <button class="batch-manage-btn" onclick="showBatchManageModal()" title="{{t "chat.sidebar.batch_manage"}}">
                                             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                                                 <line x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
                                                 <line x1="3" y1="6" x2="21" y2="6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
@@ -450,19 +451,19 @@
                                 </button>
                                 <h2 id="group-detail-title" class="group-detail-title"></h2>
                                 <div class="group-detail-actions">
-                                    <button class="group-action-btn" onclick="toggleGroupSearch()" title="搜索" id="group-search-toggle-btn">
+                                    <button class="group-action-btn" onclick="toggleGroupSearch()" title="{{t "chat.group.search"}}" id="group-search-toggle-btn">
                                         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                                             <circle cx="11" cy="11" r="8" stroke="currentColor" stroke-width="2"/>
                                             <path d="m21 21-4.35-4.35" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
                                         </svg>
                                     </button>
-                                    <button class="group-action-btn" onclick="editGroup()" title="编辑">
+                                    <button class="group-action-btn" onclick="editGroup()" title="{{t "chat.group.edit"}}">
                                         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                                             <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                                             <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                                         </svg>
                                     </button>
-                                    <button class="group-action-btn delete-btn" onclick="deleteGroup()" title="删除">
+                                    <button class="group-action-btn delete-btn" onclick="deleteGroup()" title="{{t "chat.group.delete"}}">
                                         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                                             <path d="M3 6h18M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2m3 0v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6h14z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                                         </svg>
@@ -471,8 +472,8 @@
                             </div>
                             <div id="group-search-container" class="group-search-container" style="display: none;">
                                 <div class="group-search-input-wrapper">
-                                    <input type="text" id="group-search-input" class="group-search-input" placeholder="搜索分组中的对话..." onkeyup="handleGroupSearchInput(event)" oninput="handleGroupSearchInput(event)">
-                                    <button class="group-search-clear-btn" onclick="clearGroupSearch()" title="清除搜索" id="group-search-clear-btn" style="display: none;">
+                                    <input type="text" id="group-search-input" class="group-search-input" placeholder="{{t "chat.group.search_placeholder"}}" onkeyup="handleGroupSearchInput(event)" oninput="handleGroupSearchInput(event)">
+                                    <button class="group-search-clear-btn" onclick="clearGroupSearch()" title="{{t "chat.group.clear_search"}}" id="group-search-clear-btn" style="display: none;">
                                         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                                             <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
                                             <path d="m8 8 8 8M16 8l-8 8" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
@@ -490,11 +491,11 @@
                             <!-- 会话顶部栏（只在有会话选中时显示） -->
                             <div id="conversation-header" class="conversation-header" style="display: none;">
                                 <div class="conversation-header-content">
-                                    <button id="attack-chain-btn" class="attack-chain-btn" title="查看攻击链" disabled>
+                                    <button id="attack-chain-btn" class="attack-chain-btn" title="{{t "chat.attack_chain.view_title"}}" disabled>
                                         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                                             <path d="M10.5 13.5l3-3M8 8H5a4 4 0 1 0 0 8h3m8-8h3a4 4 0 0 1 0 8h-3" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                                         </svg>
-                                        <span>攻击链</span>
+                                        <span>{{t "chat.attack_chain.btn"}}</span>
                                     </button>
                                 </div>
                             </div>
@@ -502,9 +503,9 @@
                             <div id="chat-messages" class="chat-messages"></div>
                             <div id="chat-input-container" class="chat-input-container">
                                 <div class="role-selector-wrapper">
-                                    <button id="role-selector-btn" class="role-selector-btn" onclick="toggleRoleSelectionPanel()" title="选择角色">
+                                    <button id="role-selector-btn" class="role-selector-btn" onclick="toggleRoleSelectionPanel()" title="{{t "chat.role.select_title"}}">
                                         <span id="role-selector-icon" class="role-selector-icon">🔵</span>
-                                        <span id="role-selector-text" class="role-selector-text">默认</span>
+                                        <span id="role-selector-text" class="role-selector-text">{{t "chat.role.default"}}</span>
                                         <svg class="role-selector-arrow" width="10" height="10" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                                             <path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                                         </svg>
@@ -512,8 +513,8 @@
                                     <!-- 角色选择下拉面板 -->
                                     <div id="role-selection-panel" class="role-selection-panel" style="display: none;">
                                         <div class="role-selection-panel-header">
-                                            <h3 class="role-selection-panel-title">选择角色</h3>
-                                            <button class="role-selection-panel-close" onclick="closeRoleSelectionPanel()" title="关闭">
+                                            <h3 class="role-selection-panel-title">{{t "chat.role.select_heading"}}</h3>
+                                            <button class="role-selection-panel-close" onclick="closeRoleSelectionPanel()" title="{{t "chat.role.close"}}">
                                                 <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                                                     <path d="M18 6L6 18M6 6l12 12" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                                                 </svg>
@@ -523,20 +524,20 @@
                                     </div>
                                 </div>
                                 <div class="chat-input-with-files">
-                                    <div id="chat-file-list" class="chat-file-list" aria-label="已选文件列表"></div>
+                                    <div id="chat-file-list" class="chat-file-list" aria-label="{{t "chat.file.selected_label"}}"></div>
                                     <div class="chat-input-field">
-                                        <textarea id="chat-input" placeholder="输入测试目标或命令... (输入 @ 选择工具 | Shift+Enter 换行，Enter 发送)" rows="1"></textarea>
-                                        <div id="mention-suggestions" class="mention-suggestions" role="listbox" aria-label="工具提及候选"></div>
+                                        <textarea id="chat-input" placeholder="{{t "chat.input.placeholder"}}" rows="1"></textarea>
+                                        <div id="mention-suggestions" class="mention-suggestions" role="listbox" aria-label="{{t "chat.input.mention_label"}}"></div>
                                     </div>
                                 </div>
-                                <input type="file" id="chat-file-input" class="chat-file-input-hidden" multiple accept="*" title="选择文件">
-                                <button type="button" class="chat-upload-btn" onclick="document.getElementById('chat-file-input').click()" title="上传文件（可多选或拖拽到此处）">
+                                <input type="file" id="chat-file-input" class="chat-file-input-hidden" multiple accept="*" title="{{t "chat.file.select"}}">
+                                <button type="button" class="chat-upload-btn" onclick="document.getElementById('chat-file-input').click()" title="{{t "chat.file.upload_title"}}">
                                     <svg width="18" height="18" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                                         <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M17 8l-5-5-5 5M12 3v12" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                                     </svg>
                                 </button>
                                 <button class="send-btn" onclick="sendMessage()">
-                                    <span>发送</span>
+                                    <span>{{t "chat.btn.send_label"}}</span>
                                     <svg width="14" height="14" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                                         <path d="M5 12h14M12 5l7 7-7 7" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                                     </svg>
@@ -549,50 +550,50 @@
                 <!-- MCP状态监控页面 -->
                 <div id="page-mcp-monitor" class="page">
                     <div class="page-header">
-                        <h2>MCP 状态监控</h2>
-                        <button class="btn-secondary" onclick="refreshMonitorPanel()">刷新</button>
+                        <h2>{{t "mcp_monitor.title"}}</h2>
+                        <button class="btn-secondary" onclick="refreshMonitorPanel()">{{t "ui.btn.refresh"}}</button>
                     </div>
                     <div class="page-content">
                         <div class="monitor-sections">
                             <section class="monitor-section monitor-overview">
                                 <div class="section-header">
-                                    <h3>执行统计</h3>
+                                    <h3>{{t "mcp_monitor.exec_stats"}}</h3>
                                 </div>
                                 <div id="monitor-stats" class="monitor-stats-grid">
-                                    <div class="monitor-empty">加载中...</div>
+                                    <div class="monitor-empty">{{t "ui.loading"}}</div>
                                 </div>
                             </section>
                             <section class="monitor-section monitor-executions">
                                 <div class="section-header">
-                                    <h3>最新执行记录</h3>
+                                    <h3>{{t "mcp_monitor.latest_records"}}</h3>
                                     <div class="section-actions">
                                         <label>
-                                            工具搜索
-                                            <input type="text" id="monitor-tool-filter" placeholder="输入工具名称..." oninput="handleToolFilterInput()" onkeydown="if(event.key==='Enter') applyMonitorFilters()" />
+                                            {{t "mcp_monitor.tool_search"}}
+                                            <input type="text" id="monitor-tool-filter" placeholder="{{t "mcp_monitor.tool_search_placeholder"}}" oninput="handleToolFilterInput()" onkeydown="if(event.key==='Enter') applyMonitorFilters()" />
                                         </label>
                                         <label>
-                                            状态筛选
+                                            {{t "mcp_monitor.status_filter"}}
                                             <select id="monitor-status-filter" onchange="applyMonitorFilters()">
-                                                <option value="all">全部</option>
-                                                <option value="completed">已完成</option>
-                                                <option value="running">执行中</option>
-                                                <option value="failed">失败</option>
+                                                <option value="all">{{t "mcp_monitor.status.all"}}</option>
+                                                <option value="completed">{{t "mcp_monitor.status.completed"}}</option>
+                                                <option value="running">{{t "mcp_monitor.status.running"}}</option>
+                                                <option value="failed">{{t "mcp_monitor.status.failed"}}</option>
                                             </select>
                                         </label>
                                     </div>
                                 </div>
                                 <div id="monitor-batch-actions" class="monitor-batch-actions" style="display: none;">
                                     <div class="batch-actions-info">
-                                        <span id="monitor-selected-count">已选择 0 项</span>
+                                        <span id="monitor-selected-count">{{t "mcp_monitor.selected_count"}}</span>
                                     </div>
                                     <div class="batch-actions-buttons">
-                                        <button class="btn-secondary" onclick="selectAllExecutions()">全选</button>
-                                        <button class="btn-secondary" onclick="deselectAllExecutions()">取消全选</button>
-                                        <button class="btn-secondary btn-delete" onclick="batchDeleteExecutions()">批量删除</button>
+                                        <button class="btn-secondary" onclick="selectAllExecutions()">{{t "mcp_monitor.select_all"}}</button>
+                                        <button class="btn-secondary" onclick="deselectAllExecutions()">{{t "mcp_monitor.deselect_all"}}</button>
+                                        <button class="btn-secondary btn-delete" onclick="batchDeleteExecutions()">{{t "mcp_monitor.batch_delete"}}</button>
                                     </div>
                                 </div>
                                 <div id="monitor-executions" class="monitor-table-container">
-                                    <div class="monitor-empty">加载中...</div>
+                                    <div class="monitor-empty">{{t "ui.loading"}}</div>
                                 </div>
                             </section>
                         </div>
@@ -602,26 +603,26 @@
                 <!-- MCP管理页面 -->
                 <div id="page-mcp-management" class="page">
                     <div class="page-header">
-                        <h2>MCP 管理</h2>
+                        <h2>{{t "mcp_mgmt.title"}}</h2>
                         <div class="page-header-actions">
-                            <button class="btn-secondary" onclick="loadExternalMCPs()">刷新</button>
-                            <button class="btn-primary" onclick="showAddExternalMCPModal()">添加外部MCP</button>
+                            <button class="btn-secondary" onclick="loadExternalMCPs()">{{t "ui.btn.refresh"}}</button>
+                            <button class="btn-primary" onclick="showAddExternalMCPModal()">{{t "mcp_mgmt.add_external"}}</button>
                         </div>
                     </div>
                     <div class="page-content">
                         <!-- MCP工具配置 -->
                         <div class="settings-section" style="margin-bottom: 32px;">
                             <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 16px;">
-                                <h3 style="margin: 0;">MCP 工具配置</h3>
-                                <button class="btn-primary" onclick="saveToolsConfig()">保存工具配置</button>
+                                <h3 style="margin: 0;">{{t "mcp_mgmt.tool_config"}}</h3>
+                                <button class="btn-primary" onclick="saveToolsConfig()">{{t "mcp_mgmt.save_tool_config"}}</button>
                             </div>
                             <div class="tools-controls">
                                 <div class="tools-actions">
-                                    <button class="btn-secondary" onclick="selectAllTools()">全选</button>
-                                    <button class="btn-secondary" onclick="deselectAllTools()">全不选</button>
+                                    <button class="btn-secondary" onclick="selectAllTools()">{{t "mcp_mgmt.select_all"}}</button>
+                                    <button class="btn-secondary" onclick="deselectAllTools()">{{t "mcp_mgmt.deselect_all"}}</button>
                                     <div class="search-box">
-                                        <input type="text" id="tools-search" placeholder="搜索工具..." onkeypress="handleSearchKeyPress(event)" oninput="if(this.value.trim() === '') clearSearch()" />
-                                        <button class="btn-search" onclick="searchTools()" title="搜索">🔍</button>
+                                        <input type="text" id="tools-search" placeholder="{{t "mcp_mgmt.search_placeholder"}}" onkeypress="handleSearchKeyPress(event)" oninput="if(this.value.trim() === '') clearSearch()" />
+                                        <button class="btn-search" onclick="searchTools()" title="{{t "mcp_mgmt.search"}}">🔍</button>
                                     </div>
                                     <div class="tools-stats" id="tools-stats"></div>
                                 </div>
@@ -631,7 +632,7 @@
 
                         <!-- 外部MCP配置 -->
                         <div class="settings-section">
-                            <h3>外部 MCP 配置</h3>
+                            <h3>{{t "mcp_mgmt.external_config"}}</h3>
                             <div class="external-mcp-controls">
                                 <div class="external-mcp-actions">
                                     <div class="external-mcp-stats" id="external-mcp-stats"></div>
@@ -645,55 +646,55 @@
                 <!-- 知识管理页面 -->
                 <div id="page-knowledge-management" class="page">
                     <div class="page-header">
-                        <h2>知识管理</h2>
+                        <h2>{{t "knowledge_mgmt.title"}}</h2>
                         <div class="page-header-actions">
-                            <button class="btn-secondary" onclick="refreshKnowledgeBase()">刷新</button>
-                            <button class="btn-secondary" onclick="rebuildKnowledgeIndex()">重建索引</button>
-                            <button class="btn-primary" onclick="showAddKnowledgeItemModal()">添加知识</button>
+                            <button class="btn-secondary" onclick="refreshKnowledgeBase()">{{t "ui.btn.refresh"}}</button>
+                            <button class="btn-secondary" onclick="rebuildKnowledgeIndex()">{{t "knowledge_mgmt.rebuild_index"}}</button>
+                            <button class="btn-primary" onclick="showAddKnowledgeItemModal()">{{t "knowledge_mgmt.add_knowledge"}}</button>
                         </div>
                     </div>
                     <div class="page-content">
                         <div class="knowledge-controls">
                             <div class="knowledge-stats-bar" id="knowledge-stats">
                                 <div class="knowledge-stat-item">
-                                    <span class="knowledge-stat-label">总知识项</span>
+                                    <span class="knowledge-stat-label">{{t "knowledge_mgmt.total_items"}}</span>
                                     <span class="knowledge-stat-value">-</span>
                                 </div>
                                 <div class="knowledge-stat-item">
-                                    <span class="knowledge-stat-label">分类数</span>
+                                    <span class="knowledge-stat-label">{{t "knowledge_mgmt.categories_count"}}</span>
                                     <span class="knowledge-stat-value">-</span>
                                 </div>
                                 <div class="knowledge-stat-item">
-                                    <span class="knowledge-stat-label">总内容</span>
+                                    <span class="knowledge-stat-label">{{t "knowledge_mgmt.total_content"}}</span>
                                     <span class="knowledge-stat-value">-</span>
                                 </div>
                             </div>
                             <div id="knowledge-index-progress" style="display: none; margin-bottom: 16px;"></div>
                             <div class="knowledge-filters">
                                 <label>
-                                    分类筛选
+                                    {{t "knowledge_mgmt.category_filter"}}
                                     <div class="custom-select-wrapper">
                                         <div class="custom-select" id="knowledge-category-filter-wrapper">
                                             <div class="custom-select-trigger" id="knowledge-category-filter-trigger">
-                                                <span>全部</span>
+                                                <span>{{t "knowledge_mgmt.all"}}</span>
                                                 <svg width="12" height="12" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                                                     <path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                                                 </svg>
                                             </div>
                                             <div class="custom-select-dropdown" id="knowledge-category-filter-dropdown">
-                                                <div class="custom-select-option" data-value="" onclick="selectKnowledgeCategory('')">全部</div>
+                                                <div class="custom-select-option" data-value="" onclick="selectKnowledgeCategory('')">{{t "knowledge_mgmt.all"}}</div>
                                             </div>
                                         </div>
                                     </div>
                                 </label>
                                 <div class="search-box">
-                                    <input type="text" id="knowledge-search" placeholder="搜索知识..." oninput="handleKnowledgeSearchInput()" onkeydown="if(event.key==='Enter') searchKnowledgeItems()" />
-                                    <button class="btn-search" onclick="searchKnowledgeItems()" title="搜索">🔍</button>
+                                    <input type="text" id="knowledge-search" placeholder="{{t "knowledge_mgmt.search_placeholder"}}" oninput="handleKnowledgeSearchInput()" onkeydown="if(event.key==='Enter') searchKnowledgeItems()" />
+                                    <button class="btn-search" onclick="searchKnowledgeItems()" title="{{t "ui.btn.search"}}">🔍</button>
                                 </div>
                             </div>
                         </div>
                         <div id="knowledge-items-list" class="knowledge-items-list">
-                            <div class="loading-spinner">加载中...</div>
+                            <div class="loading-spinner">{{t "ui.loading"}}</div>
                         </div>
                         <div id="knowledge-pagination"></div>
                     </div>
@@ -702,43 +703,43 @@
                 <!-- 知识检索历史页面 -->
                 <div id="page-knowledge-retrieval-logs" class="page">
                     <div class="page-header">
-                        <h2>检索历史</h2>
-                        <button class="btn-secondary" onclick="refreshRetrievalLogs()">刷新</button>
+                        <h2>{{t "knowledge_retrieval.title"}}</h2>
+                        <button class="btn-secondary" onclick="refreshRetrievalLogs()">{{t "ui.btn.refresh"}}</button>
                     </div>
                     <div class="page-content">
                         <div class="retrieval-logs-controls">
                             <div class="retrieval-stats-bar" id="retrieval-stats">
                                 <div class="retrieval-stat-item">
-                                    <span class="retrieval-stat-label">总检索次数</span>
+                                    <span class="retrieval-stat-label">{{t "knowledge_retrieval.total"}}</span>
                                     <span class="retrieval-stat-value">-</span>
                                 </div>
                                 <div class="retrieval-stat-item">
-                                    <span class="retrieval-stat-label">成功检索</span>
+                                    <span class="retrieval-stat-label">{{t "knowledge_retrieval.success"}}</span>
                                     <span class="retrieval-stat-value">-</span>
                                 </div>
                                 <div class="retrieval-stat-item">
-                                    <span class="retrieval-stat-label">成功率</span>
+                                    <span class="retrieval-stat-label">{{t "knowledge_retrieval.success_rate"}}</span>
                                     <span class="retrieval-stat-value">-</span>
                                 </div>
                                 <div class="retrieval-stat-item">
-                                    <span class="retrieval-stat-label">检索到知识项</span>
+                                    <span class="retrieval-stat-label">{{t "knowledge_retrieval.items_found"}}</span>
                                     <span class="retrieval-stat-value">-</span>
                                 </div>
                             </div>
                             <div class="retrieval-logs-filters">
                                 <label>
-                                    对话ID
-                                    <input type="text" id="retrieval-logs-conversation-id" placeholder="可选：筛选特定对话" />
+                                    {{t "knowledge_retrieval.conv_id"}}
+                                    <input type="text" id="retrieval-logs-conversation-id" placeholder="{{t "knowledge_retrieval.conv_placeholder"}}" />
                                 </label>
                                 <label>
-                                    消息ID
-                                    <input type="text" id="retrieval-logs-message-id" placeholder="可选：筛选特定消息" />
+                                    {{t "knowledge_retrieval.msg_id"}}
+                                    <input type="text" id="retrieval-logs-message-id" placeholder="{{t "knowledge_retrieval.msg_placeholder"}}" />
                                 </label>
-                                <button class="btn-secondary" onclick="filterRetrievalLogs()">筛选</button>
+                                <button class="btn-secondary" onclick="filterRetrievalLogs()">{{t "knowledge_retrieval.filter"}}</button>
                             </div>
                         </div>
                         <div id="retrieval-logs-list" class="retrieval-logs-list">
-                            <div class="loading-spinner">加载中...</div>
+                            <div class="loading-spinner">{{t "ui.loading"}}</div>
                         </div>
                     </div>
                 </div>
@@ -746,42 +747,42 @@
                 <!-- 信息收集页面 -->
                 <div id="page-info-collect" class="page">
                     <div class="page-header">
-                        <h2>信息收集</h2>
+                        <h2>{{t "info_collect.title"}}</h2>
                         <div class="page-header-actions">
-                            <button class="btn-secondary" onclick="resetFofaForm()">重置</button>
-                            <button class="btn-primary" onclick="submitFofaSearch()">确定</button>
+                            <button class="btn-secondary" onclick="resetFofaForm()">{{t "info_collect.reset"}}</button>
+                            <button class="btn-primary" onclick="submitFofaSearch()">{{t "info_collect.submit"}}</button>
                         </div>
                     </div>
                     <div class="page-content">
                         <div class="info-collect-panel">
                             <div class="info-collect-form">
                                 <div class="form-group">
-                                    <label for="fofa-query">FOFA 查询语法</label>
-                                    <textarea id="fofa-query" class="info-collect-query-input" rows="1" placeholder='例如：app="Apache" && country="CN"'></textarea>
-                                    <small class="form-hint">查询语法参考 FOFA 文档，支持 && / || / () 等。</small>
-                                    <div class="info-collect-presets" aria-label="FOFA 查询示例">
-                                        <button class="preset-chip" type="button" onclick="applyFofaQueryPreset('app=&quot;Apache&quot; &amp;&amp; country=&quot;CN&quot;')" title="填入示例">Apache + 中国</button>
-                                        <button class="preset-chip" type="button" onclick="applyFofaQueryPreset('title=&quot;登录&quot; &amp;&amp; country=&quot;CN&quot;')" title="填入示例">登录页 + 中国</button>
-                                        <button class="preset-chip" type="button" onclick="applyFofaQueryPreset('domain=&quot;example.com&quot;')" title="填入示例">指定域名</button>
-                                        <button class="preset-chip" type="button" onclick="applyFofaQueryPreset('ip=&quot;1.1.1.1&quot;')" title="填入示例">指定 IP</button>
+                                    <label for="fofa-query">{{t "info_collect.fofa_query"}}</label>
+                                    <textarea id="fofa-query" class="info-collect-query-input" rows="1" placeholder='{{t "info_collect.fofa_query_placeholder"}}'></textarea>
+                                    <small class="form-hint">{{t "info_collect.fofa_query_hint"}}</small>
+                                    <div class="info-collect-presets" aria-label="{{t "info_collect.fofa_query_presets_aria"}}">
+                                        <button class="preset-chip" type="button" onclick="applyFofaQueryPreset('app=&quot;Apache&quot; &amp;&amp; country=&quot;CN&quot;')" title="{{t "info_collect.preset.fill_hint"}}">{{t "info_collect.preset.apache_cn"}}</button>
+                                        <button class="preset-chip" type="button" onclick="applyFofaQueryPreset('title=&quot;登录&quot; &amp;&amp; country=&quot;CN&quot;')" title="{{t "info_collect.preset.fill_hint"}}">{{t "info_collect.preset.login_cn"}}</button>
+                                        <button class="preset-chip" type="button" onclick="applyFofaQueryPreset('domain=&quot;example.com&quot;')" title="{{t "info_collect.preset.fill_hint"}}">{{t "info_collect.preset.domain"}}</button>
+                                        <button class="preset-chip" type="button" onclick="applyFofaQueryPreset('ip=&quot;1.1.1.1&quot;')" title="{{t "info_collect.preset.fill_hint"}}">{{t "info_collect.preset.ip"}}</button>
                                     </div>
                                 </div>
                                 <div class="form-group">
-                                    <label for="fofa-nl">自然语言（AI 解析为 FOFA 语法）</label>
+                                    <label for="fofa-nl">{{t "info_collect.nl_label"}}</label>
                                     <div class="info-collect-nl-row">
-                                        <textarea id="fofa-nl" class="info-collect-query-input" rows="1" placeholder="例如：找美国 Missouri 的 Apache 站点，标题包含 Home"></textarea>
-                                        <button id="fofa-nl-parse-btn" class="btn-secondary" type="button" onclick="parseFofaNaturalLanguage()" title="将自然语言解析为 FOFA 查询语法">AI 解析</button>
+                                        <textarea id="fofa-nl" class="info-collect-query-input" rows="1" placeholder="{{t "info_collect.nl_placeholder"}}"></textarea>
+                                        <button id="fofa-nl-parse-btn" class="btn-secondary" type="button" onclick="parseFofaNaturalLanguage()" title="{{t "info_collect.nl_parse_title"}}">{{t "info_collect.nl_parse"}}</button>
                                     </div>
                                     <div id="fofa-nl-status" class="fofa-nl-status muted" style="display: none;" aria-live="polite"></div>
-                                    <small class="form-hint">解析后会弹窗展示 FOFA 语法（可编辑），确认无误后再填入查询框并执行查询。</small>
+                                    <small class="form-hint">{{t "info_collect.nl_hint"}}</small>
                                 </div>
                                 <div class="info-collect-form-row">
                                     <div class="form-group">
-                                        <label for="fofa-size">返回数量</label>
+                                        <label for="fofa-size">{{t "info_collect.return_count"}}</label>
                                         <input type="number" id="fofa-size" min="1" max="10000" value="100" />
                                     </div>
                                     <div class="form-group">
-                                        <label for="fofa-page">页码</label>
+                                        <label for="fofa-page">{{t "info_collect.page_num"}}</label>
                                         <input type="number" id="fofa-page" min="1" value="1" />
                                     </div>
                                     <div class="form-group">
@@ -793,12 +794,12 @@
                                     </div>
                                 </div>
                                 <div class="form-group">
-                                    <label for="fofa-fields">返回字段名（逗号分隔）</label>
+                                    <label for="fofa-fields">{{t "info_collect.return_fields"}}</label>
                                     <input type="text" id="fofa-fields" value="host,ip,port,domain,title,protocol,country,province,city,server" />
-                                    <div class="info-collect-presets" aria-label="FOFA 字段模板">
-                                        <button class="preset-chip" type="button" onclick="applyFofaFieldsPreset('host,ip,port,domain')" title="适合快速导出目标">最小字段</button>
-                                        <button class="preset-chip" type="button" onclick="applyFofaFieldsPreset('host,title,ip,port,domain,protocol,server,icp,country,province,city')" title="适合浏览和筛选">Web 常用</button>
-                                        <button class="preset-chip" type="button" onclick="applyFofaFieldsPreset('host,ip,port,domain,title,protocol,country,province,city,server,as_number,as_organization,icp,header,banner')" title="更偏指纹/情报">情报增强</button>
+                                    <div class="info-collect-presets" aria-label="{{t "info_collect.fofa_fields_presets_aria"}}">
+                                        <button class="preset-chip" type="button" onclick="applyFofaFieldsPreset('host,ip,port,domain')" title="{{t "info_collect.preset.minimal_hint"}}">{{t "info_collect.preset.minimal"}}</button>
+                                        <button class="preset-chip" type="button" onclick="applyFofaFieldsPreset('host,title,ip,port,domain,protocol,server,icp,country,province,city')" title="{{t "info_collect.preset.web_common_hint"}}">{{t "info_collect.preset.web_common"}}</button>
+                                        <button class="preset-chip" type="button" onclick="applyFofaFieldsPreset('host,ip,port,domain,title,protocol,country,province,city,server,as_number,as_organization,icp,header,banner')" title="{{t "info_collect.preset.intel_hint"}}">{{t "info_collect.preset.intel"}}</button>
                                     </div>
                                 </div>
                             </div>
@@ -807,27 +808,27 @@
                         <div class="info-collect-results">
                             <div class="info-collect-results-header">
                                 <div class="info-collect-results-header-left">
-                                    <div class="info-collect-results-title">查询结果</div>
+                                    <div class="info-collect-results-title">{{t "info_collect.results_title"}}</div>
                                     <div class="info-collect-results-meta" id="fofa-results-meta">-</div>
                                 </div>
-                                <div class="info-collect-results-toolbar" aria-label="结果工具条">
-                                    <div class="info-collect-selected" id="fofa-selected-meta">已选择 0 条</div>
-                                    <button class="btn-secondary btn-small" type="button" onclick="toggleFofaColumnsPanel()" title="显示/隐藏字段">列</button>
-                                    <button class="btn-secondary btn-small" type="button" onclick="exportFofaResults('csv')" title="导出当前结果为 CSV（UTF-8，兼容中文）">导出 CSV</button>
-                                    <button class="btn-secondary btn-small" type="button" onclick="exportFofaResults('json')" title="导出当前结果为 JSON">导出 JSON</button>
-                                    <button class="btn-secondary btn-small" type="button" onclick="exportFofaResults('xlsx')" title="导出当前结果为 Excel">导出 XLSX</button>
-                                    <button class="btn-primary btn-small" type="button" onclick="batchScanSelectedFofaRows()" title="将所选行创建为批量任务队列">批量扫描</button>
+                                <div class="info-collect-results-toolbar" aria-label="{{t "info_collect.results_toolbar"}}">
+                                    <div class="info-collect-selected" id="fofa-selected-meta">{{t "info_collect.selected"}}</div>
+                                    <button class="btn-secondary btn-small" type="button" onclick="toggleFofaColumnsPanel()" title="{{t "info_collect.columns_toggle"}}">{{t "info_collect.columns"}}</button>
+                                    <button class="btn-secondary btn-small" type="button" onclick="exportFofaResults('csv')" title="{{t "info_collect.export_csv_title"}}">{{t "info_collect.export_csv"}}</button>
+                                    <button class="btn-secondary btn-small" type="button" onclick="exportFofaResults('json')" title="{{t "info_collect.export_json_title"}}">{{t "info_collect.export_json"}}</button>
+                                    <button class="btn-secondary btn-small" type="button" onclick="exportFofaResults('xlsx')" title="{{t "info_collect.export_xlsx_title"}}">{{t "info_collect.export_xlsx"}}</button>
+                                    <button class="btn-primary btn-small" type="button" onclick="batchScanSelectedFofaRows()" title="{{t "info_collect.batch_scan_title"}}">{{t "info_collect.batch_scan"}}</button>
                                 </div>
                             </div>
                             <div class="info-collect-results-table-wrap">
                                 <!-- 字段显示/隐藏面板 -->
                                 <div id="fofa-columns-panel" class="info-collect-columns-panel" style="display: none;">
                                     <div class="info-collect-columns-panel-header">
-                                        <div class="info-collect-columns-title">显示字段</div>
+                                        <div class="info-collect-columns-title">{{t "info_collect.show_fields"}}</div>
                                         <div class="info-collect-columns-actions">
-                                            <button class="btn-secondary btn-small" type="button" onclick="showAllFofaColumns()">全选</button>
-                                            <button class="btn-secondary btn-small" type="button" onclick="hideAllFofaColumns()">全不选</button>
-                                            <button class="btn-secondary btn-small" type="button" onclick="closeFofaColumnsPanel()">关闭</button>
+                                            <button class="btn-secondary btn-small" type="button" onclick="showAllFofaColumns()">{{t "info_collect.show_all"}}</button>
+                                            <button class="btn-secondary btn-small" type="button" onclick="hideAllFofaColumns()">{{t "info_collect.hide_all"}}</button>
+                                            <button class="btn-secondary btn-small" type="button" onclick="closeFofaColumnsPanel()">{{t "ui.btn.close"}}</button>
                                         </div>
                                     </div>
                                     <div id="fofa-columns-list" class="info-collect-columns-list"></div>
@@ -835,7 +836,7 @@
                                 <table class="info-collect-table">
                                     <thead id="fofa-results-thead"></thead>
                                     <tbody id="fofa-results-tbody">
-                                        <tr><td class="muted" style="padding: 16px;">暂无数据</td></tr>
+                                        <tr><td class="muted" style="padding: 16px;">{{t "dashboard.no_data"}}</td></tr>
                                     </tbody>
                                 </table>
                             </div>
@@ -846,10 +847,10 @@
                 <!-- 漏洞管理页面 -->
                 <div id="page-vulnerabilities" class="page">
                     <div class="page-header">
-                        <h2>漏洞管理</h2>
+                        <h2>{{t "vuln.page.title"}}</h2>
                         <div class="page-header-actions">
-                            <button class="btn-secondary" onclick="refreshVulnerabilities()">刷新</button>
-                            <button class="btn-primary" onclick="showAddVulnerabilityModal()">添加漏洞</button>
+                            <button class="btn-secondary" onclick="refreshVulnerabilities()">{{t "ui.btn.refresh"}}</button>
+                            <button class="btn-primary" onclick="showAddVulnerabilityModal()">{{t "vuln.page.add"}}</button>
                         </div>
                     </div>
                     <div class="page-content">
@@ -857,27 +858,27 @@
                         <div class="vulnerability-dashboard" id="vulnerability-dashboard">
                             <div class="dashboard-stats">
                                 <div class="stat-card">
-                                    <div class="stat-label">总漏洞数</div>
+                                    <div class="stat-label">{{t "vuln.stat.total"}}</div>
                                     <div class="stat-value" id="stat-total">-</div>
                                 </div>
                                 <div class="stat-card stat-critical">
-                                    <div class="stat-label">严重</div>
+                                    <div class="stat-label">{{t "vuln.severity.critical"}}</div>
                                     <div class="stat-value" id="stat-critical">-</div>
                                 </div>
                                 <div class="stat-card stat-high">
-                                    <div class="stat-label">高危</div>
+                                    <div class="stat-label">{{t "vuln.severity.high"}}</div>
                                     <div class="stat-value" id="stat-high">-</div>
                                 </div>
                                 <div class="stat-card stat-medium">
-                                    <div class="stat-label">中危</div>
+                                    <div class="stat-label">{{t "vuln.severity.medium"}}</div>
                                     <div class="stat-value" id="stat-medium">-</div>
                                 </div>
                                 <div class="stat-card stat-low">
-                                    <div class="stat-label">低危</div>
+                                    <div class="stat-label">{{t "vuln.severity.low"}}</div>
                                     <div class="stat-value" id="stat-low">-</div>
                                 </div>
                                 <div class="stat-card stat-info">
-                                    <div class="stat-label">信息</div>
+                                    <div class="stat-label">{{t "vuln.severity.info"}}</div>
                                     <div class="stat-value" id="stat-info">-</div>
                                 </div>
                             </div>
@@ -887,42 +888,42 @@
                         <div class="vulnerability-controls">
                             <div class="vulnerability-filters">
                                 <label>
-                                    漏洞ID
-                                    <input type="text" id="vulnerability-id-filter" placeholder="搜索漏洞ID" />
+                                    {{t "vuln.filter.vuln_id"}}
+                                    <input type="text" id="vulnerability-id-filter" placeholder="{{t "vuln.filter.vuln_id_placeholder"}}" />
                                 </label>
                                 <label>
-                                    会话ID
-                                    <input type="text" id="vulnerability-conversation-filter" placeholder="筛选特定会话" />
+                                    {{t "vuln.filter.session_id"}}
+                                    <input type="text" id="vulnerability-conversation-filter" placeholder="{{t "vuln.filter.session_placeholder"}}" />
                                 </label>
                                 <label>
-                                    严重程度
+                                    {{t "vuln.filter.severity"}}
                                     <select id="vulnerability-severity-filter">
-                                        <option value="">全部</option>
-                                        <option value="critical">严重</option>
-                                        <option value="high">高危</option>
-                                        <option value="medium">中危</option>
-                                        <option value="low">低危</option>
-                                        <option value="info">信息</option>
+                                        <option value="">{{t "vuln.filter.all"}}</option>
+                                        <option value="critical">{{t "vuln.severity.critical"}}</option>
+                                        <option value="high">{{t "vuln.severity.high"}}</option>
+                                        <option value="medium">{{t "vuln.severity.medium"}}</option>
+                                        <option value="low">{{t "vuln.severity.low"}}</option>
+                                        <option value="info">{{t "vuln.severity.info"}}</option>
                                     </select>
                                 </label>
                                 <label>
-                                    状态
+                                    {{t "vuln.filter.status"}}
                                     <select id="vulnerability-status-filter">
-                                        <option value="">全部</option>
-                                        <option value="open">待处理</option>
-                                        <option value="confirmed">已确认</option>
-                                        <option value="fixed">已修复</option>
-                                        <option value="false_positive">误报</option>
+                                        <option value="">{{t "vuln.filter.all"}}</option>
+                                        <option value="open">{{t "vuln.filter.status_open"}}</option>
+                                        <option value="confirmed">{{t "vuln.filter.status_confirmed"}}</option>
+                                        <option value="fixed">{{t "vuln.filter.status_fixed"}}</option>
+                                        <option value="false_positive">{{t "vuln.filter.status_false_positive"}}</option>
                                     </select>
                                 </label>
-                                <button class="btn-secondary" onclick="filterVulnerabilities()">筛选</button>
-                                <button class="btn-secondary" onclick="clearVulnerabilityFilters()">清除</button>
+                                <button class="btn-secondary" onclick="filterVulnerabilities()">{{t "vuln.filter.filter_btn"}}</button>
+                                <button class="btn-secondary" onclick="clearVulnerabilityFilters()">{{t "vuln.filter.clear_btn"}}</button>
                             </div>
                         </div>
 
                         <!-- 漏洞列表 -->
                         <div id="vulnerabilities-list" class="vulnerabilities-list">
-                            <div class="loading-spinner">加载中...</div>
+                            <div class="loading-spinner">{{t "ui.loading"}}</div>
                         </div>
                         
                         <!-- 分页控件 -->
@@ -933,14 +934,14 @@
                 <!-- 任务管理页面 -->
                 <div id="page-tasks" class="page">
                     <div class="page-header">
-                        <h2>任务管理</h2>
+                        <h2>{{t "task.page.title"}}</h2>
                         <div class="page-header-actions">
-                            <button class="btn-primary" onclick="showBatchImportModal()">新建任务</button>
+                            <button class="btn-primary" onclick="showBatchImportModal()">{{t "task.page.new"}}</button>
                             <label class="auto-refresh-toggle">
                                 <input type="checkbox" id="tasks-auto-refresh" checked onchange="toggleTasksAutoRefresh(this.checked)">
-                                <span>自动刷新</span>
+                                <span>{{t "task.page.auto_refresh"}}</span>
                             </label>
-                            <button class="btn-secondary" onclick="refreshBatchQueues()">刷新</button>
+                            <button class="btn-secondary" onclick="refreshBatchQueues()">{{t "ui.btn.refresh"}}</button>
                         </div>
                     </div>
                     <div class="page-content">
@@ -949,19 +950,19 @@
                             <!-- 筛选控件 -->
                             <div class="batch-queues-filters tasks-filters">
                                 <label>
-                                    <span>状态筛选</span>
+                                    <span>{{t "task.filter.status"}}</span>
                                     <select id="batch-queues-status-filter" onchange="filterBatchQueues()">
-                                        <option value="all">全部</option>
-                                        <option value="pending">待执行</option>
-                                        <option value="running">执行中</option>
-                                        <option value="paused">已暂停</option>
-                                        <option value="completed">已完成</option>
-                                        <option value="cancelled">已取消</option>
+                                        <option value="all">{{t "task.filter.all"}}</option>
+                                        <option value="pending">{{t "task.filter.pending"}}</option>
+                                        <option value="running">{{t "task.filter.running"}}</option>
+                                        <option value="paused">{{t "task.filter.paused"}}</option>
+                                        <option value="completed">{{t "task.filter.completed"}}</option>
+                                        <option value="cancelled">{{t "task.filter.cancelled"}}</option>
                                     </select>
                                 </label>
                                 <label style="flex: 1; max-width: 300px;">
-                                    <span>搜索队列ID、标题或创建时间</span>
-                                    <input type="text" id="batch-queues-search" placeholder="输入关键字搜索..." 
+                                    <span>{{t "task.filter.search"}}</span>
+                                    <input type="text" id="batch-queues-search" placeholder="{{t "task.filter.search_placeholder"}}" 
                                            oninput="filterBatchQueues()">
                                 </label>
                             </div>
@@ -975,17 +976,17 @@
                 <!-- 角色管理页面 -->
                 <div id="page-roles-management" class="page">
                     <div class="page-header">
-                        <h2>角色管理</h2>
+                        <h2>{{t "roles_mgmt.title"}}</h2>
                         <div class="page-header-actions">
-                            <button class="btn-secondary" onclick="refreshRoles()">刷新</button>
-                            <button class="btn-primary" onclick="showAddRoleModal()">创建角色</button>
+                            <button class="btn-secondary" onclick="refreshRoles()">{{t "ui.btn.refresh"}}</button>
+                            <button class="btn-primary" onclick="showAddRoleModal()">{{t "roles_mgmt.create"}}</button>
                         </div>
                     </div>
                     <div class="page-content">
                         <div class="roles-controls">
                             <div class="roles-search-box">
-                                <input type="text" id="roles-search" placeholder="搜索角色..." oninput="handleRolesSearchInput()" onkeydown="if(event.key==='Enter') searchRoles()" />
-                                <button class="roles-search-clear" id="roles-search-clear" onclick="clearRolesSearch()" style="display: none;" title="清除搜索">
+                                <input type="text" id="roles-search" placeholder="{{t "roles_mgmt.search_placeholder"}}" oninput="handleRolesSearchInput()" onkeydown="if(event.key==='Enter') searchRoles()" />
+                                <button class="roles-search-clear" id="roles-search-clear" onclick="clearRolesSearch()" style="display: none;" title="{{t "roles_mgmt.clear_search"}}">
                                     <svg width="14" height="14" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                                         <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
                                         <path d="M15 9l-6 6M9 9l6 6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
@@ -994,7 +995,7 @@
                             </div>
                         </div>
                         <div id="roles-list" class="roles-grid">
-                            <div class="loading-spinner">加载中...</div>
+                            <div class="loading-spinner">{{t "ui.loading"}}</div>
                         </div>
                     </div>
                 </div>
@@ -1002,30 +1003,30 @@
                 <!-- Skills状态监控页面 -->
                 <div id="page-skills-monitor" class="page">
                     <div class="page-header">
-                        <h2>Skills状态监控</h2>
+                        <h2>{{t "skills_monitor.title"}}</h2>
                         <div class="page-header-actions">
-                            <button class="btn-secondary" onclick="refreshSkillsMonitor()">刷新</button>
+                            <button class="btn-secondary" onclick="refreshSkillsMonitor()">{{t "ui.btn.refresh"}}</button>
                         </div>
                     </div>
                     <div class="page-content">
                         <div class="monitor-sections">
                             <section class="monitor-section monitor-overview">
                                 <div class="section-header">
-                                    <h3>调用统计</h3>
+                                    <h3>{{t "skills_monitor.call_stats"}}</h3>
                                 </div>
                                 <div id="skills-stats" class="monitor-stats-grid">
-                                    <div class="monitor-empty">加载中...</div>
+                                    <div class="monitor-empty">{{t "ui.loading"}}</div>
                                 </div>
                             </section>
                             <section class="monitor-section monitor-executions">
                                 <div class="section-header">
-                                    <h3>Skills调用统计</h3>
+                                    <h3>{{t "skills_monitor.skills_call_stats"}}</h3>
                                     <div class="section-actions">
-                                        <button class="btn-secondary btn-small" onclick="clearSkillsStats()" title="清空所有统计数据">清空统计</button>
+                                        <button class="btn-secondary btn-small" onclick="clearSkillsStats()" title="{{t "skills_monitor.clear_stats"}}">{{t "skills_monitor.clear_stats"}}</button>
                                     </div>
                                 </div>
                                 <div id="skills-monitor-list" class="monitor-table-container">
-                                    <div class="monitor-empty">加载中...</div>
+                                    <div class="monitor-empty">{{t "ui.loading"}}</div>
                                 </div>
                             </section>
                         </div>
@@ -1035,17 +1036,17 @@
                 <!-- Skills管理页面 -->
                 <div id="page-skills-management" class="page">
                     <div class="page-header">
-                        <h2>Skills管理</h2>
+                        <h2>{{t "skills_mgmt.title"}}</h2>
                         <div class="page-header-actions">
-                            <button class="btn-secondary" onclick="refreshSkills()">刷新</button>
-                            <button class="btn-primary" onclick="showAddSkillModal()">创建Skill</button>
+                            <button class="btn-secondary" onclick="refreshSkills()">{{t "ui.btn.refresh"}}</button>
+                            <button class="btn-primary" onclick="showAddSkillModal()">{{t "skills_mgmt.create"}}</button>
                         </div>
                     </div>
                     <div class="page-content page-content-with-pagination">
                         <div class="skills-controls">
                             <div class="skills-search-box">
-                                <input type="text" id="skills-search" placeholder="搜索Skills..." oninput="handleSkillsSearchInput()" onkeydown="if(event.key==='Enter') searchSkills()" />
-                                <button class="skills-search-clear" id="skills-search-clear" onclick="clearSkillsSearch()" style="display: none;" title="清除搜索">
+                                <input type="text" id="skills-search" placeholder="{{t "skills_mgmt.search_placeholder"}}" oninput="handleSkillsSearchInput()" onkeydown="if(event.key==='Enter') searchSkills()" />
+                                <button class="skills-search-clear" id="skills-search-clear" onclick="clearSkillsSearch()" style="display: none;" title="{{t "skills_mgmt.clear_search"}}">
                                     <svg width="14" height="14" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                                         <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
                                         <path d="M15 9l-6 6M9 9l6 6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
@@ -1054,7 +1055,7 @@
                             </div>
                         </div>
                         <div id="skills-list" class="skills-grid">
-                            <div class="loading-spinner">加载中...</div>
+                            <div class="loading-spinner">{{t "ui.loading"}}</div>
                         </div>
                         <div id="skills-pagination" class="pagination-container pagination-fixed"></div>
                     </div>
@@ -1063,23 +1064,23 @@
                 <!-- 系统设置页面 -->
                 <div id="page-settings" class="page">
                     <div class="page-header">
-                        <h2>系统设置</h2>
+                        <h2>{{t "settings.page.title"}}</h2>
                     </div>
                     <div class="page-content settings-layout">
                         <!-- 左侧导航栏 -->
                         <aside class="settings-sidebar">
                             <nav class="settings-nav">
                                 <div class="settings-nav-item active" data-section="basic" onclick="switchSettingsSection('basic')">
-                                    <span>基本设置</span>
+                                    <span>{{t "settings.nav.basic"}}</span>
                                 </div>
                                 <div class="settings-nav-item" data-section="robots" onclick="switchSettingsSection('robots')">
-                                    <span>机器人设置</span>
+                                    <span>{{t "settings.nav.robots"}}</span>
                                 </div>
                                 <div class="settings-nav-item" data-section="terminal" onclick="switchSettingsSection('terminal')">
-                                    <span>终端</span>
+                                    <span>{{t "settings.nav.terminal"}}</span>
                                 </div>
                                 <div class="settings-nav-item" data-section="security" onclick="switchSettingsSection('security')">
-                                    <span>安全设置</span>
+                                    <span>{{t "settings.nav.security"}}</span>
                                 </div>
                             </nav>
                         </aside>
@@ -1089,12 +1090,12 @@
                             <!-- 基本设置 -->
                             <div id="settings-section-basic" class="settings-section-content active">
                                 <div class="settings-section-header">
-                                    <h3>基本设置</h3>
+                                    <h3>{{t "settings.basic.title"}}</h3>
                                 </div>
-                                
+
                                 <!-- OpenAI配置 -->
                                 <div class="settings-subsection">
-                                    <h4>OpenAI 配置</h4>
+                                    <h4>{{t "settings.openai.title"}}</h4>
                                     <div class="settings-form">
                                         <div class="form-group">
                                             <label for="openai-base-url">Base URL <span style="color: red;">*</span></label>
@@ -1102,10 +1103,10 @@
                                         </div>
                                         <div class="form-group">
                                             <label for="openai-api-key">API Key <span style="color: red;">*</span></label>
-                                            <input type="password" id="openai-api-key" placeholder="输入OpenAI API Key" required />
+                                            <input type="password" id="openai-api-key" placeholder="{{t "settings.openai.api_key_placeholder"}}" required />
                                         </div>
                                         <div class="form-group">
-                                            <label for="openai-model">模型 <span style="color: red;">*</span></label>
+                                            <label for="openai-model">{{t "settings.openai.model"}} <span style="color: red;">*</span></label>
                                             <input type="text" id="openai-model" placeholder="gpt-4" required />
                                         </div>
                                     </div>
@@ -1113,31 +1114,31 @@
 
                                 <!-- FOFA配置 -->
                                 <div class="settings-subsection">
-                                    <h4>FOFA 配置</h4>
+                                    <h4>{{t "settings.fofa.title"}}</h4>
                                     <div class="settings-form">
                                         <div class="form-group">
                                             <label for="fofa-base-url">Base URL</label>
-                                            <input type="text" id="fofa-base-url" placeholder="https://fofa.info/api/v1/search/all（可选）" />
-                                            <small class="form-hint">留空则使用默认地址。</small>
+                                            <input type="text" id="fofa-base-url" placeholder="{{t "settings.fofa.base_url_placeholder"}}" />
+                                            <small class="form-hint">{{t "settings.fofa.base_url_hint"}}</small>
                                         </div>
                                         <div class="form-group">
                                             <label for="fofa-email">Email</label>
-                                            <input type="text" id="fofa-email" placeholder="输入 FOFA 账号邮箱" autocomplete="off" />
+                                            <input type="text" id="fofa-email" placeholder="{{t "settings.fofa.email_placeholder"}}" autocomplete="off" />
                                         </div>
                                         <div class="form-group">
                                             <label for="fofa-api-key">API Key</label>
-                                            <input type="password" id="fofa-api-key" placeholder="输入 FOFA API Key" autocomplete="off" />
-                                            <small class="form-hint">仅保存在服务器配置中（`config.yaml`）。</small>
+                                            <input type="password" id="fofa-api-key" placeholder="{{t "settings.fofa.api_key_placeholder"}}" autocomplete="off" />
+                                            <small class="form-hint">{{t "settings.fofa.api_key_hint"}}</small>
                                         </div>
                                     </div>
                                 </div>
 
                                 <!-- Agent配置 -->
                                 <div class="settings-subsection">
-                                    <h4>Agent 配置</h4>
+                                    <h4>{{t "settings.agent.title"}}</h4>
                                     <div class="settings-form">
                                         <div class="form-group">
-                                            <label for="agent-max-iterations">最大迭代次数</label>
+                                            <label for="agent-max-iterations">{{t "settings.agent.max_iterations"}}</label>
                                             <input type="number" id="agent-max-iterations" min="1" max="100" placeholder="30" />
                                         </div>
                                     </div>
@@ -1145,124 +1146,124 @@
 
                                 <!-- 知识库配置 -->
                                 <div class="settings-subsection">
-                                    <h4>知识库配置</h4>
+                                    <h4>{{t "settings.knowledge.title"}}</h4>
                                     <div class="settings-form">
                                         <div class="form-group">
                                             <label class="checkbox-label">
                                                 <input type="checkbox" id="knowledge-enabled" class="modern-checkbox" />
                                                 <span class="checkbox-custom"></span>
-                                                <span class="checkbox-text">启用知识检索功能</span>
+                                                <span class="checkbox-text">{{t "settings.knowledge.enabled"}}</span>
                                             </label>
                                         </div>
                                         <div class="form-group">
-                                            <label for="knowledge-base-path">知识库路径</label>
+                                            <label for="knowledge-base-path">{{t "settings.knowledge.base_path"}}</label>
                                             <input type="text" id="knowledge-base-path" placeholder="knowledge_base" />
-                                            <small class="form-hint">相对于配置文件所在目录的路径</small>
+                                            <small class="form-hint">{{t "settings.knowledge.base_path_hint"}}</small>
                                         </div>
                                         
                                         <div class="settings-subsection-header">
-                                            <h5>嵌入模型配置</h5>
+                                            <h5>{{t "settings.knowledge.embedding_title"}}</h5>
                                         </div>
                                         <div class="form-group">
-                                            <label for="knowledge-embedding-provider">提供商</label>
+                                            <label for="knowledge-embedding-provider">{{t "settings.knowledge.provider"}}</label>
                                             <select id="knowledge-embedding-provider">
                                                 <option value="openai">OpenAI</option>
                                             </select>
                                         </div>
                                         <div class="form-group">
                                             <label for="knowledge-embedding-base-url">Base URL</label>
-                                            <input type="text" id="knowledge-embedding-base-url" placeholder="留空则使用OpenAI配置的base_url" />
-                                            <small class="form-hint">留空则使用OpenAI配置的base_url</small>
+                                            <input type="text" id="knowledge-embedding-base-url" placeholder="{{t "settings.knowledge.embedding_base_url_placeholder"}}" />
+                                            <small class="form-hint">{{t "settings.knowledge.embedding_base_url_placeholder"}}</small>
                                         </div>
                                         <div class="form-group">
                                             <label for="knowledge-embedding-api-key">API Key</label>
-                                            <input type="password" id="knowledge-embedding-api-key" placeholder="留空则使用OpenAI配置的api_key" />
-                                            <small class="form-hint">留空则使用OpenAI配置的api_key</small>
+                                            <input type="password" id="knowledge-embedding-api-key" placeholder="{{t "settings.knowledge.embedding_api_key_placeholder"}}" />
+                                            <small class="form-hint">{{t "settings.knowledge.embedding_api_key_placeholder"}}</small>
                                         </div>
                                         <div class="form-group">
-                                            <label for="knowledge-embedding-model">模型名称</label>
+                                            <label for="knowledge-embedding-model">{{t "settings.knowledge.embedding_model"}}</label>
                                             <input type="text" id="knowledge-embedding-model" placeholder="text-embedding-v4" />
                                         </div>
                                         
                                         <div class="settings-subsection-header">
-                                            <h5>检索配置</h5>
+                                            <h5>{{t "settings.knowledge.retrieval_title"}}</h5>
                                         </div>
                                         <div class="form-group">
-                                            <label for="knowledge-retrieval-top-k">Top-K 结果数量</label>
+                                            <label for="knowledge-retrieval-top-k">{{t "settings.knowledge.top_k"}}</label>
                                             <input type="number" id="knowledge-retrieval-top-k" min="1" max="20" placeholder="5" />
-                                            <small class="form-hint">检索返回的Top-K结果数量</small>
+                                            <small class="form-hint">{{t "settings.knowledge.top_k_hint"}}</small>
                                         </div>
                                         <div class="form-group">
-                                            <label for="knowledge-retrieval-similarity-threshold">相似度阈值</label>
+                                            <label for="knowledge-retrieval-similarity-threshold">{{t "settings.knowledge.similarity"}}</label>
                                             <input type="number" id="knowledge-retrieval-similarity-threshold" min="0" max="1" step="0.1" placeholder="0.7" />
-                                            <small class="form-hint">相似度阈值（0-1），低于此值的结果将被过滤</small>
+                                            <small class="form-hint">{{t "settings.knowledge.similarity_hint"}}</small>
                                         </div>
                                         <div class="form-group">
-                                            <label for="knowledge-retrieval-hybrid-weight">混合检索权重</label>
+                                            <label for="knowledge-retrieval-hybrid-weight">{{t "settings.knowledge.hybrid_weight"}}</label>
                                             <input type="number" id="knowledge-retrieval-hybrid-weight" min="0" max="1" step="0.1" placeholder="0.7" />
-                                            <small class="form-hint">向量检索的权重（0-1），1.0表示纯向量检索，0.0表示纯关键词检索</small>
+                                            <small class="form-hint">{{t "settings.knowledge.hybrid_weight_hint"}}</small>
                                         </div>
                                     </div>
                                         <div class="settings-subsection-header">
-                                            <h5>索引配置</h5>
+                                            <h5>{{t "settings.knowledge.indexing_title"}}</h5>
                                         </div>
                                         <div class="form-group">
-                                            <label for="knowledge-indexing-chunk-size">分块大小（Chunk Size）</label>
+                                            <label for="knowledge-indexing-chunk-size">{{t "settings.knowledge.chunk_size"}}</label>
                                             <input type="number" id="knowledge-indexing-chunk-size" min="128" max="4096" placeholder="512" />
-                                            <small class="form-hint">每个块的最大 token 数（默认 512），长文本会被分割成多个块</small>
+                                            <small class="form-hint">{{t "settings.knowledge.chunk_size_hint"}}</small>
                                         </div>
                                         <div class="form-group">
-                                            <label for="knowledge-indexing-chunk-overlap">分块重叠（Chunk Overlap）</label>
+                                            <label for="knowledge-indexing-chunk-overlap">{{t "settings.knowledge.chunk_overlap"}}</label>
                                             <input type="number" id="knowledge-indexing-chunk-overlap" min="0" max="512" placeholder="50" />
-                                            <small class="form-hint">块之间的重叠 token 数（默认 50），保持上下文连贯性</small>
+                                            <small class="form-hint">{{t "settings.knowledge.chunk_overlap_hint"}}</small>
                                         </div>
                                         <div class="form-group">
-                                            <label for="knowledge-indexing-max-chunks-per-item">单个知识项最大块数</label>
+                                            <label for="knowledge-indexing-max-chunks-per-item">{{t "settings.knowledge.max_chunks"}}</label>
                                             <input type="number" id="knowledge-indexing-max-chunks-per-item" min="0" max="1000" placeholder="0" />
-                                            <small class="form-hint">单个知识项的最大块数量（0 表示不限制），防止单个文件消耗过多 API 配额</small>
+                                            <small class="form-hint">{{t "settings.knowledge.max_chunks_hint"}}</small>
                                         </div>
                                         <div class="form-group">
-                                            <label for="knowledge-indexing-max-rpm">每分钟最大请求数（Max RPM）</label>
+                                            <label for="knowledge-indexing-max-rpm">{{t "settings.knowledge.max_rpm"}}</label>
                                             <input type="number" id="knowledge-indexing-max-rpm" min="0" max="1000" placeholder="0" />
-                                            <small class="form-hint">每分钟最大请求数（默认 0 表示不限制），如 OpenAI 默认 200 RPM</small>
+                                            <small class="form-hint">{{t "settings.knowledge.max_rpm_hint"}}</small>
                                         </div>
                                         <div class="form-group">
-                                            <label for="knowledge-indexing-rate-limit-delay-ms">请求间隔延迟（毫秒）</label>
+                                            <label for="knowledge-indexing-rate-limit-delay-ms">{{t "settings.knowledge.rate_delay"}}</label>
                                             <input type="number" id="knowledge-indexing-rate-limit-delay-ms" min="0" max="10000" placeholder="300" />
-                                            <small class="form-hint">请求间隔毫秒数（默认 300），用于避免 API 速率限制，设为 0 不限制</small>
+                                            <small class="form-hint">{{t "settings.knowledge.rate_delay_hint"}}</small>
                                         </div>
                                         <div class="form-group">
-                                            <label for="knowledge-indexing-max-retries">最大重试次数</label>
+                                            <label for="knowledge-indexing-max-retries">{{t "settings.knowledge.max_retries"}}</label>
                                             <input type="number" id="knowledge-indexing-max-retries" min="0" max="10" placeholder="3" />
-                                            <small class="form-hint">最大重试次数（默认 3），遇到速率限制或服务器错误时自动重试</small>
+                                            <small class="form-hint">{{t "settings.knowledge.max_retries_hint"}}</small>
                                         </div>
                                         <div class="form-group">
-                                            <label for="knowledge-indexing-retry-delay-ms">重试间隔（毫秒）</label>
+                                            <label for="knowledge-indexing-retry-delay-ms">{{t "settings.knowledge.retry_delay"}}</label>
                                             <input type="number" id="knowledge-indexing-retry-delay-ms" min="0" max="10000" placeholder="1000" />
-                                            <small class="form-hint">重试间隔毫秒数（默认 1000），每次重试会递增延迟</small>
+                                            <small class="form-hint">{{t "settings.knowledge.retry_delay_hint"}}</small>
                                         </div>                                </div>
 
                                 <div class="settings-actions">
-                                    <button class="btn-primary" onclick="applySettings()">应用配置</button>
+                                    <button class="btn-primary" onclick="applySettings()">{{t "settings.apply_config"}}</button>
                                 </div>
                             </div>
 
                             <!-- 机器人设置 -->
                             <div id="settings-section-robots" class="settings-section-content">
                                 <div class="settings-section-header">
-                                    <h3>机器人设置</h3>
-                                    <p class="settings-description">配置企业微信、钉钉、飞书等机器人，在手机端直接与 CyberStrikeAI 对话，无需在服务器上打开网页。</p>
+                                    <h3>{{t "settings.robots.title"}}</h3>
+                                    <p class="settings-description">{{t "settings.robots.description"}}</p>
                                 </div>
 
                                 <!-- 企业微信 -->
                                 <div class="settings-subsection">
-                                    <h4>企业微信</h4>
+                                    <h4>{{t "settings.robots.wecom"}}</h4>
                                     <div class="settings-form">
                                         <div class="form-group">
                                             <label class="checkbox-label">
                                                 <input type="checkbox" id="robot-wecom-enabled" class="modern-checkbox" />
                                                 <span class="checkbox-custom"></span>
-                                                <span class="checkbox-text">启用企业微信机器人</span>
+                                                <span class="checkbox-text">{{t "settings.robots.wecom_enabled"}}</span>
                                             </label>
                                         </div>
                                         <div class="form-group">
@@ -1271,106 +1272,106 @@
                                         </div>
                                         <div class="form-group">
                                             <label for="robot-wecom-encoding-aes-key">EncodingAESKey</label>
-                                            <input type="text" id="robot-wecom-encoding-aes-key" placeholder="EncodingAESKey（明文模式可留空）" autocomplete="off" />
+                                            <input type="text" id="robot-wecom-encoding-aes-key" placeholder="{{t "settings.robots.wecom_encoding_hint"}}" autocomplete="off" />
                                         </div>
                                         <div class="form-group">
                                             <label for="robot-wecom-corp-id">CorpID</label>
-                                            <input type="text" id="robot-wecom-corp-id" placeholder="企业 ID" autocomplete="off" />
+                                            <input type="text" id="robot-wecom-corp-id" placeholder="{{t "settings.robots.wecom_corp_id"}}" autocomplete="off" />
                                         </div>
                                         <div class="form-group">
                                             <label for="robot-wecom-secret">Secret</label>
-                                            <input type="password" id="robot-wecom-secret" placeholder="应用 Secret" autocomplete="off" />
+                                            <input type="password" id="robot-wecom-secret" placeholder="{{t "settings.robots.wecom_secret"}}" autocomplete="off" />
                                         </div>
                                         <div class="form-group">
                                             <label for="robot-wecom-agent-id">AgentID</label>
-                                            <input type="number" id="robot-wecom-agent-id" placeholder="应用 AgentId" />
+                                            <input type="number" id="robot-wecom-agent-id" placeholder="{{t "settings.robots.wecom_agent_id"}}" />
                                         </div>
                                     </div>
                                 </div>
 
                                 <!-- 钉钉 -->
                                 <div class="settings-subsection">
-                                    <h4>钉钉</h4>
+                                    <h4>{{t "settings.robots.dingtalk"}}</h4>
                                     <div class="settings-form">
                                         <div class="form-group">
                                             <label class="checkbox-label">
                                                 <input type="checkbox" id="robot-dingtalk-enabled" class="modern-checkbox" />
                                                 <span class="checkbox-custom"></span>
-                                                <span class="checkbox-text">启用钉钉机器人</span>
+                                                <span class="checkbox-text">{{t "settings.robots.dingtalk_enabled"}}</span>
                                             </label>
                                         </div>
                                         <div class="form-group">
                                             <label for="robot-dingtalk-client-id">Client ID (AppKey)</label>
-                                            <input type="text" id="robot-dingtalk-client-id" placeholder="钉钉应用 AppKey" autocomplete="off" />
+                                            <input type="text" id="robot-dingtalk-client-id" placeholder="{{t "settings.robots.dingtalk_client_id"}}" autocomplete="off" />
                                         </div>
                                         <div class="form-group">
                                             <label for="robot-dingtalk-client-secret">Client Secret</label>
-                                            <input type="password" id="robot-dingtalk-client-secret" placeholder="钉钉应用 Secret" autocomplete="off" />
-                                            <small class="form-hint">需开启机器人能力并配置流式接入</small>
+                                            <input type="password" id="robot-dingtalk-client-secret" placeholder="{{t "settings.robots.dingtalk_client_secret"}}" autocomplete="off" />
+                                            <small class="form-hint">{{t "settings.robots.dingtalk_hint"}}</small>
                                         </div>
                                     </div>
                                 </div>
 
                                 <!-- 飞书 -->
                                 <div class="settings-subsection">
-                                    <h4>飞书 (Lark)</h4>
+                                    <h4>{{t "settings.robots.lark"}}</h4>
                                     <div class="settings-form">
                                         <div class="form-group">
                                             <label class="checkbox-label">
                                                 <input type="checkbox" id="robot-lark-enabled" class="modern-checkbox" />
                                                 <span class="checkbox-custom"></span>
-                                                <span class="checkbox-text">启用飞书机器人</span>
+                                                <span class="checkbox-text">{{t "settings.robots.lark_enabled"}}</span>
                                             </label>
                                         </div>
                                         <div class="form-group">
                                             <label for="robot-lark-app-id">App ID</label>
-                                            <input type="text" id="robot-lark-app-id" placeholder="飞书应用 App ID" autocomplete="off" />
+                                            <input type="text" id="robot-lark-app-id" placeholder="{{t "settings.robots.lark_app_id"}}" autocomplete="off" />
                                         </div>
                                         <div class="form-group">
                                             <label for="robot-lark-app-secret">App Secret</label>
-                                            <input type="password" id="robot-lark-app-secret" placeholder="飞书应用 App Secret" autocomplete="off" />
+                                            <input type="password" id="robot-lark-app-secret" placeholder="{{t "settings.robots.lark_app_secret"}}" autocomplete="off" />
                                         </div>
                                         <div class="form-group">
-                                            <label for="robot-lark-verify-token">Verify Token（可选）</label>
-                                            <input type="text" id="robot-lark-verify-token" placeholder="事件订阅 Verification Token" autocomplete="off" />
+                                            <label for="robot-lark-verify-token">{{t "settings.robots.lark_verify_token"}}</label>
+                                            <input type="text" id="robot-lark-verify-token" placeholder="{{t "settings.robots.lark_verify_placeholder"}}" autocomplete="off" />
                                         </div>
                                     </div>
                                 </div>
 
                                 <div class="settings-subsection">
-                                    <h4>机器人命令说明</h4>
-                                    <p class="settings-description">在对话中可发送以下命令（支持中英文）：</p>
+                                    <h4>{{t "settings.robots.commands_title"}}</h4>
+                                    <p class="settings-description">{{t "settings.robots.commands_desc"}}</p>
                                     <ul style="color: var(--text-muted); font-size: 13px; line-height: 1.8; margin: 8px 0 0 16px;">
-                                        <li><code>帮助</code> <code>help</code> — 显示本帮助 | Show this help</li>
-                                        <li><code>列表</code> <code>list</code> — 列出所有对话标题与 ID | List conversations</li>
-                                        <li><code>切换 &lt;ID&gt;</code> <code>switch &lt;ID&gt;</code> — 指定对话继续 | Switch to conversation</li>
-                                        <li><code>新对话</code> <code>new</code> — 开启新对话 | Start new conversation</li>
-                                        <li><code>清空</code> <code>clear</code> — 清空当前上下文 | Clear context</li>
-                                        <li><code>当前</code> <code>current</code> — 显示当前对话 ID 与标题 | Show current conversation</li>
-                                        <li><code>停止</code> <code>stop</code> — 中断当前任务 | Stop running task</li>
-                                        <li><code>角色</code> <code>roles</code> — 列出所有可用角色 | List roles</li>
-                                        <li><code>角色 &lt;名&gt;</code> <code>role &lt;name&gt;</code> — 切换当前角色 | Switch role</li>
-                                        <li><code>删除 &lt;ID&gt;</code> <code>delete &lt;ID&gt;</code> — 删除指定对话 | Delete conversation</li>
-                                        <li><code>版本</code> <code>version</code> — 显示当前版本号 | Show version</li>
+                                        <li><code>帮助</code> <code>help</code> — {{t "settings.robots.cmd_help"}} | Show this help</li>
+                                        <li><code>列表</code> <code>list</code> — {{t "settings.robots.cmd_list"}} | List conversations</li>
+                                        <li><code>切换 &lt;ID&gt;</code> <code>switch &lt;ID&gt;</code> — {{t "settings.robots.cmd_switch"}} | Switch to conversation</li>
+                                        <li><code>新对话</code> <code>new</code> — {{t "settings.robots.cmd_new"}} | Start new conversation</li>
+                                        <li><code>清空</code> <code>clear</code> — {{t "settings.robots.cmd_clear"}} | Clear context</li>
+                                        <li><code>当前</code> <code>current</code> — {{t "settings.robots.cmd_current"}} | Show current conversation</li>
+                                        <li><code>停止</code> <code>stop</code> — {{t "settings.robots.cmd_stop"}} | Stop running task</li>
+                                        <li><code>角色</code> <code>roles</code> — {{t "settings.robots.cmd_roles"}} | List roles</li>
+                                        <li><code>角色 &lt;名&gt;</code> <code>role &lt;name&gt;</code> — {{t "settings.robots.cmd_role"}} | Switch role</li>
+                                        <li><code>删除 &lt;ID&gt;</code> <code>delete &lt;ID&gt;</code> — {{t "settings.robots.cmd_delete"}} | Delete conversation</li>
+                                        <li><code>版本</code> <code>version</code> — {{t "settings.robots.cmd_version"}} | Show version</li>
                                     </ul>
-                                    <p class="settings-description" style="margin-top: 8px;">除以上命令外，直接输入内容将发送给 AI 进行渗透测试/安全分析。Otherwise, send any text for AI penetration testing / security analysis.</p>
+                                    <p class="settings-description" style="margin-top: 8px;">{{t "settings.robots.cmd_other"}}</p>
                                 </div>
 
                                 <div class="settings-actions">
-                                    <button class="btn-primary" onclick="applySettings()">应用配置</button>
+                                    <button class="btn-primary" onclick="applySettings()">{{t "settings.apply_config"}}</button>
                                 </div>
                             </div>
 
                             <!-- 终端 -->
                             <div id="settings-section-terminal" class="settings-section-content">
                                 <div class="settings-section-header">
-                                    <h3>终端</h3>
-                                    <p class="settings-description">在服务器上执行命令，便于运维与调试。命令在服务端执行，请勿执行敏感或破坏性操作。</p>
+                                    <h3>{{t "settings.terminal.title"}}</h3>
+                                    <p class="settings-description">{{t "settings.terminal.description"}}</p>
                                 </div>
                                 <div class="terminal-wrapper">
                                     <div class="terminal-tabs">
-                                        <div class="terminal-tab active" data-tab-id="1"><span class="terminal-tab-label" onclick="switchTerminalTab(1)">终端 1</span><button type="button" class="terminal-tab-close" onclick="removeTerminalTab(1); event.stopPropagation();" title="关闭">×</button></div>
-                                        <button type="button" class="terminal-tab-new" onclick="addTerminalTab()" title="新终端">+</button>
+                                        <div class="terminal-tab active" data-tab-id="1"><span class="terminal-tab-label" onclick="switchTerminalTab(1)">{{t "settings.terminal.tab"}}</span><button type="button" class="terminal-tab-close" onclick="removeTerminalTab(1); event.stopPropagation();" title="{{t "settings.terminal.close"}}">×</button></div>
+                                        <button type="button" class="terminal-tab-new" onclick="addTerminalTab()" title="{{t "settings.terminal.new"}}">+</button>
                                     </div>
                                     <div class="terminal-panes">
                                         <div id="terminal-pane-1" class="terminal-pane active">
@@ -1383,28 +1384,28 @@
                             <!-- 安全设置 -->
                             <div id="settings-section-security" class="settings-section-content">
                                 <div class="settings-section-header">
-                                    <h3>安全设置</h3>
+                                    <h3>{{t "settings.security.title"}}</h3>
                                 </div>
-                                
+
                                 <div class="settings-subsection">
-                                    <h4>修改密码</h4>
-                                    <p class="settings-description">修改登录密码后，需要使用新密码重新登录。</p>
+                                    <h4>{{t "settings.security.change_password"}}</h4>
+                                    <p class="settings-description">{{t "settings.security.change_password_desc"}}</p>
                                     <div class="settings-form">
                                         <div class="form-group">
-                                            <label for="auth-current-password">当前密码</label>
-                                            <input type="password" id="auth-current-password" placeholder="输入当前登录密码" autocomplete="current-password" />
+                                            <label for="auth-current-password">{{t "settings.security.current_password"}}</label>
+                                            <input type="password" id="auth-current-password" placeholder="{{t "settings.security.current_password_placeholder"}}" autocomplete="current-password" />
                                         </div>
                                         <div class="form-group">
-                                            <label for="auth-new-password">新密码</label>
-                                            <input type="password" id="auth-new-password" placeholder="设置新密码（至少 8 位）" autocomplete="new-password" />
+                                            <label for="auth-new-password">{{t "settings.security.new_password"}}</label>
+                                            <input type="password" id="auth-new-password" placeholder="{{t "settings.security.new_password_placeholder"}}" autocomplete="new-password" />
                                         </div>
                                         <div class="form-group">
-                                            <label for="auth-confirm-password">确认新密码</label>
-                                            <input type="password" id="auth-confirm-password" placeholder="再次输入新密码" autocomplete="new-password" />
+                                            <label for="auth-confirm-password">{{t "settings.security.confirm_password"}}</label>
+                                            <input type="password" id="auth-confirm-password" placeholder="{{t "settings.security.confirm_password_placeholder"}}" autocomplete="new-password" />
                                         </div>
                                         <div class="form-actions">
-                                            <button class="btn-secondary" type="button" onclick="resetPasswordForm()">清空</button>
-                                            <button class="btn-primary change-password-submit" type="button" onclick="changePassword()">修改密码</button>
+                                            <button class="btn-secondary" type="button" onclick="resetPasswordForm()">{{t "settings.security.clear_form"}}</button>
+                                            <button class="btn-primary change-password-submit" type="button" onclick="changePassword()">{{t "settings.security.submit"}}</button>
                                         </div>
                                     </div>
                                 </div>
@@ -1421,37 +1422,37 @@
     <div id="mcp-detail-modal" class="modal">
         <div class="modal-content">
             <div class="modal-header">
-                <h2>工具调用详情</h2>
+                <h2>{{t "modal.mcp_detail.title"}}</h2>
                 <span class="modal-close" onclick="closeMCPDetail()">&times;</span>
             </div>
             <div class="modal-body">
                 <div class="detail-section detail-section-overview">
                     <div class="detail-section-header">
-                        <h3>执行信息</h3>
+                        <h3>{{t "modal.mcp_detail.exec_info"}}</h3>
                     </div>
                     <div class="detail-info-grid">
                         <div class="detail-item">
-                            <strong>工具</strong>
+                            <strong>{{t "modal.mcp_detail.tool"}}</strong>
                             <span id="detail-tool-name"></span>
                         </div>
                         <div class="detail-item">
-                            <strong>状态</strong>
+                            <strong>{{t "modal.mcp_detail.status"}}</strong>
                             <span id="detail-status" class="status-chip status-unknown"></span>
                         </div>
                         <div class="detail-item">
-                            <strong>时间</strong>
+                            <strong>{{t "modal.mcp_detail.time"}}</strong>
                             <span id="detail-time"></span>
                         </div>
                         <div class="detail-item">
-                            <strong>执行 ID</strong>
+                            <strong>{{t "modal.mcp_detail.exec_id"}}</strong>
                             <span id="detail-execution-id" class="mono-text"></span>
                         </div>
                     </div>
                 </div>
                 <div class="detail-section">
                     <div class="detail-section-header">
-                        <h3>请求参数</h3>
-                        <button class="btn-ghost" type="button" onclick="copyDetailBlock('detail-request', this)">复制 JSON</button>
+                        <h3>{{t "modal.mcp_detail.request"}}</h3>
+                        <button class="btn-ghost" type="button" onclick="copyDetailBlock('detail-request', this)">{{t "modal.mcp_detail.copy_json"}}</button>
                     </div>
                     <div class="detail-code-card">
                         <pre id="detail-request" class="code-block"></pre>
@@ -1459,8 +1460,8 @@
                 </div>
                 <div class="detail-section">
                     <div class="detail-section-header">
-                        <h3>响应结果</h3>
-                        <button class="btn-ghost" type="button" onclick="copyDetailBlock('detail-response', this)">复制内容</button>
+                        <h3>{{t "modal.mcp_detail.response"}}</h3>
+                        <button class="btn-ghost" type="button" onclick="copyDetailBlock('detail-response', this)">{{t "modal.mcp_detail.copy_content"}}</button>
                     </div>
                     <div class="detail-code-card">
                         <pre id="detail-response" class="code-block"></pre>
@@ -1468,8 +1469,8 @@
                 </div>
                 <div class="detail-section detail-success-wrapper" id="detail-success-section" style="display: none;">
                     <div class="detail-section-header">
-                        <h3>正确信息</h3>
-                        <button class="btn-ghost" type="button" onclick="copyDetailBlock('detail-success', this)">复制内容</button>
+                        <h3>{{t "modal.mcp_detail.success_info"}}</h3>
+                        <button class="btn-ghost" type="button" onclick="copyDetailBlock('detail-success', this)">{{t "modal.mcp_detail.copy_content"}}</button>
                     </div>
                     <div class="detail-code-card">
                         <pre id="detail-success" class="code-block"></pre>
@@ -1477,8 +1478,8 @@
                 </div>
                 <div class="detail-section detail-error-wrapper" id="detail-error-section" style="display: none;">
                     <div class="detail-section-header">
-                        <h3>错误信息</h3>
-                        <button class="btn-ghost" type="button" onclick="copyDetailBlock('detail-error', this)">复制错误</button>
+                        <h3>{{t "modal.mcp_detail.error_info"}}</h3>
+                        <button class="btn-ghost" type="button" onclick="copyDetailBlock('detail-error', this)">{{t "modal.mcp_detail.copy_error"}}</button>
                     </div>
                     <div class="detail-code-card">
                         <pre id="detail-error" class="code-block error"></pre>
@@ -1492,17 +1493,17 @@
     <div id="external-mcp-modal" class="modal">
         <div class="modal-content" style="max-width: 900px;">
             <div class="modal-header">
-                <h2 id="external-mcp-modal-title">添加外部MCP</h2>
+                <h2 id="external-mcp-modal-title">{{t "modal.external_mcp.add_title"}}</h2>
                 <span class="modal-close" onclick="closeExternalMCPModal()">&times;</span>
             </div>
             <div class="modal-body">
                 <div class="form-group">
-                    <label for="external-mcp-json">配置JSON <span style="color: red;">*</span></label>
+                    <label for="external-mcp-json">{{t "modal.external_mcp.config_json"}} <span style="color: red;">*</span></label>
                     <textarea id="external-mcp-json" rows="15" placeholder='{\n  "hexstrike-ai": {\n    "command": "python3",\n    "args": ["/path/to/script.py"],\n    "description": "描述",\n    "timeout": 300\n  }\n}' style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace; font-size: 0.875rem; line-height: 1.5;"></textarea>
                     <div class="password-hint">
-                        <strong>配置格式：</strong>JSON对象，key为配置名称，value为配置内容。状态通过"启动/停止"按钮控制，无需在JSON中配置。<br>
-                        <strong>配置示例：</strong><br>
-                        <strong>stdio模式：</strong><br>
+                        <strong>{{t "modal.external_mcp.config_format"}}</strong>{{t "modal.external_mcp.config_format_desc"}}<br>
+                        <strong>{{t "modal.external_mcp.example"}}</strong><br>
+                        <strong>{{t "modal.external_mcp.stdio_mode"}}</strong><br>
                         <code style="display: block; margin: 8px 0; padding: 8px; background: var(--bg-secondary); border-radius: 4px; white-space: pre-wrap;">{
   "hexstrike-ai": {
     "command": "python3",
@@ -1511,14 +1512,14 @@
     "timeout": 300
   }
 }</code>
-                        <strong>HTTP模式：</strong><br>
+                        <strong>{{t "modal.external_mcp.http_mode"}}</strong><br>
                         <code style="display: block; margin: 8px 0; padding: 8px; background: var(--bg-secondary); border-radius: 4px; white-space: pre-wrap;">{
   "cyberstrike-ai-http": {
     "transport": "http",
     "url": "http://127.0.0.1:8081/mcp"
   }
 }</code>
-                        <strong>SSE模式：</strong><br>
+                        <strong>{{t "modal.external_mcp.sse_mode"}}</strong><br>
                         <code style="display: block; margin: 8px 0; padding: 8px; background: var(--bg-secondary); border-radius: 4px; white-space: pre-wrap;">{
   "cyberstrike-ai-sse": {
     "transport": "sse",
@@ -1529,13 +1530,13 @@
                     <div id="external-mcp-json-error" class="error-message" style="display: none; margin-top: 8px; padding: 8px; background: rgba(220, 53, 69, 0.1); border: 1px solid rgba(220, 53, 69, 0.3); border-radius: 4px; color: var(--error-color); font-size: 0.875rem;"></div>
                 </div>
                 <div class="form-group">
-                    <button type="button" class="btn-secondary" onclick="formatExternalMCPJSON()" style="margin-top: 8px;">格式化JSON</button>
-                    <button type="button" class="btn-secondary" onclick="loadExternalMCPExample()" style="margin-top: 8px; margin-left: 8px;">加载示例</button>
+                    <button type="button" class="btn-secondary" onclick="formatExternalMCPJSON()" style="margin-top: 8px;">{{t "modal.external_mcp.format_json"}}</button>
+                    <button type="button" class="btn-secondary" onclick="loadExternalMCPExample()" style="margin-top: 8px; margin-left: 8px;">{{t "modal.external_mcp.load_example"}}</button>
                 </div>
             </div>
             <div class="modal-footer">
-                <button class="btn-secondary" onclick="closeExternalMCPModal()">取消</button>
-                <button class="btn-primary" onclick="saveExternalMCP()">保存</button>
+                <button class="btn-secondary" onclick="closeExternalMCPModal()">{{t "ui.btn.cancel"}}</button>
+                <button class="btn-primary" onclick="saveExternalMCP()">{{t "ui.btn.save"}}</button>
             </div>
         </div>
     </div>
@@ -1544,19 +1545,19 @@
     <div id="attack-chain-modal" class="modal">
         <div class="modal-content attack-chain-modal-content">
             <div class="modal-header">
-                <h2>攻击链可视化</h2>
+                <h2>{{t "modal.attack_chain.title"}}</h2>
                 <div class="modal-header-actions">
-                    <button class="btn-primary attack-chain-action-btn" onclick="regenerateAttackChain()" title="重新生成攻击链（包含最新对话内容）">
-                        🔄 重新生成
+                    <button class="btn-primary attack-chain-action-btn" onclick="regenerateAttackChain()" title="{{t "modal.attack_chain.regenerate_title"}}">
+                        🔄 {{t "modal.attack_chain.regenerate"}}
                     </button>
-                    <button class="btn-secondary attack-chain-action-btn" onclick="exportAttackChain('png')" title="导出为PNG">
+                    <button class="btn-secondary attack-chain-action-btn" onclick="exportAttackChain('png')" title="{{t "modal.attack_chain.export_png"}}">
                         📥 PNG
                     </button>
-                    <button class="btn-secondary attack-chain-action-btn" onclick="exportAttackChain('svg')" title="导出为SVG">
+                    <button class="btn-secondary attack-chain-action-btn" onclick="exportAttackChain('svg')" title="{{t "modal.attack_chain.export_svg"}}">
                         📥 SVG
                     </button>
-                    <button class="btn-secondary attack-chain-action-btn" onclick="refreshAttackChain()" title="刷新当前攻击链（不重新生成）">
-                        ↻ 刷新
+                    <button class="btn-secondary attack-chain-action-btn" onclick="refreshAttackChain()" title="{{t "modal.attack_chain.refresh_title"}}">
+                        ↻ {{t "modal.attack_chain.refresh"}}
                     </button>
                     <span class="modal-close" onclick="closeAttackChainModal()">&times;</span>
                 </div>
@@ -1566,76 +1567,76 @@
                     <div class="attack-chain-visualization-area">
                         <div class="attack-chain-toolbar">
                             <div class="attack-chain-info">
-                                <span id="attack-chain-stats">节点: 0 | 边: 0</span>
+                                <span id="attack-chain-stats">{{t "modal.attack_chain.stats_nodes"}}: 0 | {{t "modal.attack_chain.stats_edges"}}: 0</span>
                             </div>
                             <div class="attack-chain-filters">
-                                <input type="text" id="attack-chain-search" placeholder="搜索节点..." 
+                                <input type="text" id="attack-chain-search" placeholder="{{t "modal.attack_chain.search_placeholder"}}"
                                        oninput="filterAttackChainNodes(this.value)">
-                                <select id="attack-chain-type-filter" 
+                                <select id="attack-chain-type-filter"
                                         onchange="filterAttackChainByType(this.value)">
-                                    <option value="all">所有类型</option>
-                                    <option value="target">目标</option>
-                                    <option value="action">行动</option>
-                                    <option value="vulnerability">漏洞</option>
+                                    <option value="all">{{t "modal.attack_chain.type_all"}}</option>
+                                    <option value="target">{{t "modal.attack_chain.type_target"}}</option>
+                                    <option value="action">{{t "modal.attack_chain.type_action"}}</option>
+                                    <option value="vulnerability">{{t "modal.attack_chain.type_vulnerability"}}</option>
                                 </select>
                                 <select id="attack-chain-risk-filter"
                                         onchange="filterAttackChainByRisk(this.value)">
-                                    <option value="all">所有风险</option>
-                                    <option value="high">高风险 (80-100)</option>
-                                    <option value="medium-high">中高风险 (60-79)</option>
-                                    <option value="medium">中风险 (40-59)</option>
-                                    <option value="low">低风险 (0-39)</option>
+                                    <option value="all">{{t "modal.attack_chain.risk_all"}}</option>
+                                    <option value="high">{{t "modal.attack_chain.risk_high"}}</option>
+                                    <option value="medium-high">{{t "modal.attack_chain.risk_medium_high"}}</option>
+                                    <option value="medium">{{t "modal.attack_chain.risk_medium"}}</option>
+                                    <option value="low">{{t "modal.attack_chain.risk_low"}}</option>
                                 </select>
                                 <button class="btn-secondary" onclick="resetAttackChainFilters()">
-                                    重置筛选
+                                    {{t "modal.attack_chain.reset_filters"}}
                                 </button>
                             </div>
                         </div>
                         <div id="attack-chain-container" class="attack-chain-container">
-                            <div class="loading-spinner">加载中...</div>
+                            <div class="loading-spinner">{{t "ui.loading"}}</div>
                         </div>
                     </div>
                     <div class="attack-chain-sidebar">
                         <div class="attack-chain-sidebar-content">
                             <div class="attack-chain-legend">
                                 <div class="legend-section">
-                                    <div class="legend-title">风险等级</div>
+                                    <div class="legend-title">{{t "modal.attack_chain.legend_risk"}}</div>
                                     <div class="legend-item">
                                         <span class="legend-color" style="background: #ff4444;"></span>
-                                        <span>高风险 (80-100)</span>
+                                        <span>{{t "modal.attack_chain.risk_high"}}</span>
                                     </div>
                                     <div class="legend-item">
                                         <span class="legend-color" style="background: #ff8800;"></span>
-                                        <span>中高风险 (60-79)</span>
+                                        <span>{{t "modal.attack_chain.risk_medium_high"}}</span>
                                     </div>
                                     <div class="legend-item">
                                         <span class="legend-color" style="background: #ffbb00;"></span>
-                                        <span>中风险 (40-59)</span>
+                                        <span>{{t "modal.attack_chain.risk_medium"}}</span>
                                     </div>
                                     <div class="legend-item">
                                         <span class="legend-color" style="background: #88cc00;"></span>
-                                        <span>低风险 (0-39)</span>
+                                        <span>{{t "modal.attack_chain.risk_low"}}</span>
                                     </div>
                                 </div>
                                 <div class="legend-section">
-                                    <div class="legend-title">连接线含义</div>
+                                    <div class="legend-title">{{t "modal.attack_chain.legend_connections"}}</div>
                                     <div class="legend-item">
                                         <span class="legend-line" style="border-top: 2px solid #42a5f5;"></span>
-                                        <span>蓝色线：行动发现漏洞</span>
+                                        <span>{{t "modal.attack_chain.legend_blue"}}</span>
                                     </div>
                                     <div class="legend-item">
                                         <span class="legend-line" style="border-top: 2px solid #e53935;"></span>
-                                        <span>红色线：使能/促成关系</span>
+                                        <span>{{t "modal.attack_chain.legend_red"}}</span>
                                     </div>
                                     <div class="legend-item">
                                         <span class="legend-line" style="border-top: 2px solid #616161;"></span>
-                                        <span>灰色线：逻辑顺序</span>
+                                        <span>{{t "modal.attack_chain.legend_gray"}}</span>
                                     </div>
                                 </div>
                                 <div id="attack-chain-details" class="legend-section attack-chain-details" style="display: none;">
                                     <div class="legend-title attack-chain-details-title">
-                                        <span>节点详情</span>
-                                        <button class="attack-chain-details-close" onclick="closeNodeDetails()" title="关闭详情">
+                                        <span>{{t "modal.attack_chain.node_details"}}</span>
+                                        <button class="attack-chain-details-close" onclick="closeNodeDetails()" title="{{t "modal.attack_chain.close_details"}}">
                                             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                                                 <path d="M18 6L6 18M6 6l12 12" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                                             </svg>
@@ -1672,23 +1673,23 @@
     <div id="skill-modal" class="modal">
         <div class="modal-content" style="max-width: 900px;">
             <div class="modal-header">
-                <h2 id="skill-modal-title">添加Skill</h2>
+                <h2 id="skill-modal-title">{{t "modal.skill.add_title"}}</h2>
                 <span class="modal-close" onclick="closeSkillModal()">&times;</span>
             </div>
             <div class="modal-body">
                 <div class="form-group">
-                    <label for="skill-name">Skill名称 <span style="color: red;">*</span></label>
-                    <input type="text" id="skill-name" placeholder="例如: sql-injection-testing" required />
-                    <small class="form-hint">只能包含字母、数字、连字符和下划线</small>
+                    <label for="skill-name">{{t "modal.skill.name"}} <span style="color: red;">*</span></label>
+                    <input type="text" id="skill-name" placeholder="{{t "modal.skill.name_placeholder"}}" required />
+                    <small class="form-hint">{{t "modal.skill.name_hint"}}</small>
                 </div>
                 <div class="form-group">
-                    <label for="skill-description">描述</label>
-                    <input type="text" id="skill-description" placeholder="Skill的简短描述" />
+                    <label for="skill-description">{{t "modal.skill.description"}}</label>
+                    <input type="text" id="skill-description" placeholder="{{t "modal.skill.description_placeholder"}}" />
                 </div>
                 <div class="form-group">
-                    <label for="skill-content">内容（Markdown格式） <span style="color: red;">*</span></label>
-                    <textarea id="skill-content" rows="20" placeholder="输入skill内容，支持Markdown格式..." style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace; font-size: 0.875rem; line-height: 1.5;" required></textarea>
-                    <small class="form-hint">支持YAML front matter格式（可选），例如：<br>
+                    <label for="skill-content">{{t "modal.skill.content"}} <span style="color: red;">*</span></label>
+                    <textarea id="skill-content" rows="20" placeholder="{{t "modal.skill.content_placeholder"}}" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace; font-size: 0.875rem; line-height: 1.5;" required></textarea>
+                    <small class="form-hint">{{t "modal.skill.content_hint_prefix"}}<br>
 ---<br>
 name: skill-name<br>
 description: Skill描述<br>
@@ -1699,8 +1700,8 @@ version: 1.0.0<br>
                 </div>
             </div>
             <div class="modal-footer">
-                <button class="btn-secondary" onclick="closeSkillModal()">取消</button>
-                <button class="btn-primary" onclick="saveSkill()">保存</button>
+                <button class="btn-secondary" onclick="closeSkillModal()">{{t "ui.btn.cancel"}}</button>
+                <button class="btn-primary" onclick="saveSkill()">{{t "ui.btn.save"}}</button>
             </div>
         </div>
     </div>
@@ -1708,26 +1709,26 @@ version: 1.0.0<br>
     <div id="knowledge-item-modal" class="modal">
         <div class="modal-content" style="max-width: 900px;">
             <div class="modal-header">
-                <h2 id="knowledge-item-modal-title">添加知识</h2>
+                <h2 id="knowledge-item-modal-title">{{t "modal.knowledge.add_title"}}</h2>
                 <span class="modal-close" onclick="closeKnowledgeItemModal()">&times;</span>
             </div>
             <div class="modal-body">
                 <div class="form-group">
-                    <label for="knowledge-item-category">分类（风险类型）<span style="color: red;">*</span></label>
-                    <input type="text" id="knowledge-item-category" placeholder="例如：SQL注入" required />
+                    <label for="knowledge-item-category">{{t "modal.knowledge.category"}}<span style="color: red;">*</span></label>
+                    <input type="text" id="knowledge-item-category" placeholder="{{t "modal.knowledge.category_placeholder"}}" required />
                 </div>
                 <div class="form-group">
-                    <label for="knowledge-item-title">标题<span style="color: red;">*</span></label>
-                    <input type="text" id="knowledge-item-title" placeholder="知识项标题" required />
+                    <label for="knowledge-item-title">{{t "modal.knowledge.item_title"}}<span style="color: red;">*</span></label>
+                    <input type="text" id="knowledge-item-title" placeholder="{{t "modal.knowledge.item_title_placeholder"}}" required />
                 </div>
                 <div class="form-group">
-                    <label for="knowledge-item-content">内容（Markdown格式）<span style="color: red;">*</span></label>
-                    <textarea id="knowledge-item-content" rows="20" placeholder="输入知识内容，支持Markdown格式..." style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace; font-size: 0.875rem; line-height: 1.5;" required></textarea>
+                    <label for="knowledge-item-content">{{t "modal.knowledge.content"}}<span style="color: red;">*</span></label>
+                    <textarea id="knowledge-item-content" rows="20" placeholder="{{t "modal.knowledge.content_placeholder"}}" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace; font-size: 0.875rem; line-height: 1.5;" required></textarea>
                 </div>
             </div>
             <div class="modal-footer">
-                <button class="btn-secondary" onclick="closeKnowledgeItemModal()">取消</button>
-                <button class="btn-primary" onclick="saveKnowledgeItem()">保存</button>
+                <button class="btn-secondary" onclick="closeKnowledgeItemModal()">{{t "ui.btn.cancel"}}</button>
+                <button class="btn-primary" onclick="saveKnowledgeItem()">{{t "ui.btn.save"}}</button>
             </div>
         </div>
     </div>
@@ -1736,10 +1737,10 @@ version: 1.0.0<br>
     <div id="batch-manage-modal" class="modal">
         <div class="modal-content batch-manage-modal-content">
             <div class="modal-header">
-                <h2 id="batch-manage-title">管理对话记录·共<span id="batch-manage-count">0</span>条</h2>
+                <h2 id="batch-manage-title">{{t "modal.batch_manage.title"}}<span id="batch-manage-count">0</span>{{t "modal.batch_manage.title_suffix"}}</h2>
                 <div class="batch-manage-header-actions">
                     <div class="batch-search-box">
-                        <input type="text" id="batch-search-input" placeholder="搜索历史记录" oninput="filterBatchConversations(this.value)" />
+                        <input type="text" id="batch-search-input" placeholder="{{t "modal.batch_manage.search_placeholder"}}" oninput="filterBatchConversations(this.value)" />
                         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                             <circle cx="11" cy="11" r="8" stroke="currentColor" stroke-width="2"/>
                             <path d="m21 21-4.35-4.35" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
@@ -1752,9 +1753,9 @@ version: 1.0.0<br>
                 <div class="batch-conversations-table">
                     <div class="batch-table-header">
                         <div class="batch-table-col-checkbox"></div>
-                        <div class="batch-table-col-name">对话名称</div>
-                        <div class="batch-table-col-time">最近一次对话时间</div>
-                        <div class="batch-table-col-action">操作</div>
+                        <div class="batch-table-col-name">{{t "modal.batch_manage.col_name"}}</div>
+                        <div class="batch-table-col-time">{{t "modal.batch_manage.col_time"}}</div>
+                        <div class="batch-table-col-action">{{t "modal.batch_manage.col_action"}}</div>
                     </div>
                     <div id="batch-conversations-list" class="batch-conversations-list"></div>
                 </div>
@@ -1762,11 +1763,11 @@ version: 1.0.0<br>
             <div class="modal-footer batch-manage-footer">
                 <label class="select-all-checkbox">
                     <input type="checkbox" id="batch-select-all" onchange="toggleSelectAllBatch()" />
-                    <span>全选</span>
+                    <span>{{t "modal.batch_manage.select_all"}}</span>
                 </label>
                 <div class="batch-footer-actions">
-                    <button class="btn-secondary" onclick="closeBatchManageModal()">取消</button>
-                    <button class="btn-primary" onclick="deleteSelectedConversations()">删除所选</button>
+                    <button class="btn-secondary" onclick="closeBatchManageModal()">{{t "ui.btn.cancel"}}</button>
+                    <button class="btn-primary" onclick="deleteSelectedConversations()">{{t "modal.batch_manage.delete_selected"}}</button>
                 </div>
             </div>
         </div>
@@ -1776,21 +1777,21 @@ version: 1.0.0<br>
     <div id="create-group-modal" class="modal">
         <div class="modal-content create-group-modal-content">
             <div class="modal-header">
-                <h2>创建分组</h2>
+                <h2>{{t "modal.create_group.title"}}</h2>
                 <span class="modal-close" onclick="closeCreateGroupModal()">&times;</span>
             </div>
             <div class="modal-body create-group-body">
-                <p class="create-group-description">分组功能可将对话集中归类管理，让对话更加井然有序。</p>
+                <p class="create-group-description">{{t "modal.create_group.description"}}</p>
                 <div class="create-group-input-wrapper">
-                    <button type="button" class="group-icon-input" id="create-group-icon-btn" onclick="toggleGroupIconPicker()" title="点击选择图标">📁</button>
-                    <input type="text" id="create-group-name-input" placeholder="请输入分组名称" />
+                    <button type="button" class="group-icon-input" id="create-group-icon-btn" onclick="toggleGroupIconPicker()" title="{{t "modal.create_group.select_icon"}}">📁</button>
+                    <input type="text" id="create-group-name-input" placeholder="{{t "modal.create_group.name_placeholder"}}" />
                     <!-- Emoji选择器面板 -->
                     <div id="group-icon-picker" class="group-icon-picker" style="display: none;">
                         <div class="icon-picker-header">
-                            <span>选择图标</span>
+                            <span>{{t "modal.create_group.select_icon"}}</span>
                             <div class="icon-picker-custom">
-                                <input type="text" id="custom-icon-input" class="custom-icon-input" placeholder="自定义" maxlength="2" />
-                                <button type="button" class="custom-icon-btn" onclick="applyCustomIcon()">确定</button>
+                                <input type="text" id="custom-icon-input" class="custom-icon-input" placeholder="{{t "modal.create_group.custom"}}" maxlength="2" />
+                                <button type="button" class="custom-icon-btn" onclick="applyCustomIcon()">{{t "modal.create_group.apply"}}</button>
                             </div>
                         </div>
                         <div class="icon-picker-grid">
@@ -1822,15 +1823,15 @@ version: 1.0.0<br>
                     </div>
                 </div>
                 <div class="create-group-suggestions">
-                    <div class="suggestion-tag" onclick="selectSuggestion('渗透测试')">渗透测试</div>
+                    <div class="suggestion-tag" onclick="selectSuggestion('{{t "modal.create_group.suggestion_pentest"}}')">{{t "modal.create_group.suggestion_pentest"}}</div>
                     <div class="suggestion-tag" onclick="selectSuggestion('CTF')">CTF</div>
-                    <div class="suggestion-tag" onclick="selectSuggestion('红队')">红队</div>
-                    <div class="suggestion-tag" onclick="selectSuggestion('漏洞挖掘')">漏洞挖掘</div>
+                    <div class="suggestion-tag" onclick="selectSuggestion('{{t "modal.create_group.suggestion_redteam"}}')">{{t "modal.create_group.suggestion_redteam"}}</div>
+                    <div class="suggestion-tag" onclick="selectSuggestion('{{t "modal.create_group.suggestion_vulnhunt"}}')">{{t "modal.create_group.suggestion_vulnhunt"}}</div>
                 </div>
             </div>
             <div class="modal-footer">
-                <button class="btn-secondary" onclick="closeCreateGroupModal()">取消</button>
-                <button class="btn-primary" onclick="createGroup(event)">创建</button>
+                <button class="btn-secondary" onclick="closeCreateGroupModal()">{{t "ui.btn.cancel"}}</button>
+                <button class="btn-primary" onclick="createGroup(event)">{{t "modal.create_group.create"}}</button>
             </div>
         </div>
     </div>
@@ -1841,7 +1842,7 @@ version: 1.0.0<br>
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <path d="M10.5 13.5l3-3M8 8H5a4 4 0 1 0 0 8h3m8-8h3a4 4 0 0 1 0 8h-3" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
             </svg>
-            <span>查看攻击链</span>
+            <span>{{t "ctx.view_attack_chain"}}</span>
         </div>
         <div class="context-menu-divider"></div>
         <div class="context-menu-item" onclick="renameConversation()">
@@ -1849,13 +1850,13 @@ version: 1.0.0<br>
                 <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                 <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
             </svg>
-            <span>重命名</span>
+            <span>{{t "ctx.rename"}}</span>
         </div>
         <div class="context-menu-item" onclick="pinConversation()">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <path d="M12 17v5M5 17h14l-1-7H6l-1 7zM9 10V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
             </svg>
-            <span id="pin-conversation-menu-text">置顶此对话</span>
+            <span id="pin-conversation-menu-text">{{t "ctx.pin_conversation"}}</span>
         </div>
         <div class="context-menu-item" onclick="showBatchManageModal()">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -1866,13 +1867,13 @@ version: 1.0.0<br>
                 <circle cx="8" cy="12" r="1" fill="currentColor"/>
                 <circle cx="8" cy="18" r="1" fill="currentColor"/>
             </svg>
-            <span>批量管理</span>
+            <span>{{t "ctx.batch_manage"}}</span>
         </div>
         <div class="context-menu-item context-menu-item-has-submenu" onmouseenter="handleMoveToGroupSubmenuEnter()" onmouseleave="handleMoveToGroupSubmenuLeave(event)">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
             </svg>
-            <span>移动到分组</span>
+            <span>{{t "ctx.move_to_group"}}</span>
             <svg class="submenu-arrow" width="12" height="12" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <path d="M9 18l6-6-6-6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
             </svg>
@@ -1883,7 +1884,7 @@ version: 1.0.0<br>
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <path d="M3 6h18M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2m3 0v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6h14z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
             </svg>
-            <span>删除此对话</span>
+            <span>{{t "ctx.delete_conversation"}}</span>
         </div>
     </div>
 
@@ -1894,19 +1895,19 @@ version: 1.0.0<br>
                 <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                 <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
             </svg>
-            <span>重命名</span>
+            <span>{{t "ctx.rename"}}</span>
         </div>
         <div class="context-menu-item" onclick="pinGroupFromContext()">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <path d="M12 17v5M5 17h14l-1-7H6l-1 7zM9 10V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
             </svg>
-            <span id="pin-group-menu-text">置顶此分组</span>
+            <span id="pin-group-menu-text">{{t "ctx.pin_group"}}</span>
         </div>
         <div class="context-menu-item context-menu-item-danger" onclick="deleteGroupFromContext()">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <path d="M3 6h18M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2m3 0v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6h14z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
             </svg>
-            <span>删除此分组</span>
+            <span>{{t "ctx.delete_group"}}</span>
         </div>
     </div>
 
@@ -1914,31 +1915,31 @@ version: 1.0.0<br>
     <div id="batch-import-modal" class="modal">
         <div class="modal-content" style="max-width: 800px;">
             <div class="modal-header">
-                <h2>新建任务</h2>
+                <h2>{{t "modal.batch_import.title"}}</h2>
                 <span class="modal-close" onclick="closeBatchImportModal()">&times;</span>
             </div>
             <div class="modal-body">
                 <div class="form-group">
-                    <label for="batch-queue-title">任务标题</label>
-                    <input type="text" id="batch-queue-title" placeholder="请输入任务标题（可选，用于标识和筛选）" />
+                    <label for="batch-queue-title">{{t "modal.batch_import.queue_title"}}</label>
+                    <input type="text" id="batch-queue-title" placeholder="{{t "modal.batch_import.queue_title_placeholder"}}" />
                     <div class="form-hint" style="margin-top: 4px;">
-                        为批量任务队列设置一个标题，方便后续查找和管理。
+                        {{t "modal.batch_import.queue_title_hint"}}
                     </div>
                 </div>
                 <div class="form-group">
-                    <label for="batch-queue-role">角色</label>
+                    <label for="batch-queue-role">{{t "modal.batch_import.role"}}</label>
                     <select id="batch-queue-role" style="width: 100%; padding: 8px; border: 1px solid #ddd; border-radius: 4px; font-size: 0.875rem;">
-                        <option value="">默认</option>
+                        <option value="">{{t "modal.batch_import.role_default"}}</option>
                     </select>
                     <div class="form-hint" style="margin-top: 4px;">
-                        选择一个角色，所有任务将使用该角色的配置（提示词和工具）执行。
+                        {{t "modal.batch_import.role_hint"}}
                     </div>
                 </div>
                 <div class="form-group">
-                    <label for="batch-tasks-input">任务列表（每行一个任务）<span style="color: red;">*</span></label>
-                    <textarea id="batch-tasks-input" rows="15" placeholder="请输入任务列表，每行一个任务，例如：&#10;扫描 192.168.1.1 的开放端口&#10;检查 https://example.com 是否存在SQL注入&#10;枚举 example.com 的子域名" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace; font-size: 0.875rem; line-height: 1.5;"></textarea>
+                    <label for="batch-tasks-input">{{t "modal.batch_import.tasks_label"}}<span style="color: red;">*</span></label>
+                    <textarea id="batch-tasks-input" rows="15" placeholder="{{t "modal.batch_import.tasks_placeholder"}}" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace; font-size: 0.875rem; line-height: 1.5;"></textarea>
                     <div class="form-hint" style="margin-top: 8px;">
-                        <strong>提示：</strong>每行输入一个任务指令，系统将依次执行这些任务。空行会被自动忽略。
+                        {{t "modal.batch_import.tasks_hint"}}
                     </div>
                 </div>
                 <div class="form-group">
@@ -1946,8 +1947,8 @@ version: 1.0.0<br>
                 </div>
             </div>
             <div class="modal-footer">
-                <button class="btn-secondary" onclick="closeBatchImportModal()">取消</button>
-                <button class="btn-primary" onclick="createBatchQueue()">创建队列</button>
+                <button class="btn-secondary" onclick="closeBatchImportModal()">{{t "ui.btn.cancel"}}</button>
+                <button class="btn-primary" onclick="createBatchQueue()">{{t "modal.batch_import.create_queue"}}</button>
             </div>
         </div>
     </div>
@@ -1956,13 +1957,13 @@ version: 1.0.0<br>
     <div id="batch-queue-detail-modal" class="modal">
         <div class="modal-content" style="max-width: 900px;">
             <div class="modal-header">
-                <h2 id="batch-queue-detail-title">批量任务队列详情</h2>
+                <h2 id="batch-queue-detail-title">{{t "modal.batch_queue.detail_title"}}</h2>
                 <div style="display: flex; align-items: center; gap: 12px;">
                     <div class="modal-header-actions">
-                        <button class="btn-secondary btn-small" id="batch-queue-add-task-btn" onclick="showAddBatchTaskModal()" style="display: none;">添加任务</button>
-                        <button class="btn-primary btn-small" id="batch-queue-start-btn" onclick="startBatchQueue()" style="display: none;">开始执行</button>
-                        <button class="btn-secondary btn-small" id="batch-queue-pause-btn" onclick="pauseBatchQueue()" style="display: none;">暂停队列</button>
-                        <button class="btn-secondary btn-small btn-danger" id="batch-queue-delete-btn" onclick="deleteBatchQueue()" style="display: none;">删除队列</button>
+                        <button class="btn-secondary btn-small" id="batch-queue-add-task-btn" onclick="showAddBatchTaskModal()" style="display: none;">{{t "modal.batch_queue.add_task"}}</button>
+                        <button class="btn-primary btn-small" id="batch-queue-start-btn" onclick="startBatchQueue()" style="display: none;">{{t "modal.batch_queue.start"}}</button>
+                        <button class="btn-secondary btn-small" id="batch-queue-pause-btn" onclick="pauseBatchQueue()" style="display: none;">{{t "modal.batch_queue.pause"}}</button>
+                        <button class="btn-secondary btn-small btn-danger" id="batch-queue-delete-btn" onclick="deleteBatchQueue()" style="display: none;">{{t "modal.batch_queue.delete"}}</button>
                     </div>
                     <span class="modal-close" onclick="closeBatchQueueDetailModal()">&times;</span>
                 </div>
@@ -1977,17 +1978,17 @@ version: 1.0.0<br>
     <div id="edit-batch-task-modal" class="modal">
         <div class="modal-content" style="max-width: 600px;">
             <div class="modal-header">
-                <h2>编辑任务</h2>
+                <h2>{{t "modal.edit_task.title"}}</h2>
                 <span class="modal-close" onclick="closeEditBatchTaskModal()">&times;</span>
             </div>
             <div class="modal-body">
                 <div class="form-group">
-                    <label for="edit-task-message">任务消息</label>
-                    <textarea id="edit-task-message" class="form-control" rows="5" placeholder="请输入任务消息"></textarea>
+                    <label for="edit-task-message">{{t "modal.edit_task.message"}}</label>
+                    <textarea id="edit-task-message" class="form-control" rows="5" placeholder="{{t "modal.edit_task.message_placeholder"}}"></textarea>
                 </div>
                 <div class="form-actions">
-                    <button class="btn-primary" onclick="saveBatchTask()">保存</button>
-                    <button class="btn-secondary" onclick="closeEditBatchTaskModal()">取消</button>
+                    <button class="btn-primary" onclick="saveBatchTask()">{{t "ui.btn.save"}}</button>
+                    <button class="btn-secondary" onclick="closeEditBatchTaskModal()">{{t "ui.btn.cancel"}}</button>
                 </div>
             </div>
         </div>
@@ -1997,17 +1998,17 @@ version: 1.0.0<br>
     <div id="add-batch-task-modal" class="modal">
         <div class="modal-content" style="max-width: 600px;">
             <div class="modal-header">
-                <h2>添加任务</h2>
+                <h2>{{t "modal.add_task.title"}}</h2>
                 <span class="modal-close" onclick="closeAddBatchTaskModal()">&times;</span>
             </div>
             <div class="modal-body">
                 <div class="form-group">
-                    <label for="add-task-message">任务消息</label>
-                    <textarea id="add-task-message" class="form-control" rows="5" placeholder="请输入任务消息"></textarea>
+                    <label for="add-task-message">{{t "modal.add_task.message"}}</label>
+                    <textarea id="add-task-message" class="form-control" rows="5" placeholder="{{t "modal.add_task.message_placeholder"}}"></textarea>
                 </div>
                 <div class="form-actions">
-                    <button class="btn-primary" onclick="saveAddBatchTask()">添加</button>
-                    <button class="btn-secondary" onclick="closeAddBatchTaskModal()">取消</button>
+                    <button class="btn-primary" onclick="saveAddBatchTask()">{{t "modal.add_task.add"}}</button>
+                    <button class="btn-secondary" onclick="closeAddBatchTaskModal()">{{t "ui.btn.cancel"}}</button>
                 </div>
             </div>
         </div>
@@ -2017,66 +2018,66 @@ version: 1.0.0<br>
     <div id="vulnerability-modal" class="modal">
         <div class="modal-content" style="max-width: 900px;">
             <div class="modal-header">
-                <h2 id="vulnerability-modal-title">添加漏洞</h2>
+                <h2 id="vulnerability-modal-title">{{t "modal.vuln.add_title"}}</h2>
                 <span class="modal-close" onclick="closeVulnerabilityModal()">&times;</span>
             </div>
             <div class="modal-body">
                 <div class="form-group">
-                    <label for="vulnerability-conversation-id">会话ID <span style="color: red;">*</span></label>
-                    <input type="text" id="vulnerability-conversation-id" placeholder="输入会话ID" required />
+                    <label for="vulnerability-conversation-id">{{t "modal.vuln.session_id"}} <span style="color: red;">*</span></label>
+                    <input type="text" id="vulnerability-conversation-id" placeholder="{{t "modal.vuln.session_id_placeholder"}}" required />
                 </div>
                 <div class="form-group">
-                    <label for="vulnerability-title">标题 <span style="color: red;">*</span></label>
-                    <input type="text" id="vulnerability-title" placeholder="漏洞标题" required />
+                    <label for="vulnerability-title">{{t "modal.vuln.title"}} <span style="color: red;">*</span></label>
+                    <input type="text" id="vulnerability-title" placeholder="{{t "modal.vuln.title_placeholder"}}" required />
                 </div>
                 <div class="form-group">
-                    <label for="vulnerability-description">描述</label>
-                    <textarea id="vulnerability-description" rows="5" placeholder="漏洞详细描述"></textarea>
+                    <label for="vulnerability-description">{{t "modal.vuln.description"}}</label>
+                    <textarea id="vulnerability-description" rows="5" placeholder="{{t "modal.vuln.description_placeholder"}}"></textarea>
                 </div>
                 <div class="form-group">
-                    <label for="vulnerability-severity">严重程度 <span style="color: red;">*</span></label>
+                    <label for="vulnerability-severity">{{t "modal.vuln.severity"}} <span style="color: red;">*</span></label>
                     <select id="vulnerability-severity" required>
-                        <option value="">请选择</option>
-                        <option value="critical">严重</option>
-                        <option value="high">高危</option>
-                        <option value="medium">中危</option>
-                        <option value="low">低危</option>
-                        <option value="info">信息</option>
+                        <option value="">{{t "modal.vuln.severity_select"}}</option>
+                        <option value="critical">{{t "vuln.severity.critical"}}</option>
+                        <option value="high">{{t "vuln.severity.high"}}</option>
+                        <option value="medium">{{t "vuln.severity.medium"}}</option>
+                        <option value="low">{{t "vuln.severity.low"}}</option>
+                        <option value="info">{{t "vuln.severity.info"}}</option>
                     </select>
                 </div>
                 <div class="form-group">
-                    <label for="vulnerability-status">状态</label>
+                    <label for="vulnerability-status">{{t "modal.vuln.status"}}</label>
                     <select id="vulnerability-status">
-                        <option value="open">待处理</option>
-                        <option value="confirmed">已确认</option>
-                        <option value="fixed">已修复</option>
-                        <option value="false_positive">误报</option>
+                        <option value="open">{{t "vuln.filter.status_open"}}</option>
+                        <option value="confirmed">{{t "vuln.filter.status_confirmed"}}</option>
+                        <option value="fixed">{{t "vuln.filter.status_fixed"}}</option>
+                        <option value="false_positive">{{t "vuln.filter.status_false_positive"}}</option>
                     </select>
                 </div>
                 <div class="form-group">
-                    <label for="vulnerability-type">漏洞类型</label>
-                    <input type="text" id="vulnerability-type" placeholder="如：SQL注入、XSS、CSRF等" />
+                    <label for="vulnerability-type">{{t "modal.vuln.type"}}</label>
+                    <input type="text" id="vulnerability-type" placeholder="{{t "modal.vuln.type_placeholder"}}" />
                 </div>
                 <div class="form-group">
-                    <label for="vulnerability-target">目标</label>
-                    <input type="text" id="vulnerability-target" placeholder="受影响的目标（URL、IP地址等）" />
+                    <label for="vulnerability-target">{{t "modal.vuln.target"}}</label>
+                    <input type="text" id="vulnerability-target" placeholder="{{t "modal.vuln.target_placeholder"}}" />
                 </div>
                 <div class="form-group">
-                    <label for="vulnerability-proof">证明（POC）</label>
-                    <textarea id="vulnerability-proof" rows="5" placeholder="漏洞证明，如请求/响应、截图等"></textarea>
+                    <label for="vulnerability-proof">{{t "modal.vuln.proof"}}</label>
+                    <textarea id="vulnerability-proof" rows="5" placeholder="{{t "modal.vuln.proof_placeholder"}}"></textarea>
                 </div>
                 <div class="form-group">
-                    <label for="vulnerability-impact">影响</label>
-                    <textarea id="vulnerability-impact" rows="3" placeholder="漏洞影响说明"></textarea>
+                    <label for="vulnerability-impact">{{t "modal.vuln.impact"}}</label>
+                    <textarea id="vulnerability-impact" rows="3" placeholder="{{t "modal.vuln.impact_placeholder"}}"></textarea>
                 </div>
                 <div class="form-group">
-                    <label for="vulnerability-recommendation">修复建议</label>
-                    <textarea id="vulnerability-recommendation" rows="3" placeholder="修复建议"></textarea>
+                    <label for="vulnerability-recommendation">{{t "modal.vuln.recommendation"}}</label>
+                    <textarea id="vulnerability-recommendation" rows="3" placeholder="{{t "modal.vuln.recommendation_placeholder"}}"></textarea>
                 </div>
             </div>
             <div class="modal-footer">
-                <button class="btn-secondary" onclick="closeVulnerabilityModal()">取消</button>
-                <button class="btn-primary" onclick="saveVulnerability()">保存</button>
+                <button class="btn-secondary" onclick="closeVulnerabilityModal()">{{t "ui.btn.cancel"}}</button>
+                <button class="btn-primary" onclick="saveVulnerability()">{{t "ui.btn.save"}}</button>
             </div>
         </div>
     </div>
@@ -2085,7 +2086,7 @@ version: 1.0.0<br>
     <div id="role-select-modal" class="modal">
         <div class="modal-content role-select-modal-content">
             <div class="modal-header">
-                <h2>选择角色</h2>
+                <h2>{{t "modal.role_select.title"}}</h2>
                 <span class="modal-close" onclick="closeRoleSelectModal()">&times;</span>
             </div>
             <div class="modal-body role-select-body">
@@ -2098,49 +2099,49 @@ version: 1.0.0<br>
     <div id="role-modal" class="modal">
         <div class="modal-content" style="max-width: 900px;">
             <div class="modal-header">
-                <h2 id="role-modal-title">添加角色</h2>
+                <h2 id="role-modal-title">{{t "modal.role.add_title"}}</h2>
                 <span class="modal-close" onclick="closeRoleModal()">&times;</span>
             </div>
             <div class="modal-body">
                 <div class="form-group">
-                    <label for="role-name">角色名称 <span style="color: red;">*</span></label>
-                    <input type="text" id="role-name" placeholder="输入角色名称" required />
+                    <label for="role-name">{{t "modal.role.name"}} <span style="color: red;">*</span></label>
+                    <input type="text" id="role-name" placeholder="{{t "modal.role.name_placeholder"}}" required />
                 </div>
                 <div class="form-group">
-                    <label for="role-description">角色描述</label>
-                    <input type="text" id="role-description" placeholder="输入角色描述" />
+                    <label for="role-description">{{t "modal.role.description"}}</label>
+                    <input type="text" id="role-description" placeholder="{{t "modal.role.description_placeholder"}}" />
                 </div>
                 <div class="form-group">
-                    <label for="role-icon">角色图标</label>
-                    <input type="text" id="role-icon" placeholder="输入emoji图标，例如: 🏆" maxlength="10" />
-                    <small class="form-hint">输入一个emoji作为角色的图标，将显示在角色选择器中。</small>
+                    <label for="role-icon">{{t "modal.role.icon"}}</label>
+                    <input type="text" id="role-icon" placeholder="{{t "modal.role.icon_placeholder"}}" maxlength="10" />
+                    <small class="form-hint">{{t "modal.role.icon_hint"}}</small>
                 </div>
                 <div class="form-group">
-                    <label for="role-user-prompt">用户提示词</label>
-                    <textarea id="role-user-prompt" rows="10" placeholder="输入用户提示词，会在用户消息前追加此提示词..."></textarea>
-                    <small class="form-hint">此提示词会追加到用户消息前，用于指导AI的行为。注意：这不会修改系统提示词。</small>
+                    <label for="role-user-prompt">{{t "modal.role.user_prompt"}}</label>
+                    <textarea id="role-user-prompt" rows="10" placeholder="{{t "modal.role.user_prompt_placeholder"}}"></textarea>
+                    <small class="form-hint">{{t "modal.role.user_prompt_hint"}}</small>
                 </div>
                 <div class="form-group" id="role-tools-section">
-                    <label>关联的工具（可选）</label>
+                    <label>{{t "modal.role.tools"}}</label>
                     <div id="role-tools-default-hint" class="role-tools-default-hint" style="display: none;">
                         <div class="role-tools-default-info">
                             <span class="role-tools-default-icon">ℹ️</span>
                             <div class="role-tools-default-content">
-                                <div class="role-tools-default-title">默认角色使用所有工具</div>
-                                <div class="role-tools-default-desc">默认角色会自动使用MCP管理中启用的所有工具，无需单独配置。</div>
+                                <div class="role-tools-default-title">{{t "modal.role.tools_default_title"}}</div>
+                                <div class="role-tools-default-desc">{{t "modal.role.tools_default_desc"}}</div>
                             </div>
                         </div>
                     </div>
                     <div class="role-tools-controls">
                         <div class="role-tools-actions">
-                            <button type="button" class="btn-secondary" onclick="selectAllRoleTools()">全选</button>
-                            <button type="button" class="btn-secondary" onclick="deselectAllRoleTools()">全不选</button>
+                            <button type="button" class="btn-secondary" onclick="selectAllRoleTools()">{{t "modal.role.tools_select_all"}}</button>
+                            <button type="button" class="btn-secondary" onclick="deselectAllRoleTools()">{{t "modal.role.tools_deselect_all"}}</button>
                             <div class="role-tools-search-box">
-                                <input type="text" id="role-tools-search" placeholder="搜索工具..." 
-                                       oninput="searchRoleTools(this.value)" 
+                                <input type="text" id="role-tools-search" placeholder="{{t "modal.role.tools_search_placeholder"}}"
+                                       oninput="searchRoleTools(this.value)"
                                        onkeypress="if(event.key === 'Enter') searchRoleTools(this.value)" />
-                                <button class="role-tools-search-clear" id="role-tools-search-clear" 
-                                        onclick="clearRoleToolsSearch()" style="display: none;" title="清除搜索">
+                                <button class="role-tools-search-clear" id="role-tools-search-clear"
+                                        onclick="clearRoleToolsSearch()" style="display: none;" title="{{t "modal.role.tools_clear_search"}}">
                                     <svg width="14" height="14" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                                         <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
                                         <path d="M15 9l-6 6M9 9l6 6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
@@ -2151,22 +2152,22 @@ version: 1.0.0<br>
                         <div id="role-tools-stats" class="role-tools-stats"></div>
                     </div>
                     <div id="role-tools-list" class="role-tools-list">
-                        <div class="tools-loading">正在加载工具列表...</div>
+                        <div class="tools-loading">{{t "modal.role.tools_loading"}}</div>
                     </div>
-                    <small class="form-hint">勾选要关联的工具，留空则使用MCP管理中的全部工具配置。</small>
+                    <small class="form-hint">{{t "modal.role.tools_hint"}}</small>
                 </div>
                 <div class="form-group" id="role-skills-section">
-                    <label>关联的Skills（可选）</label>
+                    <label>{{t "modal.role.skills"}}</label>
                     <div class="role-skills-controls">
                         <div class="role-skills-actions">
-                            <button type="button" class="btn-secondary" onclick="selectAllRoleSkills()">全选</button>
-                            <button type="button" class="btn-secondary" onclick="deselectAllRoleSkills()">全不选</button>
+                            <button type="button" class="btn-secondary" onclick="selectAllRoleSkills()">{{t "modal.role.skills_select_all"}}</button>
+                            <button type="button" class="btn-secondary" onclick="deselectAllRoleSkills()">{{t "modal.role.skills_deselect_all"}}</button>
                             <div class="role-skills-search-box">
-                                <input type="text" id="role-skills-search" placeholder="搜索skill..." 
-                                       oninput="searchRoleSkills(this.value)" 
+                                <input type="text" id="role-skills-search" placeholder="{{t "modal.role.skills_search_placeholder"}}"
+                                       oninput="searchRoleSkills(this.value)"
                                        onkeypress="if(event.key === 'Enter') searchRoleSkills(this.value)" />
-                                <button class="role-skills-search-clear" id="role-skills-search-clear" 
-                                        onclick="clearRoleSkillsSearch()" style="display: none;" title="清除搜索">
+                                <button class="role-skills-search-clear" id="role-skills-search-clear"
+                                        onclick="clearRoleSkillsSearch()" style="display: none;" title="{{t "modal.role.skills_clear_search"}}">
                                     <svg width="14" height="14" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                                         <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
                                         <path d="M15 9l-6 6M9 9l6 6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
@@ -2177,21 +2178,21 @@ version: 1.0.0<br>
                         <div id="role-skills-stats" class="role-skills-stats"></div>
                     </div>
                     <div id="role-skills-list" class="role-skills-list">
-                        <div class="skills-loading">正在加载skills列表...</div>
+                        <div class="skills-loading">{{t "modal.role.skills_loading"}}</div>
                     </div>
-                    <small class="form-hint">勾选要关联的skills，这些skills的内容会在执行任务前注入到系统提示词中，帮助AI更好地理解相关专业知识。</small>
+                    <small class="form-hint">{{t "modal.role.skills_hint"}}</small>
                 </div>
                 <div class="form-group">
                     <label class="checkbox-label">
                         <input type="checkbox" id="role-enabled" class="modern-checkbox" checked />
                         <span class="checkbox-custom"></span>
-                        <span class="checkbox-text">启用此角色</span>
+                        <span class="checkbox-text">{{t "modal.role.enabled"}}</span>
                     </label>
                 </div>
             </div>
             <div class="modal-footer">
-                <button class="btn-secondary" onclick="closeRoleModal()">取消</button>
-                <button class="btn-primary" onclick="saveRole()">保存</button>
+                <button class="btn-secondary" onclick="closeRoleModal()">{{t "ui.btn.cancel"}}</button>
+                <button class="btn-primary" onclick="saveRole()">{{t "ui.btn.save"}}</button>
             </div>
         </div>
     </div>


### PR DESCRIPTION
- Add i18n middleware and {{t "key"}} template engine integration
- Localize all JS files (auth, chat, dashboard, knowledge, monitor, roles, settings, skills, tasks, terminal, vulnerability, info-collect)
- Localize index.html: replace ~150+ hardcoded Chinese strings with {{t "key"}} calls
- Add messages/message_cn.properties and messages/message_ko.properties with 100+ new keys
- Add CLAUDE.md with project architecture documentation