### PR TITLE
Support X-Forwarded-Proto in SSE endpoint generation

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -220,6 +220,8 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 	scheme := "http"
 	if r.TLS != nil {
 		scheme = "https"
+	} else if proto := r.Header.Get("X-Forwarded-Proto"); proto != "" {
+		scheme = proto
 	}
 	if r.URL.Scheme != "" {
 		scheme = r.URL.Scheme


### PR DESCRIPTION
Added check for `X-Forwarded-Proto` header in `internal/mcp/server.go` to correctly determine protocol when behind a reverse proxy.

---
*Automated PR created by OpenClaw daily-pr routine.*