### PR TITLE
fix(mcp): support X-Forwarded-Proto in SSE endpoint scheme

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -220,6 +220,8 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 	scheme := "http"
 	if r.TLS != nil {
 		scheme = "https"
+	} else if proto := r.Header.Get("X-Forwarded-Proto"); proto != "" {
+		scheme = proto
 	}
 	if r.URL.Scheme != "" {
 		scheme = r.URL.Scheme


### PR DESCRIPTION
When the MCP SSE server runs behind a TLS-terminating reverse proxy (nginx, Caddy, ALB), `r.TLS` is nil so the advertised endpoint URL ends up as `http://...`, breaking clients that connected over `https://`.

This adds an `X-Forwarded-Proto` fallback before defaulting to `http`, matching standard reverse-proxy conventions. `r.URL.Scheme` (when explicitly set) still wins.

```go
scheme := "http"
if r.TLS != nil {
    scheme = "https"
} else if proto := r.Header.Get("X-Forwarded-Proto"); proto != "" {
    scheme = proto
}
if r.URL.Scheme != "" {
    scheme = r.URL.Scheme
}
```

Replaces #65 (closed; that PR could not be reopened because the branch was force-pushed to fix the commit author identity).