### PR TITLE
Fix stable conversation ordering and task titles

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -849,6 +849,7 @@ func setupRoutes(
 		protected.POST("/batch-tasks/:queueId/rerun", agentHandler.RerunBatchQueue)
 		protected.POST("/batch-tasks/:queueId/pause", agentHandler.PauseBatchQueue)
 		protected.PUT("/batch-tasks/:queueId/metadata", agentHandler.UpdateBatchQueueMetadata)
+		protected.PUT("/batch-tasks/:queueId/concurrency", agentHandler.UpdateBatchQueueConcurrency)
 		protected.PUT("/batch-tasks/:queueId/schedule", agentHandler.UpdateBatchQueueSchedule)
 		protected.PUT("/batch-tasks/:queueId/schedule-enabled", agentHandler.SetBatchQueueScheduleEnabled)
 		protected.DELETE("/batch-tasks/:queueId", agentHandler.DeleteBatchQueue)

--- a/internal/database/batch_task.go
+++ b/internal/database/batch_task.go
@@ -23,6 +23,7 @@ type BatchTaskQueueRow struct {
 	LastScheduleError     sql.NullString
 	LastRunError          sql.NullString
 	ProjectID             sql.NullString
+	Concurrency           sql.NullInt64
 	Status                string
 	CreatedAt             time.Time
 	StartedAt             sql.NullTime
@@ -53,6 +54,7 @@ func (db *DB) CreateBatchQueue(
 	cronExpr string,
 	nextRunAt *time.Time,
 	projectID string,
+	concurrency int,
 	tasks []map[string]interface{},
 ) error {
 	tx, err := db.Begin()
@@ -71,9 +73,12 @@ func (db *DB) CreateBatchQueue(
 	if strings.TrimSpace(projectID) != "" {
 		projectIDVal = strings.TrimSpace(projectID)
 	}
+	if concurrency < 1 {
+		concurrency = 1
+	}
 	_, err = tx.Exec(
-		"INSERT INTO batch_task_queues (id, title, role, agent_mode, schedule_mode, cron_expr, next_run_at, schedule_enabled, project_id, status, created_at, current_index) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-		queueID, title, role, agentMode, scheduleMode, cronExpr, nextRunAtValue, 1, projectIDVal, "pending", now, 0,
+		"INSERT INTO batch_task_queues (id, title, role, agent_mode, schedule_mode, cron_expr, next_run_at, schedule_enabled, project_id, concurrency, status, created_at, current_index) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+		queueID, title, role, agentMode, scheduleMode, cronExpr, nextRunAtValue, 1, projectIDVal, concurrency, "pending", now, 0,
 	)
 	if err != nil {
 		return fmt.Errorf("创建批量任务队列失败: %w", err)
@@ -107,9 +112,9 @@ func (db *DB) GetBatchQueue(queueID string) (*BatchTaskQueueRow, error) {
 	var row BatchTaskQueueRow
 	var createdAt string
 	err := db.QueryRow(
-		"SELECT id, title, role, agent_mode, schedule_mode, cron_expr, next_run_at, schedule_enabled, last_schedule_trigger_at, last_schedule_error, last_run_error, project_id, status, created_at, started_at, completed_at, current_index FROM batch_task_queues WHERE id = ?",
+		"SELECT id, title, role, agent_mode, schedule_mode, cron_expr, next_run_at, schedule_enabled, last_schedule_trigger_at, last_schedule_error, last_run_error, project_id, concurrency, status, created_at, started_at, completed_at, current_index FROM batch_task_queues WHERE id = ?",
 		queueID,
-	).Scan(&row.ID, &row.Title, &row.Role, &row.AgentMode, &row.ScheduleMode, &row.CronExpr, &row.NextRunAt, &row.ScheduleEnabled, &row.LastScheduleTriggerAt, &row.LastScheduleError, &row.LastRunError, &row.ProjectID, &row.Status, &createdAt, &row.StartedAt, &row.CompletedAt, &row.CurrentIndex)
+	).Scan(&row.ID, &row.Title, &row.Role, &row.AgentMode, &row.ScheduleMode, &row.CronExpr, &row.NextRunAt, &row.ScheduleEnabled, &row.LastScheduleTriggerAt, &row.LastScheduleError, &row.LastRunError, &row.ProjectID, &row.Concurrency, &row.Status, &createdAt, &row.StartedAt, &row.CompletedAt, &row.CurrentIndex)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -133,7 +138,7 @@ func (db *DB) GetBatchQueue(queueID string) (*BatchTaskQueueRow, error) {
 // GetAllBatchQueues 获取所有批量任务队列
 func (db *DB) GetAllBatchQueues() ([]*BatchTaskQueueRow, error) {
 	rows, err := db.Query(
-		"SELECT id, title, role, agent_mode, schedule_mode, cron_expr, next_run_at, schedule_enabled, last_schedule_trigger_at, last_schedule_error, last_run_error, project_id, status, created_at, started_at, completed_at, current_index FROM batch_task_queues ORDER BY created_at DESC",
+		"SELECT id, title, role, agent_mode, schedule_mode, cron_expr, next_run_at, schedule_enabled, last_schedule_trigger_at, last_schedule_error, last_run_error, project_id, concurrency, status, created_at, started_at, completed_at, current_index FROM batch_task_queues ORDER BY created_at DESC",
 	)
 	if err != nil {
 		return nil, fmt.Errorf("查询批量任务队列列表失败: %w", err)
@@ -144,7 +149,7 @@ func (db *DB) GetAllBatchQueues() ([]*BatchTaskQueueRow, error) {
 	for rows.Next() {
 		var row BatchTaskQueueRow
 		var createdAt string
-		if err := rows.Scan(&row.ID, &row.Title, &row.Role, &row.AgentMode, &row.ScheduleMode, &row.CronExpr, &row.NextRunAt, &row.ScheduleEnabled, &row.LastScheduleTriggerAt, &row.LastScheduleError, &row.LastRunError, &row.ProjectID, &row.Status, &createdAt, &row.StartedAt, &row.CompletedAt, &row.CurrentIndex); err != nil {
+		if err := rows.Scan(&row.ID, &row.Title, &row.Role, &row.AgentMode, &row.ScheduleMode, &row.CronExpr, &row.NextRunAt, &row.ScheduleEnabled, &row.LastScheduleTriggerAt, &row.LastScheduleError, &row.LastRunError, &row.ProjectID, &row.Concurrency, &row.Status, &createdAt, &row.StartedAt, &row.CompletedAt, &row.CurrentIndex); err != nil {
 			return nil, fmt.Errorf("扫描批量任务队列失败: %w", err)
 		}
 		parsedTime, parseErr := time.Parse("2006-01-02 15:04:05", createdAt)
@@ -164,7 +169,7 @@ func (db *DB) GetAllBatchQueues() ([]*BatchTaskQueueRow, error) {
 
 // ListBatchQueues 列出批量任务队列（支持筛选和分页）
 func (db *DB) ListBatchQueues(limit, offset int, status, keyword string) ([]*BatchTaskQueueRow, error) {
-	query := "SELECT id, title, role, agent_mode, schedule_mode, cron_expr, next_run_at, schedule_enabled, last_schedule_trigger_at, last_schedule_error, last_run_error, project_id, status, created_at, started_at, completed_at, current_index FROM batch_task_queues WHERE 1=1"
+	query := "SELECT id, title, role, agent_mode, schedule_mode, cron_expr, next_run_at, schedule_enabled, last_schedule_trigger_at, last_schedule_error, last_run_error, project_id, concurrency, status, created_at, started_at, completed_at, current_index FROM batch_task_queues WHERE 1=1"
 	args := []interface{}{}
 
 	// 状态筛选
@@ -192,7 +197,7 @@ func (db *DB) ListBatchQueues(limit, offset int, status, keyword string) ([]*Bat
 	for rows.Next() {
 		var row BatchTaskQueueRow
 		var createdAt string
-		if err := rows.Scan(&row.ID, &row.Title, &row.Role, &row.AgentMode, &row.ScheduleMode, &row.CronExpr, &row.NextRunAt, &row.ScheduleEnabled, &row.LastScheduleTriggerAt, &row.LastScheduleError, &row.LastRunError, &row.ProjectID, &row.Status, &createdAt, &row.StartedAt, &row.CompletedAt, &row.CurrentIndex); err != nil {
+		if err := rows.Scan(&row.ID, &row.Title, &row.Role, &row.AgentMode, &row.ScheduleMode, &row.CronExpr, &row.NextRunAt, &row.ScheduleEnabled, &row.LastScheduleTriggerAt, &row.LastScheduleError, &row.LastRunError, &row.ProjectID, &row.Concurrency, &row.Status, &createdAt, &row.StartedAt, &row.CompletedAt, &row.CurrentIndex); err != nil {
 			return nil, fmt.Errorf("扫描批量任务队列失败: %w", err)
 		}
 		parsedTime, parseErr := time.Parse("2006-01-02 15:04:05", createdAt)
@@ -262,6 +267,61 @@ func (db *DB) GetBatchTasks(queueID string) ([]*BatchTaskRow, error) {
 	return tasks, nil
 }
 
+// ListBatchTaskConversationIDs returns every conversation currently associated
+// with a batch task. Startup recovery uses this snapshot to avoid treating
+// pending batch placeholders as ordinary interrupted chats.
+func (db *DB) ListBatchTaskConversationIDs() ([]string, error) {
+	rows, err := db.Query(
+		`SELECT DISTINCT conversation_id
+		 FROM batch_tasks
+		 WHERE TRIM(COALESCE(conversation_id, '')) <> ''`,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("查询批量任务对话失败: %w", err)
+	}
+	defer rows.Close()
+
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("扫描批量任务对话失败: %w", err)
+		}
+		id = strings.TrimSpace(id)
+		if id != "" {
+			ids = append(ids, id)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("遍历批量任务对话失败: %w", err)
+	}
+	return ids, nil
+}
+
+func (db *DB) MaxBatchTaskRowID() (int64, error) {
+	var rowID sql.NullInt64
+	if err := db.QueryRow("SELECT MAX(rowid) FROM batch_tasks").Scan(&rowID); err != nil {
+		return 0, fmt.Errorf("查询批量任务快照失败: %w", err)
+	}
+	if !rowID.Valid {
+		return 0, nil
+	}
+	return rowID.Int64, nil
+}
+
+// CountBatchTasksByStatus returns the number of tasks in a queue with the
+// provided status.
+func (db *DB) CountBatchTasksByStatus(queueID, status string) (int, error) {
+	var count int
+	if err := db.QueryRow(
+		"SELECT COUNT(*) FROM batch_tasks WHERE queue_id = ? AND status = ?",
+		queueID, status,
+	).Scan(&count); err != nil {
+		return 0, fmt.Errorf("统计批量任务状态失败: %w", err)
+	}
+	return count, nil
+}
+
 // UpdateBatchQueueStatus 更新批量任务队列状态
 func (db *DB) UpdateBatchQueueStatus(queueID, status string) error {
 	var err error
@@ -320,11 +380,22 @@ func (db *DB) UpdateBatchTaskStatus(queueID, taskID, status string, conversation
 	if status == "running" {
 		updates = append(updates, "started_at = COALESCE(started_at, ?)")
 		args = append(args, now)
+		updates = append(updates, "completed_at = NULL")
+		updates = append(updates, "error = NULL")
+		updates = append(updates, "result = NULL")
 	}
 
 	if status == "completed" || status == "failed" || status == "cancelled" {
 		updates = append(updates, "completed_at = COALESCE(completed_at, ?)")
 		args = append(args, now)
+		switch status {
+		case "completed":
+			updates = append(updates, "error = NULL")
+		case "failed":
+			updates = append(updates, "result = NULL")
+		case "cancelled":
+			updates = append(updates, "error = NULL")
+		}
 	}
 
 	args = append(args, queueID, taskID)
@@ -346,58 +417,148 @@ func (db *DB) UpdateBatchTaskStatus(queueID, taskID, status string, conversation
 	return nil
 }
 
+// ClaimBatchTaskForRun marks a pending task as running and clears stale output
+// fields from any previous interrupted/queued association.
+func (db *DB) ClaimBatchTaskForRun(queueID, taskID string) error {
+	now := time.Now()
+	res, err := db.Exec(
+		`UPDATE batch_tasks
+		 SET status = ?, started_at = COALESCE(started_at, ?),
+		     completed_at = NULL, error = NULL, result = NULL
+		 WHERE queue_id = ? AND id = ? AND status = ?`,
+		"running", now, queueID, taskID, "pending",
+	)
+	if err != nil {
+		return fmt.Errorf("领取批量任务失败: %w", err)
+	}
+	if n, nerr := res.RowsAffected(); nerr == nil && n == 0 {
+		return fmt.Errorf("任务不存在或已被领取")
+	}
+	return nil
+}
+
 // RecoverInterruptedBatchQueues marks tasks that were running before a process
 // restart as failed without changing their queue status. The caller can then
-// decide whether to continue recovered running queues.
-func (db *DB) RecoverInterruptedBatchQueues(errorMsg string) ([]string, int64, error) {
+// decide whether to continue recovered running queues. It also returns the
+// conversation IDs that belonged to the interrupted running subtasks, so only
+// those assistant placeholders are finalized.
+func (db *DB) RecoverInterruptedBatchQueues(errorMsg string) ([]string, []string, int64, error) {
+	return db.RecoverInterruptedBatchQueuesBefore(errorMsg, 0)
+}
+
+func (db *DB) RecoverInterruptedBatchQueuesBefore(errorMsg string, maxTaskRowID int64) ([]string, []string, int64, error) {
 	tx, err := db.Begin()
 	if err != nil {
-		return nil, 0, fmt.Errorf("开始事务失败: %w", err)
+		return nil, nil, 0, fmt.Errorf("开始事务失败: %w", err)
 	}
 	defer tx.Rollback()
 
+	taskSnapshotFilter := ""
+	args := []interface{}{"running"}
+	if maxTaskRowID > 0 {
+		taskSnapshotFilter = " AND t.rowid <= ?"
+		args = append(args, maxTaskRowID)
+	}
+
 	rows, err := tx.Query(
-		"SELECT id FROM batch_task_queues WHERE status = ? ORDER BY created_at ASC",
-		"running",
+		`SELECT DISTINCT q.id, q.status
+		 FROM batch_task_queues q
+		 JOIN batch_tasks t ON t.queue_id = q.id
+		 WHERE t.status = ?
+		 `+taskSnapshotFilter+`
+		 ORDER BY q.created_at ASC`,
+		args...,
 	)
 	if err != nil {
-		return nil, 0, fmt.Errorf("查询重启前运行中的批量任务队列失败: %w", err)
+		return nil, nil, 0, fmt.Errorf("查询重启前运行中的批量任务队列失败: %w", err)
 	}
 	defer rows.Close()
 
-	var queueIDs []string
+	var interruptedQueueIDs []string
+	var resumeQueueIDs []string
 	for rows.Next() {
 		var queueID string
-		if err := rows.Scan(&queueID); err != nil {
-			return nil, 0, fmt.Errorf("扫描重启前运行中的批量任务队列失败: %w", err)
+		var queueStatus string
+		if err := rows.Scan(&queueID, &queueStatus); err != nil {
+			return nil, nil, 0, fmt.Errorf("扫描重启前运行中的批量任务队列失败: %w", err)
 		}
-		queueIDs = append(queueIDs, queueID)
+		interruptedQueueIDs = append(interruptedQueueIDs, queueID)
+		if queueStatus == "running" {
+			resumeQueueIDs = append(resumeQueueIDs, queueID)
+		}
 	}
 	if err := rows.Err(); err != nil {
-		return nil, 0, fmt.Errorf("遍历重启前运行中的批量任务队列失败: %w", err)
+		return nil, nil, 0, fmt.Errorf("遍历重启前运行中的批量任务队列失败: %w", err)
 	}
 	if err := rows.Close(); err != nil {
-		return nil, 0, fmt.Errorf("关闭重启前运行中的批量任务队列查询失败: %w", err)
+		return nil, nil, 0, fmt.Errorf("关闭重启前运行中的批量任务队列查询失败: %w", err)
 	}
-	if len(queueIDs) == 0 {
+	if len(interruptedQueueIDs) == 0 {
 		if err := tx.Commit(); err != nil {
-			return nil, 0, fmt.Errorf("提交事务失败: %w", err)
+			return nil, nil, 0, fmt.Errorf("提交事务失败: %w", err)
 		}
-		return nil, 0, nil
+		return nil, nil, 0, nil
 	}
 
 	now := time.Now()
 	var failedTasks int64
-	for _, queueID := range queueIDs {
-		res, err := tx.Exec(
-			`UPDATE batch_tasks
-			 SET status = ?, completed_at = COALESCE(completed_at, ?),
-			     error = CASE WHEN TRIM(COALESCE(error, '')) = '' THEN ? ELSE error END
-			 WHERE queue_id = ? AND status = ?`,
-			"failed", now, errorMsg, queueID, "running",
+	conversationIDSeen := make(map[string]struct{})
+	var interruptedConversationIDs []string
+	for _, queueID := range interruptedQueueIDs {
+		taskQuery := `SELECT DISTINCT conversation_id
+			 FROM batch_tasks
+			 WHERE queue_id = ? AND status = ? AND TRIM(COALESCE(conversation_id, '')) <> ''`
+		taskArgs := []interface{}{queueID, "running"}
+		if maxTaskRowID > 0 {
+			taskQuery += " AND rowid <= ?"
+			taskArgs = append(taskArgs, maxTaskRowID)
+		}
+		taskRows, err := tx.Query(
+			taskQuery,
+			taskArgs...,
 		)
 		if err != nil {
-			return nil, 0, fmt.Errorf("标记重启中断的批量子任务失败: %w", err)
+			return nil, nil, 0, fmt.Errorf("查询重启中断的批量子任务对话失败: %w", err)
+		}
+		for taskRows.Next() {
+			var conversationID string
+			if err := taskRows.Scan(&conversationID); err != nil {
+				_ = taskRows.Close()
+				return nil, nil, 0, fmt.Errorf("扫描重启中断的批量子任务对话失败: %w", err)
+			}
+			conversationID = strings.TrimSpace(conversationID)
+			if conversationID == "" {
+				continue
+			}
+			if _, ok := conversationIDSeen[conversationID]; ok {
+				continue
+			}
+			conversationIDSeen[conversationID] = struct{}{}
+			interruptedConversationIDs = append(interruptedConversationIDs, conversationID)
+		}
+		if err := taskRows.Err(); err != nil {
+			_ = taskRows.Close()
+			return nil, nil, 0, fmt.Errorf("遍历重启中断的批量子任务对话失败: %w", err)
+		}
+		if err := taskRows.Close(); err != nil {
+			return nil, nil, 0, fmt.Errorf("关闭重启中断的批量子任务对话查询失败: %w", err)
+		}
+
+		updateQuery := `UPDATE batch_tasks
+			 SET status = ?, completed_at = COALESCE(completed_at, ?),
+			     error = CASE WHEN TRIM(COALESCE(error, '')) = '' THEN ? ELSE error END
+			 WHERE queue_id = ? AND status = ?`
+		updateArgs := []interface{}{"failed", now, errorMsg, queueID, "running"}
+		if maxTaskRowID > 0 {
+			updateQuery += " AND rowid <= ?"
+			updateArgs = append(updateArgs, maxTaskRowID)
+		}
+		res, err := tx.Exec(
+			updateQuery,
+			updateArgs...,
+		)
+		if err != nil {
+			return nil, nil, 0, fmt.Errorf("标记重启中断的批量子任务失败: %w", err)
 		}
 		if n, nerr := res.RowsAffected(); nerr == nil {
 			failedTasks += n
@@ -406,9 +567,9 @@ func (db *DB) RecoverInterruptedBatchQueues(errorMsg string) ([]string, int64, e
 	}
 
 	if err := tx.Commit(); err != nil {
-		return nil, 0, fmt.Errorf("提交事务失败: %w", err)
+		return nil, nil, 0, fmt.Errorf("提交事务失败: %w", err)
 	}
-	return queueIDs, failedTasks, nil
+	return resumeQueueIDs, interruptedConversationIDs, failedTasks, nil
 }
 
 // UpdateBatchQueueCurrentIndex 更新批量任务队列的当前索引
@@ -431,6 +592,21 @@ func (db *DB) UpdateBatchQueueMetadata(queueID, title, role, agentMode string) e
 	)
 	if err != nil {
 		return fmt.Errorf("更新批量任务队列元数据失败: %w", err)
+	}
+	return nil
+}
+
+// UpdateBatchQueueConcurrency 更新批量任务队列并发数
+func (db *DB) UpdateBatchQueueConcurrency(queueID string, concurrency int) error {
+	if concurrency < 1 {
+		concurrency = 1
+	}
+	_, err := db.Exec(
+		"UPDATE batch_task_queues SET concurrency = ? WHERE id = ?",
+		concurrency, queueID,
+	)
+	if err != nil {
+		return fmt.Errorf("更新批量任务队列并发数失败: %w", err)
 	}
 	return nil
 }

--- a/internal/database/batch_task.go
+++ b/internal/database/batch_task.go
@@ -346,6 +346,71 @@ func (db *DB) UpdateBatchTaskStatus(queueID, taskID, status string, conversation
 	return nil
 }
 
+// RecoverInterruptedBatchQueues marks tasks that were running before a process
+// restart as failed without changing their queue status. The caller can then
+// decide whether to continue recovered running queues.
+func (db *DB) RecoverInterruptedBatchQueues(errorMsg string) ([]string, int64, error) {
+	tx, err := db.Begin()
+	if err != nil {
+		return nil, 0, fmt.Errorf("开始事务失败: %w", err)
+	}
+	defer tx.Rollback()
+
+	rows, err := tx.Query(
+		"SELECT id FROM batch_task_queues WHERE status = ? ORDER BY created_at ASC",
+		"running",
+	)
+	if err != nil {
+		return nil, 0, fmt.Errorf("查询重启前运行中的批量任务队列失败: %w", err)
+	}
+	defer rows.Close()
+
+	var queueIDs []string
+	for rows.Next() {
+		var queueID string
+		if err := rows.Scan(&queueID); err != nil {
+			return nil, 0, fmt.Errorf("扫描重启前运行中的批量任务队列失败: %w", err)
+		}
+		queueIDs = append(queueIDs, queueID)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, fmt.Errorf("遍历重启前运行中的批量任务队列失败: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, 0, fmt.Errorf("关闭重启前运行中的批量任务队列查询失败: %w", err)
+	}
+	if len(queueIDs) == 0 {
+		if err := tx.Commit(); err != nil {
+			return nil, 0, fmt.Errorf("提交事务失败: %w", err)
+		}
+		return nil, 0, nil
+	}
+
+	now := time.Now()
+	var failedTasks int64
+	for _, queueID := range queueIDs {
+		res, err := tx.Exec(
+			`UPDATE batch_tasks
+			 SET status = ?, completed_at = COALESCE(completed_at, ?),
+			     error = CASE WHEN TRIM(COALESCE(error, '')) = '' THEN ? ELSE error END
+			 WHERE queue_id = ? AND status = ?`,
+			"failed", now, errorMsg, queueID, "running",
+		)
+		if err != nil {
+			return nil, 0, fmt.Errorf("标记重启中断的批量子任务失败: %w", err)
+		}
+		if n, nerr := res.RowsAffected(); nerr == nil {
+			failedTasks += n
+		}
+
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, 0, fmt.Errorf("提交事务失败: %w", err)
+	}
+	return queueIDs, failedTasks, nil
+}
+
 // UpdateBatchQueueCurrentIndex 更新批量任务队列的当前索引
 func (db *DB) UpdateBatchQueueCurrentIndex(queueID string, currentIndex int) error {
 	_, err := db.Exec(

--- a/internal/database/batch_task_recovery_test.go
+++ b/internal/database/batch_task_recovery_test.go
@@ -24,7 +24,7 @@ func TestRecoverInterruptedBatchQueuesContinuesAfterFailedRunningTask(t *testing
 		{"id": "task-2", "message": "interrupted"},
 		{"id": "task-3", "message": "next"},
 	}
-	if err := db.CreateBatchQueue(queueID, "recover", "", "eino_single", "manual", "", nil, "", tasks); err != nil {
+	if err := db.CreateBatchQueue(queueID, "recover", "", "eino_single", "manual", "", nil, "", 1, tasks); err != nil {
 		t.Fatalf("CreateBatchQueue: %v", err)
 	}
 	if err := db.UpdateBatchQueueStatus(queueID, "running"); err != nil {
@@ -41,7 +41,7 @@ func TestRecoverInterruptedBatchQueuesContinuesAfterFailedRunningTask(t *testing
 	}
 
 	const restartMsg = "服务重启，任务已中断，请重新发起或继续"
-	queueIDs, failedTasks, err := db.RecoverInterruptedBatchQueues(restartMsg)
+	queueIDs, conversationIDs, failedTasks, err := db.RecoverInterruptedBatchQueues(restartMsg)
 	if err != nil {
 		t.Fatalf("RecoverInterruptedBatchQueues: %v", err)
 	}
@@ -50,6 +50,9 @@ func TestRecoverInterruptedBatchQueuesContinuesAfterFailedRunningTask(t *testing
 	}
 	if len(queueIDs) != 1 || queueIDs[0] != queueID {
 		t.Fatalf("queueIDs = %#v, want [%q]", queueIDs, queueID)
+	}
+	if len(conversationIDs) != 0 {
+		t.Fatalf("conversationIDs = %#v, want empty", conversationIDs)
 	}
 
 	queue, err := db.GetBatchQueue(queueID)
@@ -92,7 +95,246 @@ func TestRecoverInterruptedBatchQueuesContinuesAfterFailedRunningTask(t *testing
 	}
 }
 
-func TestRecoverInterruptedAssistantPlaceholders(t *testing.T) {
+func TestRecoverInterruptedBatchQueuesDoesNotResumePausedQueue(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "batch-recovery-paused.db")
+	db, err := NewDB(dbPath, zap.NewNop())
+	if err != nil {
+		t.Fatalf("NewDB: %v", err)
+	}
+	defer db.Close()
+
+	queueID := "queue-paused-recover"
+	tasks := []map[string]interface{}{
+		{"id": "task-running", "message": "interrupted"},
+		{"id": "task-pending", "message": "next"},
+	}
+	if err := db.CreateBatchQueue(queueID, "recover paused", "", "eino_single", "manual", "", nil, "", 1, tasks); err != nil {
+		t.Fatalf("CreateBatchQueue: %v", err)
+	}
+	if err := db.UpdateBatchQueueStatus(queueID, "paused"); err != nil {
+		t.Fatalf("UpdateBatchQueueStatus paused: %v", err)
+	}
+	if err := db.UpdateBatchTaskStatus(queueID, "task-running", "running", "", "", ""); err != nil {
+		t.Fatalf("UpdateBatchTaskStatus task-running: %v", err)
+	}
+
+	const restartMsg = "服务重启，任务已中断，请重新发起或继续"
+	queueIDs, _, failedTasks, err := db.RecoverInterruptedBatchQueues(restartMsg)
+	if err != nil {
+		t.Fatalf("RecoverInterruptedBatchQueues: %v", err)
+	}
+	if len(queueIDs) != 0 {
+		t.Fatalf("queueIDs = %#v, want empty for paused queue", queueIDs)
+	}
+	if failedTasks != 1 {
+		t.Fatalf("failedTasks = %d, want 1", failedTasks)
+	}
+
+	queue, err := db.GetBatchQueue(queueID)
+	if err != nil {
+		t.Fatalf("GetBatchQueue: %v", err)
+	}
+	if queue.Status != "paused" {
+		t.Fatalf("queue status = %q, want paused", queue.Status)
+	}
+
+	gotTasks, err := db.GetBatchTasks(queueID)
+	if err != nil {
+		t.Fatalf("GetBatchTasks: %v", err)
+	}
+	statuses := map[string]string{}
+	errors := map[string]string{}
+	for _, task := range gotTasks {
+		statuses[task.ID] = task.Status
+		if task.Error.Valid {
+			errors[task.ID] = task.Error.String
+		}
+	}
+	if statuses["task-running"] != "failed" {
+		t.Fatalf("task-running status = %q, want failed", statuses["task-running"])
+	}
+	if errors["task-running"] != restartMsg {
+		t.Fatalf("task-running error = %q, want %q", errors["task-running"], restartMsg)
+	}
+	if statuses["task-pending"] != "pending" {
+		t.Fatalf("task-pending status = %q, want pending", statuses["task-pending"])
+	}
+}
+
+func TestRecoverInterruptedBatchQueuesBeforeSkipsTasksClaimedAfterSnapshot(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "batch-recovery-snapshot.db")
+	db, err := NewDB(dbPath, zap.NewNop())
+	if err != nil {
+		t.Fatalf("NewDB: %v", err)
+	}
+	defer db.Close()
+
+	queueID := "queue-recover-snapshot"
+	tasks := []map[string]interface{}{
+		{"id": "task-running-before", "message": "before restart"},
+	}
+	if err := db.CreateBatchQueue(queueID, "recover snapshot", "", "eino_single", "manual", "", nil, "", 1, tasks); err != nil {
+		t.Fatalf("CreateBatchQueue: %v", err)
+	}
+	if err := db.UpdateBatchQueueStatus(queueID, "running"); err != nil {
+		t.Fatalf("UpdateBatchQueueStatus running: %v", err)
+	}
+	if err := db.UpdateBatchTaskStatus(queueID, "task-running-before", "running", "", "", ""); err != nil {
+		t.Fatalf("UpdateBatchTaskStatus before: %v", err)
+	}
+	maxTaskRowID, err := db.MaxBatchTaskRowID()
+	if err != nil {
+		t.Fatalf("MaxBatchTaskRowID: %v", err)
+	}
+
+	if _, err := db.Exec(
+		`INSERT INTO batch_tasks (id, queue_id, message, status, started_at)
+		 VALUES (?, ?, ?, ?, ?)`,
+		"task-running-after", queueID, "claimed after startup", "running", time.Now(),
+	); err != nil {
+		t.Fatalf("insert after snapshot task: %v", err)
+	}
+
+	const restartMsg = "服务重启，任务已中断，请重新发起或继续"
+	queueIDs, _, failedTasks, err := db.RecoverInterruptedBatchQueuesBefore(restartMsg, maxTaskRowID)
+	if err != nil {
+		t.Fatalf("RecoverInterruptedBatchQueuesBefore: %v", err)
+	}
+	if failedTasks != 1 {
+		t.Fatalf("failedTasks = %d, want 1", failedTasks)
+	}
+	if len(queueIDs) != 1 || queueIDs[0] != queueID {
+		t.Fatalf("queueIDs = %#v, want [%q]", queueIDs, queueID)
+	}
+
+	gotTasks, err := db.GetBatchTasks(queueID)
+	if err != nil {
+		t.Fatalf("GetBatchTasks: %v", err)
+	}
+	statuses := map[string]string{}
+	for _, task := range gotTasks {
+		statuses[task.ID] = task.Status
+	}
+	if statuses["task-running-before"] != "failed" {
+		t.Fatalf("task-running-before status = %q, want failed", statuses["task-running-before"])
+	}
+	if statuses["task-running-after"] != "running" {
+		t.Fatalf("task-running-after status = %q, want running", statuses["task-running-after"])
+	}
+}
+
+func TestClaimBatchTaskForRunClearsStalePersistentConversationData(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "batch-claim.db")
+	db, err := NewDB(dbPath, zap.NewNop())
+	if err != nil {
+		t.Fatalf("NewDB: %v", err)
+	}
+	defer db.Close()
+
+	oldConv, err := db.CreateConversation("old", ConversationCreateMeta{})
+	if err != nil {
+		t.Fatalf("CreateConversation old: %v", err)
+	}
+
+	queueID := "queue-claim"
+	tasks := []map[string]interface{}{
+		{"id": "task-1", "message": "retry this task"},
+	}
+	if err := db.CreateBatchQueue(queueID, "claim", "", "eino_single", "manual", "", nil, "", 1, tasks); err != nil {
+		t.Fatalf("CreateBatchQueue: %v", err)
+	}
+	if err := db.UpdateBatchTaskStatus(queueID, "task-1", "failed", oldConv.ID, "old result", "old error"); err != nil {
+		t.Fatalf("UpdateBatchTaskStatus failed: %v", err)
+	}
+	if err := db.UpdateBatchTaskStatus(queueID, "task-1", "pending", "", "", ""); err != nil {
+		t.Fatalf("UpdateBatchTaskStatus pending: %v", err)
+	}
+
+	if err := db.ClaimBatchTaskForRun(queueID, "task-1"); err != nil {
+		t.Fatalf("ClaimBatchTaskForRun: %v", err)
+	}
+
+	gotTasks, err := db.GetBatchTasks(queueID)
+	if err != nil {
+		t.Fatalf("GetBatchTasks: %v", err)
+	}
+	if len(gotTasks) != 1 {
+		t.Fatalf("task count = %d, want 1", len(gotTasks))
+	}
+	task := gotTasks[0]
+	if task.Status != "running" {
+		t.Fatalf("task status = %q, want running", task.Status)
+	}
+	if !task.ConversationID.Valid || task.ConversationID.String != oldConv.ID {
+		t.Fatalf("conversation_id = %#v, want old conversation preserved until replacement", task.ConversationID)
+	}
+	if task.Error.Valid {
+		t.Fatalf("error = %q, want NULL", task.Error.String)
+	}
+	if task.Result.Valid {
+		t.Fatalf("result = %q, want NULL", task.Result.String)
+	}
+	if task.CompletedAt.Valid {
+		t.Fatalf("completed_at = %#v, want NULL", task.CompletedAt.Time)
+	}
+	if !task.StartedAt.Valid {
+		t.Fatalf("started_at is NULL, want set")
+	}
+}
+
+func TestUpdateBatchTaskStatusClearsStaleErrorForNewTerminalState(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "batch-status-clear.db")
+	db, err := NewDB(dbPath, zap.NewNop())
+	if err != nil {
+		t.Fatalf("NewDB: %v", err)
+	}
+	defer db.Close()
+
+	queueID := "queue-status-clear"
+	tasks := []map[string]interface{}{
+		{"id": "task-1", "message": "cancelled task"},
+		{"id": "task-2", "message": "completed task"},
+	}
+	if err := db.CreateBatchQueue(queueID, "status clear", "", "eino_single", "manual", "", nil, "", 1, tasks); err != nil {
+		t.Fatalf("CreateBatchQueue: %v", err)
+	}
+	const restartMsg = "服务重启，任务已中断，请重新发起或继续"
+	if err := db.UpdateBatchTaskStatus(queueID, "task-1", "failed", "old-conv-1", "", restartMsg); err != nil {
+		t.Fatalf("UpdateBatchTaskStatus task-1 failed: %v", err)
+	}
+	if err := db.UpdateBatchTaskStatus(queueID, "task-1", "cancelled", "new-conv-1", "任务已被用户取消，后续操作已停止。", ""); err != nil {
+		t.Fatalf("UpdateBatchTaskStatus task-1 cancelled: %v", err)
+	}
+	if err := db.UpdateBatchTaskStatus(queueID, "task-2", "failed", "old-conv-2", "", restartMsg); err != nil {
+		t.Fatalf("UpdateBatchTaskStatus task-2 failed: %v", err)
+	}
+	if err := db.UpdateBatchTaskStatus(queueID, "task-2", "completed", "new-conv-2", "ok", ""); err != nil {
+		t.Fatalf("UpdateBatchTaskStatus task-2 completed: %v", err)
+	}
+
+	gotTasks, err := db.GetBatchTasks(queueID)
+	if err != nil {
+		t.Fatalf("GetBatchTasks: %v", err)
+	}
+	byID := map[string]*BatchTaskRow{}
+	for _, task := range gotTasks {
+		byID[task.ID] = task
+	}
+	if byID["task-1"].Error.Valid {
+		t.Fatalf("cancelled task error = %q, want NULL", byID["task-1"].Error.String)
+	}
+	if !byID["task-1"].Result.Valid || byID["task-1"].Result.String != "任务已被用户取消，后续操作已停止。" {
+		t.Fatalf("cancelled task result = %#v, want cancel result", byID["task-1"].Result)
+	}
+	if byID["task-2"].Error.Valid {
+		t.Fatalf("completed task error = %q, want NULL", byID["task-2"].Error.String)
+	}
+	if !byID["task-2"].Result.Valid || byID["task-2"].Result.String != "ok" {
+		t.Fatalf("completed task result = %#v, want ok", byID["task-2"].Result)
+	}
+}
+
+func TestRecoverInterruptedAssistantPlaceholdersSkipsBatchPendingConversations(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "assistant-recovery.db")
 	db, err := NewDB(dbPath, zap.NewNop())
 	if err != nil {
@@ -100,43 +342,193 @@ func TestRecoverInterruptedAssistantPlaceholders(t *testing.T) {
 	}
 	defer db.Close()
 
-	conv, err := db.CreateConversation("recover", ConversationCreateMeta{})
+	runningConv, err := db.CreateConversation("running", ConversationCreateMeta{})
 	if err != nil {
-		t.Fatalf("CreateConversation: %v", err)
+		t.Fatalf("CreateConversation running: %v", err)
 	}
-	if _, err := db.AddMessage(conv.ID, "user", "hello", nil); err != nil {
-		t.Fatalf("AddMessage user: %v", err)
+	if _, err := db.AddMessage(runningConv.ID, "user", "running", nil); err != nil {
+		t.Fatalf("AddMessage running user: %v", err)
 	}
-	assistantMsg, err := db.AddMessage(conv.ID, "assistant", "处理中...", nil)
+	runningMsg, err := db.AddMessage(runningConv.ID, "assistant", "处理中...", nil)
 	if err != nil {
-		t.Fatalf("AddMessage assistant: %v", err)
+		t.Fatalf("AddMessage running assistant: %v", err)
+	}
+
+	pendingConv, err := db.CreateConversation("pending", ConversationCreateMeta{})
+	if err != nil {
+		t.Fatalf("CreateConversation pending: %v", err)
+	}
+	if _, err := db.AddMessage(pendingConv.ID, "user", "pending", nil); err != nil {
+		t.Fatalf("AddMessage pending user: %v", err)
+	}
+	pendingMsg, err := db.AddMessage(pendingConv.ID, "assistant", "处理中...", nil)
+	if err != nil {
+		t.Fatalf("AddMessage pending assistant: %v", err)
+	}
+
+	queueID := "queue-placeholders"
+	tasks := []map[string]interface{}{
+		{"id": "task-running", "message": "running"},
+		{"id": "task-pending", "message": "pending"},
+	}
+	if err := db.CreateBatchQueue(queueID, "recover", "", "eino_single", "manual", "", nil, "", 1, tasks); err != nil {
+		t.Fatalf("CreateBatchQueue: %v", err)
+	}
+	if err := db.UpdateBatchQueueStatus(queueID, "running"); err != nil {
+		t.Fatalf("UpdateBatchQueueStatus: %v", err)
+	}
+	if err := db.UpdateBatchTaskStatus(queueID, "task-running", "running", runningConv.ID, "", ""); err != nil {
+		t.Fatalf("UpdateBatchTaskStatus running: %v", err)
+	}
+	if err := db.UpdateBatchTaskStatus(queueID, "task-pending", "pending", pendingConv.ID, "", ""); err != nil {
+		t.Fatalf("UpdateBatchTaskStatus pending: %v", err)
 	}
 
 	const restartMsg = "服务重启，任务已中断，请重新发起或继续"
-	n, err := db.RecoverInterruptedAssistantPlaceholders(restartMsg)
+	_, conversationIDs, _, err := db.RecoverInterruptedBatchQueues(restartMsg)
 	if err != nil {
-		t.Fatalf("RecoverInterruptedAssistantPlaceholders: %v", err)
+		t.Fatalf("RecoverInterruptedBatchQueues: %v", err)
+	}
+	n, err := db.RecoverInterruptedAssistantPlaceholdersForConversations(restartMsg, conversationIDs)
+	if err != nil {
+		t.Fatalf("RecoverInterruptedAssistantPlaceholdersForConversations: %v", err)
 	}
 	if n != 1 {
 		t.Fatalf("recovered placeholders = %d, want 1", n)
 	}
-
-	messages, err := db.GetMessages(conv.ID)
+	n, err = db.RecoverInterruptedAssistantPlaceholders(restartMsg)
 	if err != nil {
-		t.Fatalf("GetMessages: %v", err)
+		t.Fatalf("RecoverInterruptedAssistantPlaceholders: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("non-batch recovered placeholders = %d, want 0", n)
+	}
+
+	messages, err := db.GetMessages(runningConv.ID)
+	if err != nil {
+		t.Fatalf("GetMessages running: %v", err)
 	}
 	if len(messages) != 2 {
-		t.Fatalf("message count = %d, want 2", len(messages))
+		t.Fatalf("running message count = %d, want 2", len(messages))
 	}
-	if messages[1].ID != assistantMsg.ID || messages[1].Content != restartMsg {
-		t.Fatalf("assistant message = %#v, want content %q on %q", messages[1], restartMsg, assistantMsg.ID)
+	if messages[1].ID != runningMsg.ID || messages[1].Content != restartMsg {
+		t.Fatalf("running assistant message = %#v, want content %q on %q", messages[1], restartMsg, runningMsg.ID)
 	}
-	details, err := db.GetProcessDetails(assistantMsg.ID)
+	messages, err = db.GetMessages(pendingConv.ID)
+	if err != nil {
+		t.Fatalf("GetMessages pending: %v", err)
+	}
+	if len(messages) != 2 {
+		t.Fatalf("pending message count = %d, want 2", len(messages))
+	}
+	if messages[1].ID != pendingMsg.ID || messages[1].Content != "处理中..." {
+		t.Fatalf("pending assistant message = %#v, want placeholder on %q", messages[1], pendingMsg.ID)
+	}
+	details, err := db.GetProcessDetails(runningMsg.ID)
 	if err != nil {
 		t.Fatalf("GetProcessDetails: %v", err)
 	}
 	if len(details) != 1 || details[0].EventType != "error" || details[0].Message != restartMsg {
 		t.Fatalf("process details = %#v, want restart error detail", details)
+	}
+}
+
+func TestRecoverInterruptedAssistantPlaceholdersBeforeUsesStartupSnapshot(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "assistant-snapshot-recovery.db")
+	db, err := NewDB(dbPath, zap.NewNop())
+	if err != nil {
+		t.Fatalf("NewDB: %v", err)
+	}
+	defer db.Close()
+
+	batchConv, err := db.CreateConversation("batch pending", ConversationCreateMeta{})
+	if err != nil {
+		t.Fatalf("CreateConversation batch: %v", err)
+	}
+	if _, err := db.AddMessage(batchConv.ID, "user", "batch pending", nil); err != nil {
+		t.Fatalf("AddMessage batch user: %v", err)
+	}
+	batchMsg, err := db.AddMessage(batchConv.ID, "assistant", "处理中...", nil)
+	if err != nil {
+		t.Fatalf("AddMessage batch assistant: %v", err)
+	}
+
+	ordinaryConv, err := db.CreateConversation("ordinary", ConversationCreateMeta{})
+	if err != nil {
+		t.Fatalf("CreateConversation ordinary: %v", err)
+	}
+	if _, err := db.AddMessage(ordinaryConv.ID, "user", "ordinary", nil); err != nil {
+		t.Fatalf("AddMessage ordinary user: %v", err)
+	}
+	ordinaryMsg, err := db.AddMessage(ordinaryConv.ID, "assistant", "处理中...", nil)
+	if err != nil {
+		t.Fatalf("AddMessage ordinary assistant: %v", err)
+	}
+
+	queueID := "queue-snapshot"
+	tasks := []map[string]interface{}{
+		{"id": "task-pending", "message": "pending"},
+	}
+	if err := db.CreateBatchQueue(queueID, "snapshot", "", "eino_single", "manual", "", nil, "", 1, tasks); err != nil {
+		t.Fatalf("CreateBatchQueue: %v", err)
+	}
+	if err := db.UpdateBatchTaskStatus(queueID, "task-pending", "pending", batchConv.ID, "", ""); err != nil {
+		t.Fatalf("UpdateBatchTaskStatus pending: %v", err)
+	}
+
+	maxRowID, err := db.MaxMessageRowID()
+	if err != nil {
+		t.Fatalf("MaxMessageRowID: %v", err)
+	}
+	excluded, err := db.ListBatchTaskConversationIDs()
+	if err != nil {
+		t.Fatalf("ListBatchTaskConversationIDs: %v", err)
+	}
+
+	newConv, err := db.CreateConversation("new batch run", ConversationCreateMeta{})
+	if err != nil {
+		t.Fatalf("CreateConversation new: %v", err)
+	}
+	if _, err := db.AddMessage(newConv.ID, "user", "new run", nil); err != nil {
+		t.Fatalf("AddMessage new user: %v", err)
+	}
+	newMsg, err := db.AddMessage(newConv.ID, "assistant", "处理中...", nil)
+	if err != nil {
+		t.Fatalf("AddMessage new assistant: %v", err)
+	}
+	if err := db.UpdateBatchTaskStatus(queueID, "task-pending", "running", newConv.ID, "", ""); err != nil {
+		t.Fatalf("UpdateBatchTaskStatus running: %v", err)
+	}
+
+	const restartMsg = "服务重启，任务已中断，请重新发起或继续"
+	n, err := db.RecoverInterruptedAssistantPlaceholdersBefore(restartMsg, maxRowID, excluded)
+	if err != nil {
+		t.Fatalf("RecoverInterruptedAssistantPlaceholdersBefore: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("recovered placeholders = %d, want only ordinary placeholder", n)
+	}
+
+	messages, err := db.GetMessages(ordinaryConv.ID)
+	if err != nil {
+		t.Fatalf("GetMessages ordinary: %v", err)
+	}
+	if messages[1].ID != ordinaryMsg.ID || messages[1].Content != restartMsg {
+		t.Fatalf("ordinary assistant = %#v, want restart message", messages[1])
+	}
+	messages, err = db.GetMessages(batchConv.ID)
+	if err != nil {
+		t.Fatalf("GetMessages batch: %v", err)
+	}
+	if messages[1].ID != batchMsg.ID || messages[1].Content != "处理中..." {
+		t.Fatalf("batch assistant = %#v, want unchanged placeholder", messages[1])
+	}
+	messages, err = db.GetMessages(newConv.ID)
+	if err != nil {
+		t.Fatalf("GetMessages new: %v", err)
+	}
+	if messages[1].ID != newMsg.ID || messages[1].Content != "处理中..." {
+		t.Fatalf("new assistant = %#v, want unchanged placeholder", messages[1])
 	}
 }
 

--- a/internal/database/batch_task_recovery_test.go
+++ b/internal/database/batch_task_recovery_test.go
@@ -1,0 +1,184 @@
+package database
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"cyberstrike-ai/internal/mcp"
+
+	"go.uber.org/zap"
+)
+
+func TestRecoverInterruptedBatchQueuesContinuesAfterFailedRunningTask(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "batch-recovery.db")
+	db, err := NewDB(dbPath, zap.NewNop())
+	if err != nil {
+		t.Fatalf("NewDB: %v", err)
+	}
+	defer db.Close()
+
+	queueID := "queue-recover"
+	tasks := []map[string]interface{}{
+		{"id": "task-1", "message": "done"},
+		{"id": "task-2", "message": "interrupted"},
+		{"id": "task-3", "message": "next"},
+	}
+	if err := db.CreateBatchQueue(queueID, "recover", "", "eino_single", "manual", "", nil, "", tasks); err != nil {
+		t.Fatalf("CreateBatchQueue: %v", err)
+	}
+	if err := db.UpdateBatchQueueStatus(queueID, "running"); err != nil {
+		t.Fatalf("UpdateBatchQueueStatus running: %v", err)
+	}
+	if err := db.UpdateBatchTaskStatus(queueID, "task-1", "completed", "", "ok", ""); err != nil {
+		t.Fatalf("UpdateBatchTaskStatus task-1: %v", err)
+	}
+	if err := db.UpdateBatchTaskStatus(queueID, "task-2", "running", "", "", ""); err != nil {
+		t.Fatalf("UpdateBatchTaskStatus task-2: %v", err)
+	}
+	if err := db.UpdateBatchQueueCurrentIndex(queueID, 1); err != nil {
+		t.Fatalf("UpdateBatchQueueCurrentIndex: %v", err)
+	}
+
+	const restartMsg = "服务重启，任务已中断，请重新发起或继续"
+	queueIDs, failedTasks, err := db.RecoverInterruptedBatchQueues(restartMsg)
+	if err != nil {
+		t.Fatalf("RecoverInterruptedBatchQueues: %v", err)
+	}
+	if failedTasks != 1 {
+		t.Fatalf("failedTasks = %d, want 1", failedTasks)
+	}
+	if len(queueIDs) != 1 || queueIDs[0] != queueID {
+		t.Fatalf("queueIDs = %#v, want [%q]", queueIDs, queueID)
+	}
+
+	queue, err := db.GetBatchQueue(queueID)
+	if err != nil {
+		t.Fatalf("GetBatchQueue: %v", err)
+	}
+	if queue.Status != "running" {
+		t.Fatalf("queue status = %q, want running", queue.Status)
+	}
+	if queue.CurrentIndex != 1 {
+		t.Fatalf("queue current_index = %d, want 1", queue.CurrentIndex)
+	}
+	if queue.LastRunError.Valid {
+		t.Fatalf("last_run_error = %#v, want unset", queue.LastRunError)
+	}
+
+	gotTasks, err := db.GetBatchTasks(queueID)
+	if err != nil {
+		t.Fatalf("GetBatchTasks: %v", err)
+	}
+	statuses := map[string]string{}
+	errors := map[string]string{}
+	for _, task := range gotTasks {
+		statuses[task.ID] = task.Status
+		if task.Error.Valid {
+			errors[task.ID] = task.Error.String
+		}
+	}
+	if statuses["task-1"] != "completed" {
+		t.Fatalf("task-1 status = %q, want completed", statuses["task-1"])
+	}
+	if statuses["task-2"] != "failed" {
+		t.Fatalf("task-2 status = %q, want failed", statuses["task-2"])
+	}
+	if errors["task-2"] != restartMsg {
+		t.Fatalf("task-2 error = %q, want %q", errors["task-2"], restartMsg)
+	}
+	if statuses["task-3"] != "pending" {
+		t.Fatalf("task-3 status = %q, want pending", statuses["task-3"])
+	}
+}
+
+func TestRecoverInterruptedAssistantPlaceholders(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "assistant-recovery.db")
+	db, err := NewDB(dbPath, zap.NewNop())
+	if err != nil {
+		t.Fatalf("NewDB: %v", err)
+	}
+	defer db.Close()
+
+	conv, err := db.CreateConversation("recover", ConversationCreateMeta{})
+	if err != nil {
+		t.Fatalf("CreateConversation: %v", err)
+	}
+	if _, err := db.AddMessage(conv.ID, "user", "hello", nil); err != nil {
+		t.Fatalf("AddMessage user: %v", err)
+	}
+	assistantMsg, err := db.AddMessage(conv.ID, "assistant", "处理中...", nil)
+	if err != nil {
+		t.Fatalf("AddMessage assistant: %v", err)
+	}
+
+	const restartMsg = "服务重启，任务已中断，请重新发起或继续"
+	n, err := db.RecoverInterruptedAssistantPlaceholders(restartMsg)
+	if err != nil {
+		t.Fatalf("RecoverInterruptedAssistantPlaceholders: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("recovered placeholders = %d, want 1", n)
+	}
+
+	messages, err := db.GetMessages(conv.ID)
+	if err != nil {
+		t.Fatalf("GetMessages: %v", err)
+	}
+	if len(messages) != 2 {
+		t.Fatalf("message count = %d, want 2", len(messages))
+	}
+	if messages[1].ID != assistantMsg.ID || messages[1].Content != restartMsg {
+		t.Fatalf("assistant message = %#v, want content %q on %q", messages[1], restartMsg, assistantMsg.ID)
+	}
+	details, err := db.GetProcessDetails(assistantMsg.ID)
+	if err != nil {
+		t.Fatalf("GetProcessDetails: %v", err)
+	}
+	if len(details) != 1 || details[0].EventType != "error" || details[0].Message != restartMsg {
+		t.Fatalf("process details = %#v, want restart error detail", details)
+	}
+}
+
+func TestRecoverInterruptedToolExecutions(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "tool-recovery.db")
+	db, err := NewDB(dbPath, zap.NewNop())
+	if err != nil {
+		t.Fatalf("NewDB: %v", err)
+	}
+	defer db.Close()
+
+	exec := &mcp.ToolExecution{
+		ID:        "tool-recover",
+		ToolName:  "shell",
+		Arguments: map[string]interface{}{"cmd": "sleep 10"},
+		Status:    "running",
+		StartTime: time.Now().Add(-time.Minute),
+	}
+	if err := db.SaveToolExecution(exec); err != nil {
+		t.Fatalf("SaveToolExecution: %v", err)
+	}
+
+	const restartMsg = "服务重启，任务已中断，请重新发起或继续"
+	n, err := db.RecoverInterruptedToolExecutions(restartMsg)
+	if err != nil {
+		t.Fatalf("RecoverInterruptedToolExecutions: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("recovered executions = %d, want 1", n)
+	}
+
+	got, err := db.GetToolExecution(exec.ID)
+	if err != nil {
+		t.Fatalf("GetToolExecution: %v", err)
+	}
+	if got.Status != "failed" {
+		t.Fatalf("tool status = %q, want failed", got.Status)
+	}
+	if got.Error != restartMsg {
+		t.Fatalf("tool error = %q, want %q", got.Error, restartMsg)
+	}
+	if got.EndTime == nil {
+		t.Fatal("tool end time is nil, want set")
+	}
+}

--- a/internal/database/conversation.go
+++ b/internal/database/conversation.go
@@ -395,13 +395,13 @@ func (db *DB) ListConversations(limit, offset int, search string) ([]*Conversati
 			 FROM conversations c
 			 WHERE c.title LIKE ?
 			    OR EXISTS (SELECT 1 FROM messages m WHERE m.conversation_id = c.id AND m.content LIKE ?)
-			 ORDER BY c.updated_at DESC
+			 ORDER BY c.created_at DESC, c.id DESC
 			 LIMIT ? OFFSET ?`,
 			searchPattern, searchPattern, limit, offset,
 		)
 	} else {
 		rows, err = db.Query(
-			"SELECT id, title, COALESCE(pinned, 0), created_at, updated_at, project_id FROM conversations ORDER BY updated_at DESC LIMIT ? OFFSET ?",
+			"SELECT id, title, COALESCE(pinned, 0), created_at, updated_at, project_id FROM conversations ORDER BY created_at DESC, id DESC LIMIT ? OFFSET ?",
 			limit, offset,
 		)
 	}
@@ -471,7 +471,7 @@ func (db *DB) ListUngroupedConversations(limit, offset int) ([]*Conversation, er
 	rows, err := db.Query(
 		`SELECT c.id, c.title, COALESCE(c.pinned, 0), c.created_at, c.updated_at, c.project_id `+
 			ungroupedConversationsSQL+`
-		 ORDER BY c.updated_at DESC
+		 ORDER BY c.created_at DESC, c.id DESC
 		 LIMIT ? OFFSET ?`,
 		limit, offset,
 	)
@@ -711,6 +711,25 @@ func (db *DB) AddMessage(conversationID, role, content string, mcpExecutionIDs [
 	}
 
 	return message, nil
+}
+
+// GetFirstUserMessageContent returns the first user message in a conversation.
+func (db *DB) GetFirstUserMessageContent(conversationID string) (string, error) {
+	var content string
+	err := db.QueryRow(
+		`SELECT content FROM messages
+		 WHERE conversation_id = ? AND role = 'user'
+		 ORDER BY created_at ASC, rowid ASC
+		 LIMIT 1`,
+		conversationID,
+	).Scan(&content)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("查询首条用户消息失败: %w", err)
+	}
+	return strings.TrimSpace(content), nil
 }
 
 // UpdateAssistantMessageFinalize 更新助手消息终态（正文、MCP id、思考链聚合文本，供无轨迹回退时回放）。

--- a/internal/database/conversation.go
+++ b/internal/database/conversation.go
@@ -752,14 +752,97 @@ func (db *DB) UpdateAssistantMessageFinalize(messageID, content string, mcpExecu
 	return nil
 }
 
-// RecoverInterruptedAssistantPlaceholders finalizes assistant placeholders that
-// were left as the latest message in a conversation by a previous process exit.
+// RecoverInterruptedAssistantPlaceholders finalizes non-batch assistant
+// placeholders that were left as the latest message in a conversation by a
+// previous process exit.
 func (db *DB) RecoverInterruptedAssistantPlaceholders(content string) (int64, error) {
+	return db.RecoverInterruptedAssistantPlaceholdersBefore(content, 0, nil)
+}
+
+// RecoverInterruptedAssistantPlaceholdersBefore finalizes non-batch assistant
+// placeholders from the startup snapshot only. Excluded conversation IDs are
+// usually batch task conversations that existed before recovery began.
+func (db *DB) RecoverInterruptedAssistantPlaceholdersBefore(content string, maxMessageRowID int64, excludedConversationIDs []string) (int64, error) {
+	return db.recoverInterruptedAssistantPlaceholders(content, nil, true, maxMessageRowID, excludedConversationIDs)
+}
+
+// RecoverInterruptedAssistantPlaceholdersForConversations finalizes assistant
+// placeholders only for the provided conversations, used for batch subtasks
+// that were actually running before a restart.
+func (db *DB) RecoverInterruptedAssistantPlaceholdersForConversations(content string, conversationIDs []string) (int64, error) {
+	return db.recoverInterruptedAssistantPlaceholders(content, conversationIDs, false, 0, nil)
+}
+
+func (db *DB) MaxMessageRowID() (int64, error) {
+	var rowID sql.NullInt64
+	if err := db.QueryRow("SELECT MAX(rowid) FROM messages").Scan(&rowID); err != nil {
+		return 0, fmt.Errorf("查询消息快照失败: %w", err)
+	}
+	if !rowID.Valid {
+		return 0, nil
+	}
+	return rowID.Int64, nil
+}
+
+func (db *DB) recoverInterruptedAssistantPlaceholders(content string, conversationIDs []string, excludeBatchConversations bool, maxMessageRowID int64, excludedConversationIDs []string) (int64, error) {
+	args := make([]interface{}, 0, len(conversationIDs)+len(excludedConversationIDs)+1)
+	filter := ""
+	if len(conversationIDs) > 0 {
+		placeholders := make([]string, 0, len(conversationIDs))
+		seen := make(map[string]struct{}, len(conversationIDs))
+		for _, conversationID := range conversationIDs {
+			conversationID = strings.TrimSpace(conversationID)
+			if conversationID == "" {
+				continue
+			}
+			if _, ok := seen[conversationID]; ok {
+				continue
+			}
+			seen[conversationID] = struct{}{}
+			placeholders = append(placeholders, "?")
+			args = append(args, conversationID)
+		}
+		if len(placeholders) == 0 {
+			return 0, nil
+		}
+		filter += " AND m.conversation_id IN (" + strings.Join(placeholders, ",") + ")"
+	}
+	if maxMessageRowID > 0 {
+		filter += " AND m.rowid <= ?"
+		args = append(args, maxMessageRowID)
+	}
+	if len(excludedConversationIDs) > 0 {
+		placeholders := make([]string, 0, len(excludedConversationIDs))
+		seen := make(map[string]struct{}, len(excludedConversationIDs))
+		for _, conversationID := range excludedConversationIDs {
+			conversationID = strings.TrimSpace(conversationID)
+			if conversationID == "" {
+				continue
+			}
+			if _, ok := seen[conversationID]; ok {
+				continue
+			}
+			seen[conversationID] = struct{}{}
+			placeholders = append(placeholders, "?")
+			args = append(args, conversationID)
+		}
+		if len(placeholders) > 0 {
+			filter += " AND m.conversation_id NOT IN (" + strings.Join(placeholders, ",") + ")"
+		}
+	}
+	if excludeBatchConversations {
+		filter += ` AND NOT EXISTS (
+		       SELECT 1 FROM batch_tasks bt
+		       WHERE bt.conversation_id = m.conversation_id
+		   )`
+	}
+
 	rows, err := db.Query(
 		`SELECT m.id, m.conversation_id
 		 FROM messages m
 		 WHERE m.role = 'assistant'
 		   AND TRIM(m.content) = '处理中...'
+		   `+filter+`
 		   AND NOT EXISTS (
 		       SELECT 1 FROM messages newer
 		       WHERE newer.conversation_id = m.conversation_id
@@ -768,6 +851,7 @@ func (db *DB) RecoverInterruptedAssistantPlaceholders(content string) (int64, er
 		             OR (newer.created_at = m.created_at AND newer.rowid > m.rowid)
 		         )
 		   )`,
+		args...,
 	)
 	if err != nil {
 		return 0, fmt.Errorf("查询重启中断的助手占位消息失败: %w", err)

--- a/internal/database/conversation.go
+++ b/internal/database/conversation.go
@@ -752,6 +752,61 @@ func (db *DB) UpdateAssistantMessageFinalize(messageID, content string, mcpExecu
 	return nil
 }
 
+// RecoverInterruptedAssistantPlaceholders finalizes assistant placeholders that
+// were left as the latest message in a conversation by a previous process exit.
+func (db *DB) RecoverInterruptedAssistantPlaceholders(content string) (int64, error) {
+	rows, err := db.Query(
+		`SELECT m.id, m.conversation_id
+		 FROM messages m
+		 WHERE m.role = 'assistant'
+		   AND TRIM(m.content) = '处理中...'
+		   AND NOT EXISTS (
+		       SELECT 1 FROM messages newer
+		       WHERE newer.conversation_id = m.conversation_id
+		         AND (
+		             newer.created_at > m.created_at
+		             OR (newer.created_at = m.created_at AND newer.rowid > m.rowid)
+		         )
+		   )`,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("查询重启中断的助手占位消息失败: %w", err)
+	}
+	defer rows.Close()
+
+	type placeholder struct {
+		messageID      string
+		conversationID string
+	}
+	var placeholders []placeholder
+	for rows.Next() {
+		var p placeholder
+		if err := rows.Scan(&p.messageID, &p.conversationID); err != nil {
+			return 0, fmt.Errorf("扫描重启中断的助手占位消息失败: %w", err)
+		}
+		placeholders = append(placeholders, p)
+	}
+	if err := rows.Err(); err != nil {
+		return 0, fmt.Errorf("遍历重启中断的助手占位消息失败: %w", err)
+	}
+
+	for _, p := range placeholders {
+		if _, err := db.Exec(
+			"UPDATE messages SET content = ?, updated_at = ? WHERE id = ? AND role = 'assistant' AND TRIM(content) = '处理中...'",
+			content, time.Now(), p.messageID,
+		); err != nil {
+			return 0, fmt.Errorf("更新重启中断的助手占位消息失败: %w", err)
+		}
+		if err := db.AddProcessDetail(p.messageID, p.conversationID, "error", content, map[string]interface{}{
+			"reason": "process_restarted",
+		}); err != nil {
+			db.logger.Warn("保存重启中断详情失败", zap.String("messageId", p.messageID), zap.Error(err))
+		}
+	}
+
+	return int64(len(placeholders)), nil
+}
+
 // GetMessages 获取对话的所有消息
 func (db *DB) GetMessages(conversationID string) ([]Message, error) {
 	rows, err := db.Query(

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sync"
 	"strings"
+	"sync"
 	"time"
 
 	_ "github.com/mattn/go-sqlite3"
@@ -386,6 +386,7 @@ func (db *DB) initTables() error {
 		cron_expr TEXT,
 		next_run_at DATETIME,
 		schedule_enabled INTEGER NOT NULL DEFAULT 1,
+		concurrency INTEGER NOT NULL DEFAULT 1,
 		last_schedule_trigger_at DATETIME,
 		last_schedule_error TEXT,
 		last_run_error TEXT,
@@ -1108,6 +1109,21 @@ func (db *DB) migrateBatchTaskQueuesTable() error {
 	} else if projectIDCount == 0 {
 		if _, err := db.Exec("ALTER TABLE batch_task_queues ADD COLUMN project_id TEXT"); err != nil {
 			db.logger.Warn("添加batch_task_queues.project_id字段失败", zap.Error(err))
+		}
+	}
+
+	var concurrencyCount int
+	err = db.QueryRow("SELECT COUNT(*) FROM pragma_table_info('batch_task_queues') WHERE name='concurrency'").Scan(&concurrencyCount)
+	if err != nil {
+		if _, addErr := db.Exec("ALTER TABLE batch_task_queues ADD COLUMN concurrency INTEGER NOT NULL DEFAULT 1"); addErr != nil {
+			errMsg := strings.ToLower(addErr.Error())
+			if !strings.Contains(errMsg, "duplicate column") && !strings.Contains(errMsg, "already exists") {
+				db.logger.Warn("添加batch_task_queues.concurrency字段失败", zap.Error(addErr))
+			}
+		}
+	} else if concurrencyCount == 0 {
+		if _, err := db.Exec("ALTER TABLE batch_task_queues ADD COLUMN concurrency INTEGER NOT NULL DEFAULT 1"); err != nil {
+			db.logger.Warn("添加batch_task_queues.concurrency字段失败", zap.Error(err))
 		}
 	}
 

--- a/internal/database/group.go
+++ b/internal/database/group.go
@@ -237,7 +237,7 @@ func (db *DB) GetConversationsByGroup(groupID string) ([]*Conversation, error) {
 		 FROM conversations c
 		 INNER JOIN conversation_group_mappings cgm ON c.id = cgm.conversation_id
 		 WHERE cgm.group_id = ?
-		 ORDER BY COALESCE(cgm.pinned, 0) DESC, c.updated_at DESC`,
+		 ORDER BY COALESCE(cgm.pinned, 0) DESC, c.created_at DESC, c.id DESC`,
 		groupID,
 	)
 	if err != nil {
@@ -309,7 +309,7 @@ func (db *DB) SearchConversationsByGroup(groupID string, searchQuery string) ([]
 		args = append(args, searchPattern, searchPattern)
 	}
 
-	query += " ORDER BY COALESCE(cgm.pinned, 0) DESC, c.updated_at DESC"
+	query += " ORDER BY COALESCE(cgm.pinned, 0) DESC, c.created_at DESC, c.id DESC"
 
 	rows, err := db.Query(query, args...)
 	if err != nil {

--- a/internal/database/monitor.go
+++ b/internal/database/monitor.go
@@ -72,6 +72,32 @@ func (db *DB) SaveToolExecution(exec *mcp.ToolExecution) error {
 	return nil
 }
 
+// RecoverInterruptedToolExecutions marks persisted running tool executions from
+// a previous process as failed so the monitor view does not stay stuck.
+func (db *DB) RecoverInterruptedToolExecutions(errorMsg string) (int64, error) {
+	now := time.Now()
+	res, err := db.Exec(
+		`UPDATE tool_executions
+		 SET status = ?,
+		     error = CASE WHEN TRIM(COALESCE(error, '')) = '' THEN ? ELSE error END,
+		     end_time = COALESCE(end_time, ?),
+		     duration_ms = CASE
+		         WHEN duration_ms IS NULL THEN CAST((julianday(?) - julianday(start_time)) * 86400000 AS INTEGER)
+		         ELSE duration_ms
+		     END
+		 WHERE status = ?`,
+		"failed", errorMsg, now, now, "running",
+	)
+	if err != nil {
+		return 0, err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, err
+	}
+	return n, nil
+}
+
 // CountToolExecutions 统计工具执行记录总数
 func (db *DB) CountToolExecutions(status, toolName string) (int, error) {
 	query := `SELECT COUNT(*) FROM tool_executions`

--- a/internal/handler/agent.go
+++ b/internal/handler/agent.go
@@ -20,11 +20,11 @@ import (
 	"cyberstrike-ai/internal/audit"
 	"cyberstrike-ai/internal/config"
 	"cyberstrike-ai/internal/database"
-	"cyberstrike-ai/internal/reasoning"
 	"cyberstrike-ai/internal/mcp"
 	"cyberstrike-ai/internal/mcp/builtin"
 	"cyberstrike-ai/internal/multiagent"
 	"cyberstrike-ai/internal/openai"
+	"cyberstrike-ai/internal/reasoning"
 
 	"github.com/gin-gonic/gin"
 	"github.com/robfig/cron/v3"
@@ -204,15 +204,35 @@ func NewAgentHandler(agent *agent.Agent, db *database.DB, cfg *config.Config, lo
 
 	var recoveredBatchQueueIDs []string
 	if db != nil {
-		queueIDs, failedTasks, err := db.RecoverInterruptedBatchQueues(interruptedTaskMessage)
+		startupMaxMessageRowID, err := db.MaxMessageRowID()
+		if err != nil {
+			logger.Warn("获取启动恢复消息快照失败", zap.Error(err))
+		}
+		startupBatchConversationIDs, err := db.ListBatchTaskConversationIDs()
+		if err != nil {
+			logger.Warn("获取启动恢复批量任务对话快照失败", zap.Error(err))
+		}
+		startupMaxBatchTaskRowID, err := db.MaxBatchTaskRowID()
+		if err != nil {
+			logger.Warn("获取启动恢复批量任务快照失败", zap.Error(err))
+		}
+
+		queueIDs, interruptedBatchConversationIDs, failedTasks, err := db.RecoverInterruptedBatchQueuesBefore(interruptedTaskMessage, startupMaxBatchTaskRowID)
 		if err != nil {
 			logger.Warn("恢复重启中断的批量任务队列失败", zap.Error(err))
-		} else if len(queueIDs) > 0 {
-			recoveredBatchQueueIDs = queueIDs
+		} else if len(queueIDs) > 0 || failedTasks > 0 {
+			recoveredBatchQueueIDs = append(recoveredBatchQueueIDs, queueIDs...)
 			logger.Info("恢复重启中断的批量任务队列",
-				zap.Int("queue_count", len(queueIDs)),
+				zap.Int("resume_queue_count", len(queueIDs)),
 				zap.Int64("failed_task_count", failedTasks),
 			)
+		}
+		if len(interruptedBatchConversationIDs) > 0 {
+			if n, err := db.RecoverInterruptedAssistantPlaceholdersForConversations(interruptedTaskMessage, interruptedBatchConversationIDs); err != nil {
+				logger.Warn("恢复重启中断的批量任务助手占位消息失败", zap.Error(err))
+			} else if n > 0 {
+				logger.Info("恢复重启中断的批量任务助手占位消息", zap.Int64("count", n))
+			}
 		}
 
 		if n, err := db.RecoverInterruptedToolExecutions(interruptedTaskMessage); err != nil {
@@ -221,7 +241,7 @@ func NewAgentHandler(agent *agent.Agent, db *database.DB, cfg *config.Config, lo
 			logger.Info("恢复重启中断的工具执行记录", zap.Int64("count", n))
 		}
 
-		if n, err := db.RecoverInterruptedAssistantPlaceholders(interruptedTaskMessage); err != nil {
+		if n, err := db.RecoverInterruptedAssistantPlaceholdersBefore(interruptedTaskMessage, startupMaxMessageRowID, startupBatchConversationIDs); err != nil {
 			logger.Warn("恢复重启中断的助手占位消息失败", zap.Error(err))
 		} else if n > 0 {
 			logger.Info("恢复重启中断的助手占位消息", zap.Int64("count", n))
@@ -256,36 +276,6 @@ func NewAgentHandler(agent *agent.Agent, db *database.DB, cfg *config.Config, lo
 	}
 	go handler.batchQueueSchedulerLoop()
 	return handler
-}
-
-func (h *AgentHandler) resumeRecoveredBatchQueues(queueIDs []string) {
-	for _, queueID := range queueIDs {
-		queueID = strings.TrimSpace(queueID)
-		if queueID == "" {
-			continue
-		}
-		if !h.markBatchQueueRunning(queueID) {
-			continue
-		}
-
-		queue, exists := h.batchTaskManager.GetBatchQueue(queueID)
-		if !exists {
-			h.unmarkBatchQueueRunning(queueID)
-			h.logger.Warn("重启后继续批量任务队列失败，队列不存在", zap.String("queueId", queueID))
-			continue
-		}
-		if queue.Status != BatchQueueStatusRunning {
-			h.unmarkBatchQueueRunning(queueID)
-			continue
-		}
-		if batchQueueWantsEino(queue.AgentMode) && (h.config == nil || !h.config.MultiAgent.Enabled) {
-			h.unmarkBatchQueueRunning(queueID)
-			h.logger.Warn("重启后继续批量任务队列失败，Eino 多代理未启用", zap.String("queueId", queueID))
-			continue
-		}
-
-		go h.executeBatchQueue(queueID)
-	}
 }
 
 // SetKnowledgeManager 设置知识库管理器（用于记录检索日志）
@@ -331,13 +321,13 @@ type ChatReasoningRequest struct {
 
 // ChatRequest 聊天请求
 type ChatRequest struct {
-	Message              string           `json:"message" binding:"required"`
-	ConversationID       string           `json:"conversationId,omitempty"`
-	ProjectID            string           `json:"projectId,omitempty"` // 新对话绑定的项目（可选；未指定时可用 config.project.default_project_id）
-	Role                 string           `json:"role,omitempty"` // 角色名称
-	Attachments          []ChatAttachment `json:"attachments,omitempty"`
-	WebShellConnectionID string           `json:"webshellConnectionId,omitempty"` // WebShell 管理 - AI 助手：当前选中的连接 ID，仅使用 webshell_* 工具
-	Hitl                 *HITLRequest     `json:"hitl,omitempty"`
+	Message              string                `json:"message" binding:"required"`
+	ConversationID       string                `json:"conversationId,omitempty"`
+	ProjectID            string                `json:"projectId,omitempty"` // 新对话绑定的项目（可选；未指定时可用 config.project.default_project_id）
+	Role                 string                `json:"role,omitempty"`      // 角色名称
+	Attachments          []ChatAttachment      `json:"attachments,omitempty"`
+	WebShellConnectionID string                `json:"webshellConnectionId,omitempty"` // WebShell 管理 - AI 助手：当前选中的连接 ID，仅使用 webshell_* 工具
+	Hitl                 *HITLRequest          `json:"hitl,omitempty"`
 	Reasoning            *ChatReasoningRequest `json:"reasoning,omitempty"`
 	// Orchestration 仅对 /api/multi-agent、/api/multi-agent/stream：deep | plan_execute | supervisor；空则等同 deep。机器人/批量等无请求体时由服务端默认 deep。/api/eino-agent* 不使用此字段。
 	Orchestration string `json:"orchestration,omitempty"`
@@ -597,7 +587,7 @@ func appendAttachmentsToMessage(msg string, attachments []ChatAttachment, savedP
 }
 
 // appendAssistantMessageNotice 在助手消息末尾追加提示，避免覆盖已生成内容。
-// 若消息为空则直接写入提示；若已包含相同提示则保持不变。
+// 若消息为空或仍是占位内容则直接写入提示；若已包含相同提示则保持不变。
 func (h *AgentHandler) appendAssistantMessageNotice(messageID, notice string) error {
 	trimmedNotice := strings.TrimSpace(notice)
 	if strings.TrimSpace(messageID) == "" || trimmedNotice == "" {
@@ -606,14 +596,15 @@ func (h *AgentHandler) appendAssistantMessageNotice(messageID, notice string) er
 	_, err := h.db.Exec(
 		`UPDATE messages
 		 SET content = CASE
-			WHEN content IS NULL OR TRIM(content) = '' THEN ?
+			WHEN content IS NULL OR TRIM(content) = '' OR TRIM(content) = '处理中...' THEN ?
 			WHEN INSTR(content, ?) > 0 THEN content
-			ELSE content || '\n\n' || ?
+			ELSE content || ? || ?
 		 END,
 		     updated_at = ?
 		 WHERE id = ?`,
 		trimmedNotice,
 		trimmedNotice,
+		"\n\n",
 		trimmedNotice,
 		time.Now(),
 		messageID,
@@ -1464,10 +1455,10 @@ func (h *AgentHandler) CancelAgentLoop(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{
-		"status":           "cancelling",
-		"conversationId": req.ConversationID,
-		"message":          msg,
-		"continueAfter":    false,
+		"status":            "cancelling",
+		"conversationId":    req.ConversationID,
+		"message":           msg,
+		"continueAfter":     false,
 		"interruptWithNote": false,
 	})
 }
@@ -1582,6 +1573,7 @@ type BatchTaskRequest struct {
 	CronExpr     string   `json:"cronExpr,omitempty"`       // scheduleMode=cron 时必填
 	ExecuteNow   bool     `json:"executeNow,omitempty"`     // 创建后是否立即执行（默认 false）
 	ProjectID    string   `json:"projectId,omitempty"`      // 队列内子对话绑定的项目（可选）
+	Concurrency  int      `json:"concurrency,omitempty"`    // 并发执行的子任务数，默认 1
 }
 
 // batchQueueWantsEino 队列是否配置为走 Eino 多代理。
@@ -1641,7 +1633,7 @@ func (h *AgentHandler) CreateBatchQueue(c *gin.Context) {
 		nextRunAt = &next
 	}
 
-	queue, createErr := h.batchTaskManager.CreateBatchQueue(req.Title, req.Role, agentMode, scheduleMode, cronExpr, req.ProjectID, nextRunAt, validTasks)
+	queue, createErr := h.batchTaskManager.CreateBatchQueue(req.Title, req.Role, agentMode, scheduleMode, cronExpr, req.ProjectID, nextRunAt, req.Concurrency, validTasks)
 	if createErr != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": createErr.Error()})
 		return
@@ -1838,6 +1830,24 @@ func (h *AgentHandler) UpdateBatchQueueMetadata(c *gin.Context) {
 		return
 	}
 	if err := h.batchTaskManager.UpdateQueueMetadata(queueID, req.Title, req.Role, req.AgentMode); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	updated, _ := h.batchTaskManager.GetBatchQueue(queueID)
+	c.JSON(http.StatusOK, gin.H{"queue": updated})
+}
+
+// UpdateBatchQueueConcurrency 修改批量任务队列的并发数
+func (h *AgentHandler) UpdateBatchQueueConcurrency(c *gin.Context) {
+	queueID := c.Param("queueId")
+	var req struct {
+		Concurrency int `json:"concurrency"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if err := h.batchTaskManager.UpdateQueueConcurrency(queueID, req.Concurrency); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
@@ -2086,6 +2096,18 @@ func (h *AgentHandler) startBatchQueueExecution(queueID string, scheduled bool) 
 		return true, fmt.Errorf("队列状态不允许启动")
 	}
 
+	if h.db != nil {
+		pendingCount, err := h.db.CountBatchTasksByStatus(queueID, BatchTaskStatusPending)
+		if err != nil {
+			h.unmarkBatchQueueRunning(queueID)
+			return true, err
+		}
+		if pendingCount == 0 {
+			h.unmarkBatchQueueRunning(queueID)
+			return true, fmt.Errorf("没有待执行的子任务")
+		}
+	}
+
 	if queue != nil && batchQueueWantsEino(queue.AgentMode) && (h.config == nil || !h.config.MultiAgent.Enabled) {
 		h.unmarkBatchQueueRunning(queueID)
 		err := fmt.Errorf("当前队列配置为 Eino 多代理，但系统未启用多代理")
@@ -2108,6 +2130,36 @@ func (h *AgentHandler) startBatchQueueExecution(queueID string, scheduled bool) 
 
 	go h.executeBatchQueue(queueID)
 	return true, nil
+}
+
+func (h *AgentHandler) resumeRecoveredBatchQueues(queueIDs []string) {
+	for _, queueID := range queueIDs {
+		queueID = strings.TrimSpace(queueID)
+		if queueID == "" {
+			continue
+		}
+		queue, exists := h.batchTaskManager.GetBatchQueue(queueID)
+		if !exists || queue.Status != BatchQueueStatusRunning {
+			continue
+		}
+
+		if h.db != nil {
+			pendingCount, err := h.db.CountBatchTasksByStatus(queueID, BatchTaskStatusPending)
+			if err != nil {
+				h.logger.Warn("恢复批量任务队列时统计待执行子任务失败", zap.String("queueId", queueID), zap.Error(err))
+				continue
+			}
+			if pendingCount == 0 {
+				continue
+			}
+		}
+
+		if !h.markBatchQueueRunning(queueID) {
+			continue
+		}
+		h.logger.Info("继续执行重启前运行中的批量任务队列", zap.String("queueId", queueID))
+		go h.executeBatchQueue(queueID)
+	}
 }
 
 func (h *AgentHandler) batchQueueSchedulerLoop() {
@@ -2142,8 +2194,26 @@ func (h *AgentHandler) batchQueueSchedulerLoop() {
 // executeBatchQueue 执行批量任务队列
 func (h *AgentHandler) executeBatchQueue(queueID string) {
 	defer h.unmarkBatchQueueRunning(queueID)
-	h.logger.Info("开始执行批量任务队列", zap.String("queueId", queueID))
 
+	queue, exists := h.batchTaskManager.GetBatchQueue(queueID)
+	if !exists {
+		return
+	}
+	concurrency := normalizeBatchQueueConcurrency(queue.Concurrency)
+	h.logger.Info("开始执行批量任务队列", zap.String("queueId", queueID), zap.Int("concurrency", concurrency))
+
+	var wg sync.WaitGroup
+	for workerID := 0; workerID < concurrency; workerID++ {
+		wg.Add(1)
+		go func(workerID int) {
+			defer wg.Done()
+			h.executeBatchQueueWorker(queueID, workerID)
+		}(workerID)
+	}
+	wg.Wait()
+}
+
+func (h *AgentHandler) executeBatchQueueWorker(queueID string, workerID int) {
 	for {
 		// 检查队列状态
 		queue, exists := h.batchTaskManager.GetBatchQueue(queueID)
@@ -2151,27 +2221,27 @@ func (h *AgentHandler) executeBatchQueue(queueID string) {
 			break
 		}
 
-		// 获取下一个任务
-		task, hasNext := h.batchTaskManager.GetNextTask(queueID)
+		// 领取下一个任务。领取与 running 状态更新在同一把锁内完成，避免并发 worker 重复执行同一子任务。
+		task, hasNext := h.batchTaskManager.ClaimNextTask(queueID)
 		if !hasNext {
-			// 所有任务完成：汇总子任务失败信息便于排障
-			q, ok := h.batchTaskManager.GetBatchQueue(queueID)
-			lastRunErr := ""
-			if ok {
-				for _, t := range q.Tasks {
-					if t.Status == "failed" && t.Error != "" {
-						lastRunErr = t.Error
+			pending, running, ok := h.batchTaskManager.QueueHasActiveTasks(queueID)
+			if ok && !pending && !running {
+				// 所有任务完成：汇总子任务失败信息便于排障
+				q, ok := h.batchTaskManager.GetBatchQueue(queueID)
+				lastRunErr := ""
+				if ok {
+					for _, t := range q.Tasks {
+						if t.Status == "failed" && t.Error != "" {
+							lastRunErr = t.Error
+						}
 					}
 				}
+				h.batchTaskManager.SetLastRunError(queueID, lastRunErr)
+				h.batchTaskManager.UpdateQueueStatus(queueID, "completed")
+				h.logger.Info("批量任务队列执行完成", zap.String("queueId", queueID))
 			}
-			h.batchTaskManager.SetLastRunError(queueID, lastRunErr)
-			h.batchTaskManager.UpdateQueueStatus(queueID, "completed")
-			h.logger.Info("批量任务队列执行完成", zap.String("queueId", queueID))
 			break
 		}
-
-		// 更新任务状态为运行中
-		h.batchTaskManager.UpdateTaskStatus(queueID, task.ID, "running", "", "")
 
 		// 创建新对话
 		title := safeTruncateString(task.Message, 50)
@@ -2182,7 +2252,6 @@ func (h *AgentHandler) executeBatchQueue(queueID string) {
 		if err != nil {
 			h.logger.Error("创建对话失败", zap.String("queueId", queueID), zap.String("taskId", task.ID), zap.Error(err))
 			h.batchTaskManager.UpdateTaskStatus(queueID, task.ID, "failed", "", "创建对话失败: "+err.Error())
-			h.batchTaskManager.MoveToNextTask(queueID)
 			continue
 		}
 		conversationID = conv.ID
@@ -2247,7 +2316,7 @@ func (h *AgentHandler) executeBatchQueue(queueID string) {
 			finishStatus := "completed"
 
 			defer func() {
-				h.batchTaskManager.SetTaskCancel(queueID, nil)
+				h.batchTaskManager.SetTaskCancel(queueID, task.ID, nil)
 				timeoutCancel()
 				if registered {
 					// 与流式接口保持一致：结束前补一个 done，便于前端 task-events 侧及时收口 UI。
@@ -2294,7 +2363,7 @@ func (h *AgentHandler) executeBatchQueue(queueID string) {
 			}
 			registered = true
 			// 存储取消函数：暂停队列时取消子任务 context（与原先语义一致）
-			h.batchTaskManager.SetTaskCancel(queueID, timeoutCancel)
+			h.batchTaskManager.SetTaskCancel(queueID, task.ID, timeoutCancel)
 
 			// 创建进度回调函数：写 DB + 镜像到 task-events，支持刷新后继续流式展示。
 			progressCallback = h.createProgressCallback(taskCtx, cancelWithCause, conversationID, assistantMessageID, sendEvent)
@@ -2435,10 +2504,6 @@ func (h *AgentHandler) executeBatchQueue(queueID string) {
 				h.batchTaskManager.UpdateTaskStatusWithConversationID(queueID, task.ID, "completed", resText, "", conversationID)
 			}
 		}()
-
-		// 移动到下一个任务
-		h.batchTaskManager.MoveToNextTask(queueID)
-
 		// 检查是否被取消或暂停
 		queue, _ = h.batchTaskManager.GetBatchQueue(queueID)
 		if queue.Status == "cancelled" || queue.Status == "paused" {

--- a/internal/handler/agent.go
+++ b/internal/handler/agent.go
@@ -200,6 +200,34 @@ func NewAgentHandler(agent *agent.Agent, db *database.DB, cfg *config.Config, lo
 	batchTaskManager := NewBatchTaskManager(logger)
 	batchTaskManager.SetDB(db)
 
+	const interruptedTaskMessage = "服务重启，任务已中断，请重新发起或继续"
+
+	var recoveredBatchQueueIDs []string
+	if db != nil {
+		queueIDs, failedTasks, err := db.RecoverInterruptedBatchQueues(interruptedTaskMessage)
+		if err != nil {
+			logger.Warn("恢复重启中断的批量任务队列失败", zap.Error(err))
+		} else if len(queueIDs) > 0 {
+			recoveredBatchQueueIDs = queueIDs
+			logger.Info("恢复重启中断的批量任务队列",
+				zap.Int("queue_count", len(queueIDs)),
+				zap.Int64("failed_task_count", failedTasks),
+			)
+		}
+
+		if n, err := db.RecoverInterruptedToolExecutions(interruptedTaskMessage); err != nil {
+			logger.Warn("恢复重启中断的工具执行记录失败", zap.Error(err))
+		} else if n > 0 {
+			logger.Info("恢复重启中断的工具执行记录", zap.Int64("count", n))
+		}
+
+		if n, err := db.RecoverInterruptedAssistantPlaceholders(interruptedTaskMessage); err != nil {
+			logger.Warn("恢复重启中断的助手占位消息失败", zap.Error(err))
+		} else if n > 0 {
+			logger.Info("恢复重启中断的助手占位消息", zap.Int64("count", n))
+		}
+	}
+
 	// 从数据库加载所有批量任务队列
 	if err := batchTaskManager.LoadFromDB(); err != nil {
 		logger.Warn("从数据库加载批量任务队列失败", zap.Error(err))
@@ -223,8 +251,41 @@ func NewAgentHandler(agent *agent.Agent, db *database.DB, cfg *config.Config, lo
 	if err := handler.hitlManager.EnsureSchema(); err != nil {
 		logger.Warn("初始化 HITL 表失败", zap.Error(err))
 	}
+	if len(recoveredBatchQueueIDs) > 0 {
+		go handler.resumeRecoveredBatchQueues(recoveredBatchQueueIDs)
+	}
 	go handler.batchQueueSchedulerLoop()
 	return handler
+}
+
+func (h *AgentHandler) resumeRecoveredBatchQueues(queueIDs []string) {
+	for _, queueID := range queueIDs {
+		queueID = strings.TrimSpace(queueID)
+		if queueID == "" {
+			continue
+		}
+		if !h.markBatchQueueRunning(queueID) {
+			continue
+		}
+
+		queue, exists := h.batchTaskManager.GetBatchQueue(queueID)
+		if !exists {
+			h.unmarkBatchQueueRunning(queueID)
+			h.logger.Warn("重启后继续批量任务队列失败，队列不存在", zap.String("queueId", queueID))
+			continue
+		}
+		if queue.Status != BatchQueueStatusRunning {
+			h.unmarkBatchQueueRunning(queueID)
+			continue
+		}
+		if batchQueueWantsEino(queue.AgentMode) && (h.config == nil || !h.config.MultiAgent.Enabled) {
+			h.unmarkBatchQueueRunning(queueID)
+			h.logger.Warn("重启后继续批量任务队列失败，Eino 多代理未启用", zap.String("queueId", queueID))
+			continue
+		}
+
+		go h.executeBatchQueue(queueID)
+	}
 }
 
 // SetKnowledgeManager 设置知识库管理器（用于记录检索日志）
@@ -2293,86 +2354,86 @@ func (h *AgentHandler) executeBatchQueue(queueID string) {
 				}
 
 				if isCancelled {
-				h.logger.Info("批量任务被取消", zap.String("queueId", queueID), zap.String("taskId", task.ID), zap.String("conversationId", conversationID))
-				cancelMsg := "任务已被用户取消，后续操作已停止。"
-				// 如果执行结果中有更具体的取消消息，使用它
-				if partialResp != "" && (strings.Contains(partialResp, "任务已被取消") || strings.Contains(partialResp, "任务执行中断")) {
-					cancelMsg = partialResp
+					h.logger.Info("批量任务被取消", zap.String("queueId", queueID), zap.String("taskId", task.ID), zap.String("conversationId", conversationID))
+					cancelMsg := "任务已被用户取消，后续操作已停止。"
+					// 如果执行结果中有更具体的取消消息，使用它
+					if partialResp != "" && (strings.Contains(partialResp, "任务已被取消") || strings.Contains(partialResp, "任务执行中断")) {
+						cancelMsg = partialResp
+					}
+					// 更新助手消息内容
+					if assistantMessageID != "" {
+						if updateErr := h.appendAssistantMessageNotice(assistantMessageID, cancelMsg); updateErr != nil {
+							h.logger.Warn("更新取消后的助手消息失败", zap.String("queueId", queueID), zap.String("taskId", task.ID), zap.Error(updateErr))
+						}
+						// 保存取消详情到数据库
+						if err := h.db.AddProcessDetail(assistantMessageID, conversationID, "cancelled", cancelMsg, nil); err != nil {
+							h.logger.Warn("保存取消详情失败", zap.String("queueId", queueID), zap.String("taskId", task.ID), zap.Error(err))
+						}
+					} else {
+						// 如果没有预先创建的助手消息，创建一个新的
+						_, errMsg := h.db.AddMessage(conversationID, "assistant", cancelMsg, nil)
+						if errMsg != nil {
+							h.logger.Warn("保存取消消息失败", zap.String("queueId", queueID), zap.String("taskId", task.ID), zap.Error(errMsg))
+						}
+					}
+					h.batchTaskManager.UpdateTaskStatusWithConversationID(queueID, task.ID, "cancelled", cancelMsg, "", conversationID)
+				} else {
+					h.logger.Error("批量任务执行失败", zap.String("queueId", queueID), zap.String("taskId", task.ID), zap.String("conversationId", conversationID), zap.Error(runErr))
+					errorMsg := "执行失败: " + runErr.Error()
+					// 更新助手消息内容
+					if assistantMessageID != "" {
+						if _, updateErr := h.db.Exec(
+							"UPDATE messages SET content = ?, updated_at = ? WHERE id = ?",
+							errorMsg,
+							time.Now(), assistantMessageID,
+						); updateErr != nil {
+							h.logger.Warn("更新失败后的助手消息失败", zap.String("queueId", queueID), zap.String("taskId", task.ID), zap.Error(updateErr))
+						}
+						// 保存错误详情到数据库
+						if err := h.db.AddProcessDetail(assistantMessageID, conversationID, "error", errorMsg, nil); err != nil {
+							h.logger.Warn("保存错误详情失败", zap.String("queueId", queueID), zap.String("taskId", task.ID), zap.Error(err))
+						}
+					}
+					h.batchTaskManager.UpdateTaskStatus(queueID, task.ID, "failed", "", runErr.Error())
 				}
+			} else {
+				h.logger.Info("批量任务执行成功", zap.String("queueId", queueID), zap.String("taskId", task.ID), zap.String("conversationId", conversationID))
+
+				resText := resultMA.Response
+				mcpIDs := resultMA.MCPExecutionIDs
+				lastIn := resultMA.LastAgentTraceInput
+				lastOut := resultMA.LastAgentTraceOutput
+
 				// 更新助手消息内容
 				if assistantMessageID != "" {
-					if updateErr := h.appendAssistantMessageNotice(assistantMessageID, cancelMsg); updateErr != nil {
-						h.logger.Warn("更新取消后的助手消息失败", zap.String("queueId", queueID), zap.String("taskId", task.ID), zap.Error(updateErr))
-					}
-					// 保存取消详情到数据库
-					if err := h.db.AddProcessDetail(assistantMessageID, conversationID, "cancelled", cancelMsg, nil); err != nil {
-						h.logger.Warn("保存取消详情失败", zap.String("queueId", queueID), zap.String("taskId", task.ID), zap.Error(err))
+					if updateErr := h.db.UpdateAssistantMessageFinalize(assistantMessageID, resText, mcpIDs, multiagent.AggregatedReasoningFromTraceJSON(lastIn)); updateErr != nil {
+						h.logger.Warn("更新助手消息失败", zap.String("queueId", queueID), zap.String("taskId", task.ID), zap.Error(updateErr))
+						// 如果更新失败，尝试创建新消息
+						_, err = h.db.AddMessage(conversationID, "assistant", resText, mcpIDs)
+						if err != nil {
+							h.logger.Error("保存助手消息失败", zap.String("queueId", queueID), zap.String("taskId", task.ID), zap.String("conversationId", conversationID), zap.Error(err))
+						}
 					}
 				} else {
 					// 如果没有预先创建的助手消息，创建一个新的
-					_, errMsg := h.db.AddMessage(conversationID, "assistant", cancelMsg, nil)
-					if errMsg != nil {
-						h.logger.Warn("保存取消消息失败", zap.String("queueId", queueID), zap.String("taskId", task.ID), zap.Error(errMsg))
-					}
-				}
-				h.batchTaskManager.UpdateTaskStatusWithConversationID(queueID, task.ID, "cancelled", cancelMsg, "", conversationID)
-			} else {
-				h.logger.Error("批量任务执行失败", zap.String("queueId", queueID), zap.String("taskId", task.ID), zap.String("conversationId", conversationID), zap.Error(runErr))
-				errorMsg := "执行失败: " + runErr.Error()
-				// 更新助手消息内容
-				if assistantMessageID != "" {
-					if _, updateErr := h.db.Exec(
-						"UPDATE messages SET content = ?, updated_at = ? WHERE id = ?",
-						errorMsg,
-						time.Now(), assistantMessageID,
-					); updateErr != nil {
-						h.logger.Warn("更新失败后的助手消息失败", zap.String("queueId", queueID), zap.String("taskId", task.ID), zap.Error(updateErr))
-					}
-					// 保存错误详情到数据库
-					if err := h.db.AddProcessDetail(assistantMessageID, conversationID, "error", errorMsg, nil); err != nil {
-						h.logger.Warn("保存错误详情失败", zap.String("queueId", queueID), zap.String("taskId", task.ID), zap.Error(err))
-					}
-				}
-				h.batchTaskManager.UpdateTaskStatus(queueID, task.ID, "failed", "", runErr.Error())
-			}
-		} else {
-			h.logger.Info("批量任务执行成功", zap.String("queueId", queueID), zap.String("taskId", task.ID), zap.String("conversationId", conversationID))
-
-			resText := resultMA.Response
-			mcpIDs := resultMA.MCPExecutionIDs
-			lastIn := resultMA.LastAgentTraceInput
-			lastOut := resultMA.LastAgentTraceOutput
-
-			// 更新助手消息内容
-			if assistantMessageID != "" {
-				if updateErr := h.db.UpdateAssistantMessageFinalize(assistantMessageID, resText, mcpIDs, multiagent.AggregatedReasoningFromTraceJSON(lastIn)); updateErr != nil {
-					h.logger.Warn("更新助手消息失败", zap.String("queueId", queueID), zap.String("taskId", task.ID), zap.Error(updateErr))
-					// 如果更新失败，尝试创建新消息
 					_, err = h.db.AddMessage(conversationID, "assistant", resText, mcpIDs)
 					if err != nil {
 						h.logger.Error("保存助手消息失败", zap.String("queueId", queueID), zap.String("taskId", task.ID), zap.String("conversationId", conversationID), zap.Error(err))
 					}
 				}
-			} else {
-				// 如果没有预先创建的助手消息，创建一个新的
-				_, err = h.db.AddMessage(conversationID, "assistant", resText, mcpIDs)
-				if err != nil {
-					h.logger.Error("保存助手消息失败", zap.String("queueId", queueID), zap.String("taskId", task.ID), zap.String("conversationId", conversationID), zap.Error(err))
-				}
-			}
 
-			// 保存代理轨迹
-			if lastIn != "" || lastOut != "" {
-				if err := h.db.SaveAgentTrace(conversationID, lastIn, lastOut); err != nil {
-					h.logger.Warn("保存代理轨迹失败", zap.String("queueId", queueID), zap.String("taskId", task.ID), zap.Error(err))
-				} else {
-					h.logger.Info("已保存代理轨迹", zap.String("queueId", queueID), zap.String("taskId", task.ID), zap.String("conversationId", conversationID))
+				// 保存代理轨迹
+				if lastIn != "" || lastOut != "" {
+					if err := h.db.SaveAgentTrace(conversationID, lastIn, lastOut); err != nil {
+						h.logger.Warn("保存代理轨迹失败", zap.String("queueId", queueID), zap.String("taskId", task.ID), zap.Error(err))
+					} else {
+						h.logger.Info("已保存代理轨迹", zap.String("queueId", queueID), zap.String("taskId", task.ID), zap.String("conversationId", conversationID))
+					}
 				}
-			}
 
-			// 保存结果
-			h.batchTaskManager.UpdateTaskStatusWithConversationID(queueID, task.ID, "completed", resText, "", conversationID)
-		}
+				// 保存结果
+				h.batchTaskManager.UpdateTaskStatusWithConversationID(queueID, task.ID, "completed", resText, "", conversationID)
+			}
 		}()
 
 		// 移动到下一个任务

--- a/internal/handler/agent.go
+++ b/internal/handler/agent.go
@@ -1458,15 +1458,56 @@ func (h *AgentHandler) SubscribeAgentTaskEvents(c *gin.Context) {
 
 // ListAgentTasks 列出所有运行中的任务
 func (h *AgentHandler) ListAgentTasks(c *gin.Context) {
+	tasks := h.tasks.GetActiveTasks()
+	items := make([]gin.H, 0, len(tasks))
+	for _, task := range tasks {
+		if task == nil {
+			continue
+		}
+		taskTitle := ""
+		if h.db != nil && strings.TrimSpace(task.ConversationID) != "" {
+			if firstUserMessage, err := h.db.GetFirstUserMessageContent(task.ConversationID); err == nil {
+				taskTitle = strings.TrimSpace(firstUserMessage)
+			}
+		}
+		items = append(items, gin.H{
+			"conversationId": task.ConversationID,
+			"message":        task.Message,
+			"taskTitle":      taskTitle,
+			"startedAt":      task.StartedAt,
+			"status":         task.Status,
+		})
+	}
 	c.JSON(http.StatusOK, gin.H{
-		"tasks": h.tasks.GetActiveTasks(),
+		"tasks": items,
 	})
 }
 
 // ListCompletedTasks 列出最近完成的任务历史
 func (h *AgentHandler) ListCompletedTasks(c *gin.Context) {
+	tasks := h.tasks.GetCompletedTasks()
+	items := make([]gin.H, 0, len(tasks))
+	for _, task := range tasks {
+		if task == nil {
+			continue
+		}
+		taskTitle := ""
+		if h.db != nil && strings.TrimSpace(task.ConversationID) != "" {
+			if firstUserMessage, err := h.db.GetFirstUserMessageContent(task.ConversationID); err == nil {
+				taskTitle = strings.TrimSpace(firstUserMessage)
+			}
+		}
+		items = append(items, gin.H{
+			"conversationId": task.ConversationID,
+			"message":        task.Message,
+			"taskTitle":      taskTitle,
+			"startedAt":      task.StartedAt,
+			"completedAt":    task.CompletedAt,
+			"status":         task.Status,
+		})
+	}
 	c.JSON(http.StatusOK, gin.H{
-		"tasks": h.tasks.GetCompletedTasks(),
+		"tasks": items,
 	})
 }
 

--- a/internal/handler/assistant_notice_test.go
+++ b/internal/handler/assistant_notice_test.go
@@ -1,0 +1,76 @@
+package handler
+
+import (
+	"path/filepath"
+	"testing"
+
+	"cyberstrike-ai/internal/database"
+
+	"go.uber.org/zap"
+)
+
+func TestAppendAssistantMessageNoticeReplacesPlaceholder(t *testing.T) {
+	db, err := database.NewDB(filepath.Join(t.TempDir(), "test.db"), zap.NewNop())
+	if err != nil {
+		t.Fatalf("NewDB failed: %v", err)
+	}
+	defer db.Close()
+
+	h := &AgentHandler{db: db}
+	conv, err := db.CreateConversation("notice test", database.ConversationCreateMeta{})
+	if err != nil {
+		t.Fatalf("CreateConversation failed: %v", err)
+	}
+	msg, err := db.AddMessage(conv.ID, "assistant", "处理中...", nil)
+	if err != nil {
+		t.Fatalf("AddMessage failed: %v", err)
+	}
+
+	const cancelMsg = "任务已被用户取消，后续操作已停止。"
+	if err := h.appendAssistantMessageNotice(msg.ID, cancelMsg); err != nil {
+		t.Fatalf("appendAssistantMessageNotice failed: %v", err)
+	}
+
+	messages, err := db.GetMessages(conv.ID)
+	if err != nil {
+		t.Fatalf("GetMessages failed: %v", err)
+	}
+	if got := messages[0].Content; got != cancelMsg {
+		t.Fatalf("message content = %q, want %q", got, cancelMsg)
+	}
+}
+
+func TestAppendAssistantMessageNoticeAppendsToExistingContentOnce(t *testing.T) {
+	db, err := database.NewDB(filepath.Join(t.TempDir(), "test.db"), zap.NewNop())
+	if err != nil {
+		t.Fatalf("NewDB failed: %v", err)
+	}
+	defer db.Close()
+
+	h := &AgentHandler{db: db}
+	conv, err := db.CreateConversation("notice test", database.ConversationCreateMeta{})
+	if err != nil {
+		t.Fatalf("CreateConversation failed: %v", err)
+	}
+	msg, err := db.AddMessage(conv.ID, "assistant", "已生成的部分内容", nil)
+	if err != nil {
+		t.Fatalf("AddMessage failed: %v", err)
+	}
+
+	const cancelMsg = "任务已被用户取消，后续操作已停止。"
+	if err := h.appendAssistantMessageNotice(msg.ID, cancelMsg); err != nil {
+		t.Fatalf("appendAssistantMessageNotice failed: %v", err)
+	}
+	if err := h.appendAssistantMessageNotice(msg.ID, cancelMsg); err != nil {
+		t.Fatalf("second appendAssistantMessageNotice failed: %v", err)
+	}
+
+	messages, err := db.GetMessages(conv.ID)
+	if err != nil {
+		t.Fatalf("GetMessages failed: %v", err)
+	}
+	want := "已生成的部分内容\n\n" + cancelMsg
+	if got := messages[0].Content; got != want {
+		t.Fatalf("message content = %q, want %q", got, want)
+	}
+}

--- a/internal/handler/batch_task_manager.go
+++ b/internal/handler/batch_task_manager.go
@@ -39,6 +39,9 @@ const (
 
 	// MaxBatchQueueRoleLen 角色名最大长度
 	MaxBatchQueueRoleLen = 100
+
+	// MaxBatchQueueConcurrency 单个队列最大并发子任务数
+	MaxBatchQueueConcurrency = 25
 )
 
 // BatchTask 批量任务项
@@ -67,6 +70,7 @@ type BatchTaskQueue struct {
 	LastScheduleError     string       `json:"lastScheduleError,omitempty"`
 	LastRunError          string       `json:"lastRunError,omitempty"`
 	ProjectID             string       `json:"projectId,omitempty"`
+	Concurrency           int          `json:"concurrency"`
 	Tasks                 []*BatchTask `json:"tasks"`
 	Status                string       `json:"status"` // pending, running, paused, completed, cancelled
 	CreatedAt             time.Time    `json:"createdAt"`
@@ -80,7 +84,7 @@ type BatchTaskManager struct {
 	db          *database.DB
 	logger      *zap.Logger
 	queues      map[string]*BatchTaskQueue
-	taskCancels map[string]context.CancelFunc // 存储每个队列当前任务的取消函数
+	taskCancels map[string]map[string]context.CancelFunc // queueID -> taskID -> cancel
 	mu          sync.RWMutex
 }
 
@@ -92,7 +96,7 @@ func NewBatchTaskManager(logger *zap.Logger) *BatchTaskManager {
 	return &BatchTaskManager{
 		logger:      logger,
 		queues:      make(map[string]*BatchTaskQueue),
-		taskCancels: make(map[string]context.CancelFunc),
+		taskCancels: make(map[string]map[string]context.CancelFunc),
 	}
 }
 
@@ -103,10 +107,21 @@ func (m *BatchTaskManager) SetDB(db *database.DB) {
 	m.db = db
 }
 
+func normalizeBatchQueueConcurrency(concurrency int) int {
+	if concurrency < 1 {
+		return 1
+	}
+	if concurrency > MaxBatchQueueConcurrency {
+		return MaxBatchQueueConcurrency
+	}
+	return concurrency
+}
+
 // CreateBatchQueue 创建批量任务队列
 func (m *BatchTaskManager) CreateBatchQueue(
 	title, role, agentMode, scheduleMode, cronExpr, projectID string,
 	nextRunAt *time.Time,
+	concurrency int,
 	tasks []string,
 ) (*BatchTaskQueue, error) {
 	// 输入校验
@@ -124,11 +139,13 @@ func (m *BatchTaskManager) CreateBatchQueue(
 	defer m.mu.Unlock()
 
 	queueID := time.Now().Format("20060102150405") + "-" + generateShortID()
+	concurrency = normalizeBatchQueueConcurrency(concurrency)
 	queue := &BatchTaskQueue{
 		ID:              queueID,
 		Title:           title,
 		Role:            role,
 		ProjectID:       strings.TrimSpace(projectID),
+		Concurrency:     concurrency,
 		AgentMode:       config.NormalizeAgentMode(agentMode),
 		ScheduleMode:    normalizeBatchQueueScheduleMode(scheduleMode),
 		CronExpr:        strings.TrimSpace(cronExpr),
@@ -175,6 +192,7 @@ func (m *BatchTaskManager) CreateBatchQueue(
 			queue.CronExpr,
 			queue.NextRunAt,
 			queue.ProjectID,
+			queue.Concurrency,
 			dbTasks,
 		); err != nil {
 			m.logger.Warn("batch queue DB create failed", zap.String("queueId", queueID), zap.Error(err))
@@ -228,6 +246,7 @@ func (m *BatchTaskManager) loadQueueFromDB(queueID string) *BatchTaskQueue {
 		ID:           queueRow.ID,
 		AgentMode:    "eino_single",
 		ScheduleMode: "manual",
+		Concurrency:  1,
 		Status:       queueRow.Status,
 		CreatedAt:    queueRow.CreatedAt,
 		CurrentIndex: queueRow.CurrentIndex,
@@ -269,6 +288,9 @@ func (m *BatchTaskManager) loadQueueFromDB(queueID string) *BatchTaskQueue {
 	}
 	if queueRow.ProjectID.Valid {
 		queue.ProjectID = strings.TrimSpace(queueRow.ProjectID.String)
+	}
+	if queueRow.Concurrency.Valid {
+		queue.Concurrency = normalizeBatchQueueConcurrency(int(queueRow.Concurrency.Int64))
 	}
 	if queueRow.StartedAt.Valid {
 		queue.StartedAt = &queueRow.StartedAt.Time
@@ -467,6 +489,7 @@ func (m *BatchTaskManager) LoadFromDB() error {
 			ID:           queueRow.ID,
 			AgentMode:    "eino_single",
 			ScheduleMode: "manual",
+			Concurrency:  1,
 			Status:       queueRow.Status,
 			CreatedAt:    queueRow.CreatedAt,
 			CurrentIndex: queueRow.CurrentIndex,
@@ -508,6 +531,9 @@ func (m *BatchTaskManager) LoadFromDB() error {
 		}
 		if queueRow.ProjectID.Valid {
 			queue.ProjectID = strings.TrimSpace(queueRow.ProjectID.String)
+		}
+		if queueRow.Concurrency.Valid {
+			queue.Concurrency = normalizeBatchQueueConcurrency(int(queueRow.Concurrency.Int64))
 		}
 		if queueRow.StartedAt.Valid {
 			queue.StartedAt = &queueRow.StartedAt.Time
@@ -583,11 +609,24 @@ func (m *BatchTaskManager) UpdateTaskStatusWithConversationID(queueID, taskID, s
 				task.ConversationID = conversationID
 			}
 			now := time.Now()
-			if status == BatchTaskStatusRunning && task.StartedAt == nil {
-				task.StartedAt = &now
+			if status == BatchTaskStatusRunning {
+				if task.StartedAt == nil {
+					task.StartedAt = &now
+				}
+				task.CompletedAt = nil
+				task.Error = ""
+				task.Result = ""
 			}
 			if status == BatchTaskStatusCompleted || status == BatchTaskStatusFailed || status == BatchTaskStatusCancelled {
 				task.CompletedAt = &now
+				switch status {
+				case BatchTaskStatusCompleted:
+					task.Error = ""
+				case BatchTaskStatusFailed:
+					task.Result = ""
+				case BatchTaskStatusCancelled:
+					task.Error = ""
+				}
 			}
 			break
 		}
@@ -684,6 +723,35 @@ func (m *BatchTaskManager) UpdateQueueMetadata(queueID, title, role, agentMode s
 			m.logger.Warn("batch queue DB metadata update failed", zap.String("queueId", queueID), zap.Error(err))
 		}
 	}
+	return nil
+}
+
+// UpdateQueueConcurrency 更新队列并发数（非 running 时可用）
+func (m *BatchTaskManager) UpdateQueueConcurrency(queueID string, concurrency int) error {
+	concurrency = normalizeBatchQueueConcurrency(concurrency)
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	queue, exists := m.queues[queueID]
+	if !exists {
+		return fmt.Errorf("队列不存在")
+	}
+	if queue.Status == BatchQueueStatusRunning {
+		return fmt.Errorf("队列正在运行中，无法修改并发数")
+	}
+
+	if m.db != nil {
+		if err := m.db.UpdateBatchQueueConcurrency(queueID, concurrency); err != nil {
+			m.logger.Warn("batch queue DB concurrency update failed",
+				zap.String("queueId", queueID),
+				zap.Int("concurrency", concurrency),
+				zap.Error(err))
+			return fmt.Errorf("更新队列并发数失败: %w", err)
+		}
+	}
+
+	queue.Concurrency = concurrency
 	return nil
 }
 
@@ -957,6 +1025,76 @@ func (m *BatchTaskManager) GetNextTask(queueID string) (*BatchTask, bool) {
 	return nil, false
 }
 
+// ClaimNextTask 领取队列中最早的 pending 任务，并立即标记为 running。
+func (m *BatchTaskManager) ClaimNextTask(queueID string) (*BatchTask, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	queue, exists := m.queues[queueID]
+	if !exists || queue.Status != BatchQueueStatusRunning {
+		return nil, false
+	}
+
+	for i := 0; i < len(queue.Tasks); i++ {
+		task := queue.Tasks[i]
+		if task.Status != BatchTaskStatusPending {
+			continue
+		}
+
+		if m.db != nil {
+			if err := m.db.ClaimBatchTaskForRun(queueID, task.ID); err != nil {
+				m.logger.Warn("batch task DB claim failed",
+					zap.String("queueId", queueID),
+					zap.String("taskId", task.ID),
+					zap.Error(err))
+				return nil, false
+			}
+			if err := m.db.UpdateBatchQueueCurrentIndex(queueID, i); err != nil {
+				m.logger.Warn("batch queue DB claim index update failed",
+					zap.String("queueId", queueID),
+					zap.Int("currentIndex", i),
+					zap.Error(err))
+			}
+		}
+
+		now := time.Now()
+		task.Status = BatchTaskStatusRunning
+		if task.StartedAt == nil {
+			task.StartedAt = &now
+		}
+		task.CompletedAt = nil
+		task.Error = ""
+		task.Result = ""
+		queue.CurrentIndex = i
+		return task, true
+	}
+
+	return nil, false
+}
+
+// QueueHasActiveTasks 判断队列是否还有 pending/running 子任务。
+func (m *BatchTaskManager) QueueHasActiveTasks(queueID string) (pending bool, running bool, exists bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	queue, exists := m.queues[queueID]
+	if !exists {
+		return false, false, false
+	}
+	for _, task := range queue.Tasks {
+		if task == nil {
+			continue
+		}
+		switch task.Status {
+		case BatchTaskStatusPending:
+			pending = true
+		case BatchTaskStatusRunning:
+			running = true
+		}
+	}
+	return pending, running, true
+}
+
 // MoveToNextTask 移动到下一个任务
 func (m *BatchTaskManager) MoveToNextTask(queueID string) {
 	m.mu.Lock()
@@ -978,19 +1116,31 @@ func (m *BatchTaskManager) MoveToNextTask(queueID string) {
 }
 
 // SetTaskCancel 设置当前任务的取消函数
-func (m *BatchTaskManager) SetTaskCancel(queueID string, cancel context.CancelFunc) {
+func (m *BatchTaskManager) SetTaskCancel(queueID, taskID string, cancel context.CancelFunc) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if cancel != nil {
-		m.taskCancels[queueID] = cancel
+		if m.taskCancels[queueID] == nil {
+			m.taskCancels[queueID] = make(map[string]context.CancelFunc)
+		}
+		m.taskCancels[queueID][taskID] = cancel
 	} else {
-		delete(m.taskCancels, queueID)
+		if taskID == "" {
+			delete(m.taskCancels, queueID)
+			return
+		}
+		if cancels, ok := m.taskCancels[queueID]; ok {
+			delete(cancels, taskID)
+			if len(cancels) == 0 {
+				delete(m.taskCancels, queueID)
+			}
+		}
 	}
 }
 
 // PauseQueue 暂停队列
 func (m *BatchTaskManager) PauseQueue(queueID string) bool {
-	var cancelFunc context.CancelFunc
+	var cancelFuncs []context.CancelFunc
 
 	m.mu.Lock()
 	queue, exists := m.queues[queueID]
@@ -1017,14 +1167,18 @@ func (m *BatchTaskManager) PauseQueue(queueID string) bool {
 	queue.Status = BatchQueueStatusPaused
 
 	// 取消当前正在执行的任务（通过取消context）
-	if cancel, ok := m.taskCancels[queueID]; ok {
-		cancelFunc = cancel
+	if cancels, ok := m.taskCancels[queueID]; ok {
+		for _, cancel := range cancels {
+			if cancel != nil {
+				cancelFuncs = append(cancelFuncs, cancel)
+			}
+		}
 		delete(m.taskCancels, queueID)
 	}
 	m.mu.Unlock()
 
 	// 释放锁后执行取消回调（cancel 可能阻塞，不应持锁）
-	if cancelFunc != nil {
+	for _, cancelFunc := range cancelFuncs {
 		cancelFunc()
 	}
 
@@ -1034,7 +1188,7 @@ func (m *BatchTaskManager) PauseQueue(queueID string) bool {
 // CancelQueue 取消队列（保留此方法以保持向后兼容，但建议使用PauseQueue）
 func (m *BatchTaskManager) CancelQueue(queueID string) bool {
 	now := time.Now()
-	var cancelFunc context.CancelFunc
+	var cancelFuncs []context.CancelFunc
 
 	m.mu.Lock()
 	queue, exists := m.queues[queueID]
@@ -1076,14 +1230,18 @@ func (m *BatchTaskManager) CancelQueue(queueID string) bool {
 	}
 
 	// 取消当前正在执行的任务
-	if cancel, ok := m.taskCancels[queueID]; ok {
-		cancelFunc = cancel
+	if cancels, ok := m.taskCancels[queueID]; ok {
+		for _, cancel := range cancels {
+			if cancel != nil {
+				cancelFuncs = append(cancelFuncs, cancel)
+			}
+		}
 		delete(m.taskCancels, queueID)
 	}
 	m.mu.Unlock()
 
 	// 释放锁后执行取消回调（cancel 可能阻塞，不应持锁）
-	if cancelFunc != nil {
+	for _, cancelFunc := range cancelFuncs {
 		cancelFunc()
 	}
 

--- a/internal/handler/batch_task_manager.go
+++ b/internal/handler/batch_task_manager.go
@@ -946,7 +946,7 @@ func (m *BatchTaskManager) GetNextTask(queueID string) (*BatchTask, bool) {
 		return nil, false
 	}
 
-	for i := queue.CurrentIndex; i < len(queue.Tasks); i++ {
+	for i := 0; i < len(queue.Tasks); i++ {
 		task := queue.Tasks[i]
 		if task.Status == BatchTaskStatusPending {
 			queue.CurrentIndex = i

--- a/internal/handler/batch_task_manager_test.go
+++ b/internal/handler/batch_task_manager_test.go
@@ -1,0 +1,49 @@
+package handler
+
+import (
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+func TestGetNextTaskReturnsEarliestPendingTask(t *testing.T) {
+	manager := NewBatchTaskManager(zap.NewNop())
+	queueID := "queue-resume-order"
+	manager.queues[queueID] = &BatchTaskQueue{
+		ID:           queueID,
+		Status:       BatchQueueStatusPaused,
+		CreatedAt:    time.Now(),
+		CurrentIndex: 6,
+		Tasks: []*BatchTask{
+			{ID: "task-1", Status: BatchTaskStatusCancelled},
+			{ID: "task-2", Status: BatchTaskStatusCancelled},
+			{ID: "task-3", Status: BatchTaskStatusPending},
+			{ID: "task-4", Status: BatchTaskStatusCancelled},
+			{ID: "task-5", Status: BatchTaskStatusCancelled},
+			{ID: "task-6", Status: BatchTaskStatusCancelled},
+			{ID: "task-7", Status: BatchTaskStatusPending},
+		},
+	}
+
+	task, ok := manager.GetNextTask(queueID)
+	if !ok {
+		t.Fatal("GetNextTask returned no task")
+	}
+	if task.ID != "task-3" {
+		t.Fatalf("GetNextTask returned %q, want task-3", task.ID)
+	}
+	if got := manager.queues[queueID].CurrentIndex; got != 2 {
+		t.Fatalf("CurrentIndex = %d, want 2", got)
+	}
+
+	task.Status = BatchTaskStatusCompleted
+	manager.MoveToNextTask(queueID)
+	task, ok = manager.GetNextTask(queueID)
+	if !ok {
+		t.Fatal("GetNextTask after MoveToNextTask returned no task")
+	}
+	if task.ID != "task-7" {
+		t.Fatalf("GetNextTask after MoveToNextTask returned %q, want task-7", task.ID)
+	}
+}

--- a/internal/handler/batch_task_manager_test.go
+++ b/internal/handler/batch_task_manager_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -45,5 +46,228 @@ func TestGetNextTaskReturnsEarliestPendingTask(t *testing.T) {
 	}
 	if task.ID != "task-7" {
 		t.Fatalf("GetNextTask after MoveToNextTask returned %q, want task-7", task.ID)
+	}
+}
+
+func TestClaimNextTaskClaimsDistinctEarliestPendingTasks(t *testing.T) {
+	manager := NewBatchTaskManager(zap.NewNop())
+	queueID := "queue-concurrent-claim"
+	manager.queues[queueID] = &BatchTaskQueue{
+		ID:           queueID,
+		Status:       BatchQueueStatusRunning,
+		CreatedAt:    time.Now(),
+		CurrentIndex: 6,
+		Tasks: []*BatchTask{
+			{ID: "task-1", Status: BatchTaskStatusCancelled},
+			{ID: "task-2", Status: BatchTaskStatusPending},
+			{ID: "task-3", Status: BatchTaskStatusPending},
+			{ID: "task-4", Status: BatchTaskStatusCancelled},
+		},
+	}
+
+	first, ok := manager.ClaimNextTask(queueID)
+	if !ok {
+		t.Fatal("first ClaimNextTask returned no task")
+	}
+	if first.ID != "task-2" {
+		t.Fatalf("first ClaimNextTask returned %q, want task-2", first.ID)
+	}
+	if first.Status != BatchTaskStatusRunning {
+		t.Fatalf("first task status = %q, want running", first.Status)
+	}
+
+	second, ok := manager.ClaimNextTask(queueID)
+	if !ok {
+		t.Fatal("second ClaimNextTask returned no task")
+	}
+	if second.ID != "task-3" {
+		t.Fatalf("second ClaimNextTask returned %q, want task-3", second.ID)
+	}
+	if second.Status != BatchTaskStatusRunning {
+		t.Fatalf("second task status = %q, want running", second.Status)
+	}
+
+	if _, ok := manager.ClaimNextTask(queueID); ok {
+		t.Fatal("third ClaimNextTask returned a task, want none")
+	}
+	pending, running, exists := manager.QueueHasActiveTasks(queueID)
+	if !exists {
+		t.Fatal("QueueHasActiveTasks returned exists=false")
+	}
+	if pending {
+		t.Fatal("QueueHasActiveTasks pending=true, want false")
+	}
+	if !running {
+		t.Fatal("QueueHasActiveTasks running=false, want true")
+	}
+}
+
+func TestClaimNextTaskClearsStaleConversationData(t *testing.T) {
+	manager := NewBatchTaskManager(zap.NewNop())
+	queueID := "queue-stale-conversation"
+	completedAt := time.Now()
+	manager.queues[queueID] = &BatchTaskQueue{
+		ID:        queueID,
+		Status:    BatchQueueStatusRunning,
+		CreatedAt: time.Now(),
+		Tasks: []*BatchTask{
+			{
+				ID:             "task-1",
+				Status:         BatchTaskStatusPending,
+				ConversationID: "old-conversation",
+				Error:          "服务重启，任务已中断，请重新发起或继续",
+				Result:         "old result",
+				CompletedAt:    &completedAt,
+			},
+		},
+	}
+
+	task, ok := manager.ClaimNextTask(queueID)
+	if !ok {
+		t.Fatal("ClaimNextTask returned no task")
+	}
+	if task.ID != "task-1" {
+		t.Fatalf("ClaimNextTask returned %q, want task-1", task.ID)
+	}
+	if task.ConversationID != "old-conversation" {
+		t.Fatalf("ConversationID = %q, want old-conversation preserved until replacement", task.ConversationID)
+	}
+	if task.Error != "" {
+		t.Fatalf("Error = %q, want empty", task.Error)
+	}
+	if task.Result != "" {
+		t.Fatalf("Result = %q, want empty", task.Result)
+	}
+	if task.CompletedAt != nil {
+		t.Fatalf("CompletedAt = %#v, want nil", task.CompletedAt)
+	}
+}
+
+func TestUpdateTaskStatusClearsStaleErrorForCancelledAndCompleted(t *testing.T) {
+	manager := NewBatchTaskManager(zap.NewNop())
+	queueID := "queue-clear-stale-error"
+	manager.queues[queueID] = &BatchTaskQueue{
+		ID:        queueID,
+		Status:    BatchQueueStatusRunning,
+		CreatedAt: time.Now(),
+		Tasks: []*BatchTask{
+			{
+				ID:             "task-cancelled",
+				Status:         BatchTaskStatusRunning,
+				ConversationID: "old-cancelled",
+				Error:          "服务重启，任务已中断，请重新发起或继续",
+			},
+			{
+				ID:             "task-completed",
+				Status:         BatchTaskStatusRunning,
+				ConversationID: "old-completed",
+				Error:          "服务重启，任务已中断，请重新发起或继续",
+			},
+		},
+	}
+
+	manager.UpdateTaskStatusWithConversationID(queueID, "task-cancelled", BatchTaskStatusCancelled, "任务已被用户取消，后续操作已停止。", "", "new-cancelled")
+	manager.UpdateTaskStatusWithConversationID(queueID, "task-completed", BatchTaskStatusCompleted, "ok", "", "new-completed")
+
+	cancelled := manager.queues[queueID].Tasks[0]
+	if cancelled.Error != "" {
+		t.Fatalf("cancelled error = %q, want empty", cancelled.Error)
+	}
+	if cancelled.Result != "任务已被用户取消，后续操作已停止。" {
+		t.Fatalf("cancelled result = %q, want cancel result", cancelled.Result)
+	}
+	if cancelled.ConversationID != "new-cancelled" {
+		t.Fatalf("cancelled conversation = %q, want new-cancelled", cancelled.ConversationID)
+	}
+
+	completed := manager.queues[queueID].Tasks[1]
+	if completed.Error != "" {
+		t.Fatalf("completed error = %q, want empty", completed.Error)
+	}
+	if completed.Result != "ok" {
+		t.Fatalf("completed result = %q, want ok", completed.Result)
+	}
+	if completed.ConversationID != "new-completed" {
+		t.Fatalf("completed conversation = %q, want new-completed", completed.ConversationID)
+	}
+}
+
+func TestPauseQueueCancelsAllRunningTaskContexts(t *testing.T) {
+	manager := NewBatchTaskManager(zap.NewNop())
+	queueID := "queue-pause-concurrent"
+	manager.queues[queueID] = &BatchTaskQueue{
+		ID:        queueID,
+		Status:    BatchQueueStatusRunning,
+		CreatedAt: time.Now(),
+		Tasks: []*BatchTask{
+			{ID: "task-1", Status: BatchTaskStatusRunning},
+			{ID: "task-2", Status: BatchTaskStatusRunning},
+		},
+	}
+
+	ctx1, cancel1 := context.WithCancel(context.Background())
+	ctx2, cancel2 := context.WithCancel(context.Background())
+	manager.SetTaskCancel(queueID, "task-1", cancel1)
+	manager.SetTaskCancel(queueID, "task-2", cancel2)
+
+	if !manager.PauseQueue(queueID) {
+		t.Fatal("PauseQueue returned false")
+	}
+
+	select {
+	case <-ctx1.Done():
+	default:
+		t.Fatal("task-1 context was not cancelled")
+	}
+	select {
+	case <-ctx2.Done():
+	default:
+		t.Fatal("task-2 context was not cancelled")
+	}
+	if len(manager.taskCancels) != 0 {
+		t.Fatalf("taskCancels still has %d queue entries, want 0", len(manager.taskCancels))
+	}
+}
+
+func TestUpdateQueueConcurrencyNormalizesValue(t *testing.T) {
+	manager := NewBatchTaskManager(zap.NewNop())
+	queueID := "queue-concurrency-update"
+	manager.queues[queueID] = &BatchTaskQueue{
+		ID:          queueID,
+		Status:      BatchQueueStatusPending,
+		Concurrency: 1,
+		CreatedAt:   time.Now(),
+	}
+
+	if err := manager.UpdateQueueConcurrency(queueID, 99); err != nil {
+		t.Fatalf("UpdateQueueConcurrency: %v", err)
+	}
+	if got := manager.queues[queueID].Concurrency; got != MaxBatchQueueConcurrency {
+		t.Fatalf("Concurrency = %d, want %d", got, MaxBatchQueueConcurrency)
+	}
+
+	if err := manager.UpdateQueueConcurrency(queueID, 0); err != nil {
+		t.Fatalf("UpdateQueueConcurrency zero: %v", err)
+	}
+	if got := manager.queues[queueID].Concurrency; got != 1 {
+		t.Fatalf("Concurrency after zero = %d, want 1", got)
+	}
+}
+
+func TestUpdateQueueConcurrencyRejectsRunningQueue(t *testing.T) {
+	manager := NewBatchTaskManager(zap.NewNop())
+	queueID := "queue-concurrency-running"
+	manager.queues[queueID] = &BatchTaskQueue{
+		ID:          queueID,
+		Status:      BatchQueueStatusRunning,
+		Concurrency: 1,
+		CreatedAt:   time.Now(),
+	}
+
+	if err := manager.UpdateQueueConcurrency(queueID, 2); err == nil {
+		t.Fatal("UpdateQueueConcurrency returned nil for running queue")
+	}
+	if got := manager.queues[queueID].Concurrency; got != 1 {
+		t.Fatalf("Concurrency changed to %d, want 1", got)
 	}
 }

--- a/internal/handler/batch_task_mcp.go
+++ b/internal/handler/batch_task_mcp.go
@@ -177,6 +177,10 @@ func RegisterBatchTaskMCPTools(mcpServer *mcp.Server, h *AgentHandler, logger *z
 					"type":        "boolean",
 					"description": "创建后是否立即开始执行队列，默认 false（pending，需 batch_task_start）",
 				},
+				"concurrency": map[string]interface{}{
+					"type":        "integer",
+					"description": fmt.Sprintf("并发执行的子任务数，默认 1，最大 %d", MaxBatchQueueConcurrency),
+				},
 				"project_id": map[string]interface{}{
 					"type":        "string",
 					"description": "队列内子对话绑定的项目 ID（可选，未指定时使用 config.project.default_project_id）",
@@ -209,8 +213,9 @@ func RegisterBatchTaskMCPTools(mcpServer *mcp.Server, h *AgentHandler, logger *z
 		if !ok {
 			executeNow = false
 		}
+		concurrency := int(mcpArgFloat(args, "concurrency"))
 		projectID := strings.TrimSpace(mcpArgString(args, "project_id"))
-		queue, createErr := h.batchTaskManager.CreateBatchQueue(title, role, agentMode, scheduleMode, cronExpr, projectID, nextRunAt, tasks)
+		queue, createErr := h.batchTaskManager.CreateBatchQueue(title, role, agentMode, scheduleMode, cronExpr, projectID, nextRunAt, concurrency, tasks)
 		if createErr != nil {
 			return batchMCPTextResult("创建队列失败: "+createErr.Error(), true), nil
 		}
@@ -647,6 +652,7 @@ type batchTaskQueueMCPListItem struct {
 	NextRunAt             *time.Time                `json:"nextRunAt,omitempty"`
 	ScheduleEnabled       bool                      `json:"scheduleEnabled"`
 	LastScheduleTriggerAt *time.Time                `json:"lastScheduleTriggerAt,omitempty"`
+	Concurrency           int                       `json:"concurrency"`
 	Status                string                    `json:"status"`
 	CreatedAt             time.Time                 `json:"createdAt"`
 	StartedAt             *time.Time                `json:"startedAt,omitempty"`
@@ -710,6 +716,7 @@ func toBatchTaskQueueMCPListItem(q *BatchTaskQueue) batchTaskQueueMCPListItem {
 		NextRunAt:             q.NextRunAt,
 		ScheduleEnabled:       q.ScheduleEnabled,
 		LastScheduleTriggerAt: q.LastScheduleTriggerAt,
+		Concurrency:           normalizeBatchQueueConcurrency(q.Concurrency),
 		Status:                q.Status,
 		CreatedAt:             q.CreatedAt,
 		StartedAt:             q.StartedAt,

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -22,7 +22,7 @@ KNOWLEDGE_BASE_DIR="$ROOT_DIR/knowledge_base"
 
 BACKUP_BASE_DIR="$ROOT_DIR/.upgrade-backup"
 
-GITHUB_REPO="Ed1s0nZ/CyberStrikeAI"
+GITHUB_REPO="${GITHUB_REPO:-hagerjoshua799-oss/CyberStrikeAI}"
 
 TAG=""
 PRESERVE_VENV=1
@@ -408,4 +408,3 @@ main() {
 }
 
 main "$@"
-

--- a/web/static/i18n/en-US.json
+++ b/web/static/i18n/en-US.json
@@ -2374,6 +2374,8 @@
     "agentModeSingle": "Single-agent (Eino ADK)",
     "agentModeMulti": "Multi-agent (Eino)",
     "agentModeHint": "Same as chat: Eino single-agent (ADK), or Deep / Plan-Execute / Supervisor (last three require multi_agent.enabled).",
+    "concurrency": "Concurrency",
+    "concurrencyHint": "Number of subtasks/conversations to run at the same time. Enter 2 to create and run 2 conversations concurrently. Maximum 25; higher concurrency increases model API, tool execution, and database write load.",
     "scheduleMode": "Schedule mode",
     "scheduleModeManual": "Manual",
     "scheduleModeCron": "Cron expression",

--- a/web/static/i18n/zh-CN.json
+++ b/web/static/i18n/zh-CN.json
@@ -2362,6 +2362,8 @@
     "agentModeSingle": "单代理（Eino ADK）",
     "agentModeMulti": "多代理（Eino）",
     "agentModeHint": "与对话页一致：Eino 单代理（ADK），或 Deep / Plan-Execute / Supervisor（后三种需已启用多代理）。",
+    "concurrency": "并发数",
+    "concurrencyHint": "同时运行的子任务/对话数量；填 2 会同时创建并运行 2 个对话，最大 25。并发越高，对模型 API、工具执行和数据库写入压力越大。",
     "scheduleMode": "调度方式",
     "scheduleModeManual": "手工执行",
     "scheduleModeCron": "调度表达式（Cron）",

--- a/web/static/js/chat.js
+++ b/web/static/js/chat.js
@@ -5978,10 +5978,10 @@ async function loadConversationsWithGroups(searchQuery = '') {
             }
         });
 
-        // 按时间排序
+        // 按创建时间排序，避免追问旧对话时因 updatedAt 变化跳到列表顶部
         const sortByTime = (a, b) => {
-            const timeA = a.updatedAt ? new Date(a.updatedAt) : new Date(0);
-            const timeB = b.updatedAt ? new Date(b.updatedAt) : new Date(0);
+            const timeA = a.createdAt ? new Date(a.createdAt) : (a.updatedAt ? new Date(a.updatedAt) : new Date(0));
+            const timeB = b.createdAt ? new Date(b.createdAt) : (b.updatedAt ? new Date(b.updatedAt) : new Date(0));
             return timeB - timeA;
         };
 
@@ -6011,7 +6011,7 @@ async function loadConversationsWithGroups(searchQuery = '') {
         };
 
         normalConvs.forEach(conv => {
-            const dateObj = conv.updatedAt ? new Date(conv.updatedAt) : new Date();
+            const dateObj = conv.createdAt ? new Date(conv.createdAt) : (conv.updatedAt ? new Date(conv.updatedAt) : new Date());
             const validDate = isNaN(dateObj.getTime()) ? new Date() : dateObj;
             const groupKey = getConversationGroup(validDate, todayStart, sevenDaysCutoff, yesterdayStart);
             groups[groupKey].push({
@@ -6024,7 +6024,7 @@ async function loadConversationsWithGroups(searchQuery = '') {
 
         if (pinnedConvs.length > 0) {
             pinnedConvs.forEach(conv => {
-                const dateObj = conv.updatedAt ? new Date(conv.updatedAt) : new Date();
+                const dateObj = conv.createdAt ? new Date(conv.createdAt) : (conv.updatedAt ? new Date(conv.updatedAt) : new Date());
                 const validDate = isNaN(dateObj.getTime()) ? new Date() : dateObj;
                 fragment.appendChild(createConversationListItemWithMenu({
                     ...conv,
@@ -6135,7 +6135,7 @@ function createConversationListItemWithMenu(conversation, isPinned) {
 
     const time = document.createElement('div');
     time.className = 'conversation-time';
-    const dateObj = conversation.updatedAt ? new Date(conversation.updatedAt) : new Date();
+    const dateObj = conversation.createdAt ? new Date(conversation.createdAt) : (conversation.updatedAt ? new Date(conversation.updatedAt) : new Date());
     time.textContent = conversation._timeText || formatConversationTimestamp(dateObj);
     contentWrapper.appendChild(time);
 
@@ -7949,7 +7949,7 @@ async function loadGroupConversations(groupId, searchQuery = '') {
 
                 const timeWrapper = document.createElement('div');
                 timeWrapper.className = 'group-conversation-time';
-                const dateObj = fullConv.updatedAt ? new Date(fullConv.updatedAt) : new Date();
+                const dateObj = fullConv.createdAt ? new Date(fullConv.createdAt) : (fullConv.updatedAt ? new Date(fullConv.updatedAt) : new Date());
                 const convListLocale = (typeof window.__locale === 'string' && window.__locale.startsWith('zh')) ? 'zh-CN' : 'en-US';
                 timeWrapper.textContent = dateObj.toLocaleString(convListLocale, {
                     year: 'numeric',

--- a/web/static/js/monitor.js
+++ b/web/static/js/monitor.js
@@ -3442,11 +3442,12 @@ function renderActiveTasks(tasks) {
         const isFinalStatus = ['failed', 'timeout', 'cancelled', 'completed'].includes(task.status);
         const unnamedTaskText = _t('tasks.unnamedTask');
         const stopTaskBtnText = _t('tasks.stopTask');
+        const taskLabel = task.taskTitle || task.message || unnamedTaskText;
 
         item.innerHTML = `
             <div class="active-task-info">
                 <span class="active-task-status">${statusText}</span>
-                <span class="active-task-message">${escapeHtml(task.message || unnamedTaskText)}</span>
+                <span class="active-task-message">${escapeHtml(taskLabel)}</span>
             </div>
             <div class="active-task-actions">
                 ${timeText ? `<span class="active-task-time">${timeText}</span>` : ''}

--- a/web/static/js/tasks.js
+++ b/web/static/js/tasks.js
@@ -105,6 +105,12 @@ const tasksState = {
     showHistory: true // 是否显示历史记录
 };
 
+function getTaskDisplayTitle(task) {
+    const fixedTitle = task && typeof task.taskTitle === 'string' ? task.taskTitle.trim() : '';
+    const message = task && typeof task.message === 'string' ? task.message.trim() : '';
+    return fixedTitle || message || _t('tasks.unnamedTask');
+}
+
 // 从localStorage加载已完成任务历史
 function loadCompletedTasksHistory() {
     try {
@@ -167,6 +173,7 @@ function updateCompletedTasksHistory(currentTasks) {
             tasksState.completedTasksHistory.push({
                 conversationId: task.conversationId,
                 message: task.message || '未命名任务',
+                taskTitle: task.taskTitle || '',
                 startedAt: task.startedAt,
                 status: finalStatus,
                 completedAt: new Date().toISOString()
@@ -233,6 +240,7 @@ async function loadTasks() {
                 ...completedTasks.map(t => ({
                     conversationId: t.conversationId,
                     message: t.message || '未命名任务',
+                    taskTitle: t.taskTitle || '',
                     startedAt: t.startedAt,
                     status: t.status || 'completed',
                     completedAt: t.completedAt || new Date().toISOString()
@@ -359,7 +367,7 @@ function filterAndSortTasks() {
             case 'status':
                 return (a.status || '').localeCompare(b.status || '');
             case 'message':
-                return (a.message || '').localeCompare(b.message || '');
+                return getTaskDisplayTitle(a).localeCompare(getTaskDisplayTitle(b));
             default:
                 return 0;
         }
@@ -509,6 +517,7 @@ function renderTaskItem(task, statusMap, isHistory = false) {
     const duration = (task.status === 'running' || task.status === 'cancelling') 
         ? calculateDuration(task.startedAt) 
         : '';
+    const displayTitle = getTaskDisplayTitle(task);
 
     return `
         <div class="task-item ${isHistory ? 'task-item-history' : ''}" data-task-id="${task.conversationId}" data-started-at="${task.startedAt}" data-status="${task.status}">
@@ -522,7 +531,7 @@ function renderTaskItem(task, statusMap, isHistory = false) {
                     ` : '<div class="task-checkbox-placeholder"></div>'}
                     <span class="task-status ${status.class}">${status.text}</span>
                     ${isHistory ? '<span class="task-history-badge" title="' + _t('tasks.historyBadge') + '">📜</span>' : ''}
-                    <span class="task-message" title="${escapeHtml(task.message || _t('tasks.unnamedTask'))}">${escapeHtml(task.message || _t('tasks.unnamedTask'))}</span>
+                    <span class="task-message" title="${escapeHtml(displayTitle)}">${escapeHtml(displayTitle)}</span>
                 </div>
                 <div class="task-actions">
                     ${duration ? `<span class="task-duration" title="${_t('tasks.duration')}">⏱ ${duration}</span>` : ''}

--- a/web/static/js/tasks.js
+++ b/web/static/js/tasks.js
@@ -866,6 +866,7 @@ async function showBatchImportModal() {
     const roleSelect = document.getElementById('batch-queue-role');
     const projectSelect = document.getElementById('batch-queue-project-id');
     const agentModeSelect = document.getElementById('batch-queue-agent-mode');
+    const concurrencyInput = document.getElementById('batch-queue-concurrency');
     const scheduleModeSelect = document.getElementById('batch-queue-schedule-mode');
     const cronExprInput = document.getElementById('batch-queue-cron-expr');
     const executeNowCheckbox = document.getElementById('batch-queue-execute-now');
@@ -883,6 +884,9 @@ async function showBatchImportModal() {
         }
         if (agentModeSelect) {
             agentModeSelect.value = 'eino_single';
+        }
+        if (concurrencyInput) {
+            concurrencyInput.value = '1';
         }
         if (scheduleModeSelect) {
             scheduleModeSelect.value = 'manual';
@@ -988,6 +992,7 @@ async function createBatchQueue() {
     const roleSelect = document.getElementById('batch-queue-role');
     const projectSelect = document.getElementById('batch-queue-project-id');
     const agentModeSelect = document.getElementById('batch-queue-agent-mode');
+    const concurrencyInput = document.getElementById('batch-queue-concurrency');
     const scheduleModeSelect = document.getElementById('batch-queue-schedule-mode');
     const cronExprInput = document.getElementById('batch-queue-cron-expr');
     const executeNowCheckbox = document.getElementById('batch-queue-execute-now');
@@ -1014,6 +1019,12 @@ async function createBatchQueue() {
     const projectId = projectSelect ? (projectSelect.value || '').trim() : '';
     const rawMode = agentModeSelect ? agentModeSelect.value : 'eino_single';
     const agentMode = isBatchQueueAgentMode(rawMode) ? rawMode : 'eino_single';
+    let concurrency = concurrencyInput ? parseInt(concurrencyInput.value, 10) : 1;
+    if (!Number.isFinite(concurrency) || concurrency < 1) {
+        concurrency = 1;
+    } else if (concurrency > 25) {
+        concurrency = 25;
+    }
     const scheduleMode = scheduleModeSelect ? (scheduleModeSelect.value === 'cron' ? 'cron' : 'manual') : 'manual';
     const cronExpr = cronExprInput ? cronExprInput.value.trim() : '';
     const executeNow = executeNowCheckbox ? !!executeNowCheckbox.checked : false;
@@ -1037,6 +1048,7 @@ async function createBatchQueue() {
                 tasks,
                 role,
                 agentMode,
+                concurrency,
                 scheduleMode,
                 cronExpr,
                 executeNow,
@@ -1452,6 +1464,7 @@ async function showBatchQueueDetail(queueId) {
             roleLineVal = '\uD83D\uDD35 ' + escapeHtml(_t('batchQueueDetailModal.defaultRole'));
         }
         const agentModeText = batchQueueAgentModeLabel(queue.agentMode);
+        const concurrencyText = String(queue.concurrency || 1);
         const scheduleModeText = queue.scheduleMode === 'cron' ? _t('batchImportModal.scheduleModeCron') : _t('batchImportModal.scheduleModeManual');
         const scheduleDetail = escapeHtml(scheduleModeText) + (queue.scheduleMode === 'cron' && queue.cronExpr ? `（${escapeHtml(queue.cronExpr)}）` : '');
         const showProgressNoteInModal = !!(pres.progressNote && !pres.callout);
@@ -1479,6 +1492,7 @@ async function showBatchQueueDetail(queueId) {
                 <div class="bq-kv"><span class="bq-kv__k">${escapeHtml(_t('batchQueueDetailModal.queueTitle'))}</span><span class="bq-kv__v" id="bq-title-val">${allowSubtaskMutation ? `<span class="bq-inline-editable" onclick="startInlineEditTitle()" title="${escapeHtml(_t('common.edit'))}">${escapeHtml(queue.title || _t('tasks.batchQueueUntitled'))}</span>` : escapeHtml(queue.title || _t('tasks.batchQueueUntitled'))}</span></div>
                 <div class="bq-kv"><span class="bq-kv__k">${escapeHtml(_t('batchQueueDetailModal.role'))}</span><span class="bq-kv__v" id="bq-role-val">${allowSubtaskMutation ? `<span class="bq-inline-editable" onclick="startInlineEditRole()" title="${escapeHtml(_t('common.edit'))}">${roleLineVal}</span>` : roleLineVal}</span></div>
                 <div class="bq-kv"><span class="bq-kv__k">${escapeHtml(_t('batchImportModal.agentMode'))}</span><span class="bq-kv__v" id="bq-agentmode-val">${allowSubtaskMutation ? `<span class="bq-inline-editable" onclick="startInlineEditAgentMode()" title="${escapeHtml(_t('common.edit'))}">${escapeHtml(agentModeText)}</span>` : escapeHtml(agentModeText)}</span></div>
+                <div class="bq-kv"><span class="bq-kv__k">${escapeHtml(_t('batchImportModal.concurrency'))}</span><span class="bq-kv__v" id="bq-concurrency-val">${allowSubtaskMutation ? `<span class="bq-inline-editable" onclick="startInlineEditConcurrency()" title="${escapeHtml(_t('common.edit'))}">${escapeHtml(concurrencyText)}</span>` : escapeHtml(concurrencyText)}</span></div>
                 <div class="bq-kv"><span class="bq-kv__k">${escapeHtml(_t('batchImportModal.scheduleMode'))}</span><span class="bq-kv__v" id="bq-schedule-val">${allowSubtaskMutation ? `<span class="bq-inline-editable" onclick="startInlineEditSchedule()" title="${escapeHtml(_t('common.edit'))}">${scheduleDetail}</span>` : scheduleDetail}</span></div>
                 <div class="bq-kv"><span class="bq-kv__k">${escapeHtml(_t('batchQueueDetailModal.taskTotal'))}</span><span class="bq-kv__v">${queue.tasks.length}</span></div>
                 ${queue.scheduleMode === 'cron' ? `<div class="bq-kv bq-kv--block"><span class="bq-kv__k">${escapeHtml(_t('batchQueueDetailModal.scheduleCronAuto'))}</span><span class="bq-kv__v bq-kv__v--control"><label class="bq-cron-toggle"><input type="checkbox" ${queue.scheduleEnabled !== false ? 'checked' : ''} onchange="updateBatchQueueScheduleEnabled(this.checked)" /><span class="bq-cron-toggle__hint">${escapeHtml(_t('batchQueueDetailModal.scheduleCronAutoHint'))}</span></label></span></div>` : ''}
@@ -2286,6 +2300,67 @@ async function saveInlineAgentMode() {
     }
 }
 
+// --- 内联编辑：并发数 ---
+function startInlineEditConcurrency() {
+    const container = document.getElementById('bq-concurrency-val');
+    if (!container) return;
+    const queueId = batchQueuesState.currentQueueId;
+    if (!queueId) return;
+    apiFetch(`/api/batch-tasks/${queueId}`).then(r => r.json()).then(detail => {
+        const queue = detail.queue;
+        const currentConcurrency = Math.min(25, Math.max(1, parseInt(queue.concurrency || 1, 10)));
+        container.innerHTML = `<span class="bq-inline-edit-controls">
+            <input type="number" id="bq-edit-concurrency" min="1" max="25" value="${currentConcurrency}" style="width:80px;" />
+        </span>`;
+        const inp = document.getElementById('bq-edit-concurrency');
+        if (inp) {
+            inp.focus();
+            inp.select();
+            let cancelled = false;
+            inp.addEventListener('keydown', (e) => {
+                if (e.key === 'Enter') { e.preventDefault(); inp.blur(); }
+                if (e.key === 'Escape') { cancelled = true; cancelAllInlineEdits(); }
+            });
+            inp.addEventListener('blur', () => {
+                if (cancelled) return;
+                saveInlineConcurrency();
+            });
+        }
+    });
+}
+
+async function saveInlineConcurrency() {
+    if (_bqInlineSaving) return;
+    _bqInlineSaving = true;
+    const queueId = batchQueuesState.currentQueueId;
+    if (!queueId) { _bqInlineSaving = false; return; }
+    const inp = document.getElementById('bq-edit-concurrency');
+    let concurrency = inp ? parseInt(inp.value, 10) : 1;
+    if (!Number.isFinite(concurrency) || concurrency < 1) {
+        concurrency = 1;
+    } else if (concurrency > 25) {
+        concurrency = 25;
+    }
+    try {
+        const response = await apiFetch(`/api/batch-tasks/${queueId}/concurrency`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ concurrency }),
+        });
+        if (!response.ok) {
+            const result = await response.json().catch(() => ({}));
+            throw new Error(result.error || _t('tasks.updateTaskFailed'));
+        }
+        _bqInlineSaving = false;
+        showBatchQueueDetail(queueId);
+        refreshBatchQueues();
+    } catch (e) {
+        _bqInlineSaving = false;
+        console.error(e);
+        alert(e.message);
+    }
+}
+
 // --- 重试失败任务 ---
 async function retryBatchTask(queueId, taskId) {
     if (!queueId || !taskId) return;
@@ -2453,6 +2528,8 @@ window.startInlineEditRole = startInlineEditRole;
 window.saveInlineRole = saveInlineRole;
 window.startInlineEditAgentMode = startInlineEditAgentMode;
 window.saveInlineAgentMode = saveInlineAgentMode;
+window.startInlineEditConcurrency = startInlineEditConcurrency;
+window.saveInlineConcurrency = saveInlineConcurrency;
 window.retryBatchTask = retryBatchTask;
 window.startInlineEditSchedule = startInlineEditSchedule;
 window.toggleInlineScheduleCron = toggleInlineScheduleCron;

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -3813,6 +3813,11 @@
                     <div class="form-hint" style="margin-top: 4px;" data-i18n="batchImportModal.agentModeHint">与对话页一致：Eino 单代理（ADK），或 Deep / Plan-Execute / Supervisor（后三种需已启用多代理）。</div>
                 </div>
                 <div class="form-group">
+                    <label for="batch-queue-concurrency" data-i18n="batchImportModal.concurrency">并发数</label>
+                    <input type="number" id="batch-queue-concurrency" min="1" max="25" value="1" style="width: 100%; padding: 8px; border: 1px solid #ddd; border-radius: 4px; font-size: 0.875rem;" />
+                    <div class="form-hint" style="margin-top: 4px;" data-i18n="batchImportModal.concurrencyHint">同时运行的子任务/对话数量；填 2 会同时创建并运行 2 个对话，最大 25。并发越高，对模型 API、工具执行和数据库写入压力越大。</div>
+                </div>
+                <div class="form-group">
                     <label for="batch-queue-schedule-mode" data-i18n="batchImportModal.scheduleMode">调度方式</label>
                     <select id="batch-queue-schedule-mode" onchange="handleBatchScheduleModeChange()" style="width: 100%; padding: 8px; border: 1px solid #ddd; border-radius: 4px; font-size: 0.875rem;">
                         <option value="manual" data-i18n="batchImportModal.scheduleModeManual">手工执行</option>
@@ -4295,4 +4300,3 @@
     <script src="/static/js/c2.js"></script>
 </body>
 </html>
-


### PR DESCRIPTION
## Summary
- keep conversation/sidebar ordering stable by sorting on creation time instead of update time
- expose `taskTitle` from the first user message for active/completed agent tasks
- prefer fixed task titles in the active task bar and task list UI

## Verification
- `node --check web/static/js/chat.js web/static/js/monitor.js web/static/js/tasks.js`
- `go test ./internal/handler ./internal/database`
- `go build -o /tmp/cyberstrike-ai-pr-verify ./cmd/server`
