### PR TITLE
fix(mcp-stdio): initialize result storage so query tools work

### DIFF
--- a/cmd/mcp-stdio/main.go
+++ b/cmd/mcp-stdio/main.go
@@ -5,6 +5,7 @@ import (
 	"cyberstrike-ai/internal/logger"
 	"cyberstrike-ai/internal/mcp"
 	"cyberstrike-ai/internal/security"
+	"cyberstrike-ai/internal/storage"
 	"flag"
 	"fmt"
 	"os"
@@ -31,6 +32,23 @@ func main() {
 
 	// 创建安全工具执行器
 	executor := security.NewExecutor(&cfg.Security, mcpServer, log.Logger)
+
+	// 初始化结果存储（与 internal/app/app.go 同样的逻辑）。
+	// stdio 模式下原本不初始化，导致 'exec' 等查询型工具报"结果存储未初始化"。
+	resultStorageDir := "tmp"
+	if cfg.Agent.ResultStorageDir != "" {
+		resultStorageDir = cfg.Agent.ResultStorageDir
+	}
+	if err := os.MkdirAll(resultStorageDir, 0755); err != nil {
+		fmt.Fprintf(os.Stderr, "创建结果存储目录失败: %v\n", err)
+		os.Exit(1)
+	}
+	resultStorage, err := storage.NewFileResultStorage(resultStorageDir, log.Logger)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "初始化结果存储失败: %v\n", err)
+		os.Exit(1)
+	}
+	executor.SetResultStorage(resultStorage)
 
 	// 注册工具
 	executor.RegisterTools(mcpServer)


### PR DESCRIPTION
## Summary

The stdio MCP entrypoint (`cmd/mcp-stdio/main.go`) constructs the security `Executor` without calling `SetResultStorage`, so the executor's `resultStorage` is `nil`. Any tool that goes through the query path — notably `exec` (the generic shell tool) and YAML wrappers that emit large results — fails with:

> 错误: 结果存储未初始化  (Error: result storage not initialized)

The HTTP entrypoint (`internal/app/app.go:118-147`) already initializes a `FileResultStorage` from `cfg.Agent.ResultStorageDir` and wires it via `agent.SetResultStorage` + `executor.SetResultStorage`. The stdio entrypoint needs the same wiring.

This patch replicates the storage init block in `main.go`. After the fix, `exec` calls work end-to-end in stdio mode.

## Repro

Connected `cmd/mcp-stdio` to an external MCP client (OpenJarvis), invoked `tools/call` with `{"name":"exec","arguments":{"command":"nmap -p 22,80,443 -T4 127.0.0.1"}}`.

- Before: response content = `"错误: 结果存储未初始化"`, scan never runs.
- After: response content = full nmap scan output (0.01s on localhost).

The same applies to other YAML-wrapped tools that route through the executor's query/store path.

## Change

`cmd/mcp-stdio/main.go`: copy the storage-init pattern from `internal/app/app.go` (resolve `ResultStorageDir`, `os.MkdirAll`, `storage.NewFileResultStorage`, `executor.SetResultStorage`) before tools are registered.

## Test plan

- [x] Manual: `exec`-based MCP tool call returns the actual command output instead of the "结果存储未初始化" error.
- [ ] Adding a stdio-mode unit test in `cmd/mcp-stdio/` would be welcome — happy to follow whatever pattern you prefer.

Note: this is the same `storage.NewFileResultStorage` constructor used by the HTTP app; the storage dir defaults to `tmp` and is overridable via `agent.result_storage_dir` in the config (same as for the HTTP entrypoint).