### PR TITLE
fix: repair interrupted task states on startup

### DIFF
--- a/internal/database/batch_task.go
+++ b/internal/database/batch_task.go
@@ -123,7 +123,7 @@ func (db *DB) RepairInterruptedBatchRuns(reason string) (*BatchStartupRepairSumm
 		summary.TasksFailed, _ = res.RowsAffected()
 	}
 
-	qRows, err := tx.Query(`SELECT id FROM batch_task_queues WHERE status = 'running'`)
+	qRows, err := tx.Query(`SELECT id FROM batch_task_queues WHERE status IN ('running', 'pausing')`)
 	if err != nil {
 		return nil, fmt.Errorf("查询中断批量队列失败: %w", err)
 	}
@@ -158,7 +158,7 @@ func (db *DB) RepairInterruptedBatchRuns(reason string) (*BatchStartupRepairSumm
 				UPDATE batch_task_queues
 				SET status = 'paused',
 				    last_run_error = ?
-				WHERE id = ? AND status = 'running'
+				WHERE id = ? AND status IN ('running', 'pausing')
 			`, reason, queueID)
 		} else {
 			res, err = tx.Exec(`
@@ -169,7 +169,7 @@ func (db *DB) RepairInterruptedBatchRuns(reason string) (*BatchStartupRepairSumm
 				        WHEN ? THEN ?
 				        ELSE last_run_error
 				    END
-				WHERE id = ? AND status = 'running'
+				WHERE id = ? AND status IN ('running', 'pausing')
 			`, now, repairedTaskQueues[queueID], reason, queueID)
 		}
 		if err != nil {

--- a/internal/database/batch_task.go
+++ b/internal/database/batch_task.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"go.uber.org/zap"
 )
 
@@ -41,6 +42,194 @@ type BatchTaskRow struct {
 	CompletedAt    sql.NullTime
 	Error          sql.NullString
 	Result         sql.NullString
+}
+
+// BatchStartupRepairSummary records orphaned batch state fixed during startup.
+type BatchStartupRepairSummary struct {
+	QueuesRepaired int64
+	TasksFailed    int64
+}
+
+// RepairInterruptedBatchRuns closes batch queue/task states left as running by a previous process.
+//
+// Batch runners and cancellation callbacks are in-memory only. If the process exits while a
+// queue is running, those callbacks disappear but the database still says running. On the next
+// startup, any such task is no longer executing, so mark it failed and move the queue to an
+// actionable state.
+func (db *DB) RepairInterruptedBatchRuns(reason string) (*BatchStartupRepairSummary, error) {
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		reason = "服务重启导致批量任务中断"
+	}
+	now := time.Now()
+	summary := &BatchStartupRepairSummary{}
+
+	tx, err := db.Begin()
+	if err != nil {
+		return nil, fmt.Errorf("开始事务失败: %w", err)
+	}
+	defer tx.Rollback()
+
+	type runningTask struct {
+		ID             string
+		QueueID        string
+		ConversationID string
+	}
+	var runningTasks []runningTask
+	rows, err := tx.Query(`
+		SELECT id, queue_id, COALESCE(conversation_id, '')
+		FROM batch_tasks
+		WHERE status = 'running'
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("查询中断批量子任务失败: %w", err)
+	}
+	for rows.Next() {
+		var t runningTask
+		if err := rows.Scan(&t.ID, &t.QueueID, &t.ConversationID); err != nil {
+			rows.Close()
+			return nil, fmt.Errorf("扫描中断批量子任务失败: %w", err)
+		}
+		runningTasks = append(runningTasks, t)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, fmt.Errorf("关闭中断批量子任务游标失败: %w", err)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("遍历中断批量子任务失败: %w", err)
+	}
+
+	repairedTaskQueues := make(map[string]bool)
+	for _, t := range runningTasks {
+		repairedTaskQueues[t.QueueID] = true
+		if t.ConversationID != "" {
+			if err := db.recordInterruptedBatchConversationTx(tx, t.ConversationID, reason, now); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	if len(runningTasks) > 0 {
+		res, err := tx.Exec(`
+			UPDATE batch_tasks
+			SET status = 'failed',
+			    completed_at = COALESCE(completed_at, ?),
+			    error = CASE WHEN COALESCE(error, '') = '' THEN ? ELSE error END
+			WHERE status = 'running'
+		`, now, reason)
+		if err != nil {
+			return nil, fmt.Errorf("标记中断批量子任务失败: %w", err)
+		}
+		summary.TasksFailed, _ = res.RowsAffected()
+	}
+
+	qRows, err := tx.Query(`SELECT id FROM batch_task_queues WHERE status = 'running'`)
+	if err != nil {
+		return nil, fmt.Errorf("查询中断批量队列失败: %w", err)
+	}
+	var runningQueueIDs []string
+	for qRows.Next() {
+		var queueID string
+		if err := qRows.Scan(&queueID); err != nil {
+			qRows.Close()
+			return nil, fmt.Errorf("扫描中断批量队列失败: %w", err)
+		}
+		runningQueueIDs = append(runningQueueIDs, queueID)
+	}
+	if err := qRows.Close(); err != nil {
+		return nil, fmt.Errorf("关闭中断批量队列游标失败: %w", err)
+	}
+	if err := qRows.Err(); err != nil {
+		return nil, fmt.Errorf("遍历中断批量队列失败: %w", err)
+	}
+
+	for _, queueID := range runningQueueIDs {
+		var pendingCount int
+		if err := tx.QueryRow(
+			`SELECT COUNT(1) FROM batch_tasks WHERE queue_id = ? AND status = 'pending'`,
+			queueID,
+		).Scan(&pendingCount); err != nil {
+			return nil, fmt.Errorf("统计批量队列待执行子任务失败: %w", err)
+		}
+
+		var res sql.Result
+		if pendingCount > 0 {
+			res, err = tx.Exec(`
+				UPDATE batch_task_queues
+				SET status = 'paused',
+				    last_run_error = ?
+				WHERE id = ? AND status = 'running'
+			`, reason, queueID)
+		} else {
+			res, err = tx.Exec(`
+				UPDATE batch_task_queues
+				SET status = 'completed',
+				    completed_at = COALESCE(completed_at, ?),
+				    last_run_error = CASE
+				        WHEN ? THEN ?
+				        ELSE last_run_error
+				    END
+				WHERE id = ? AND status = 'running'
+			`, now, repairedTaskQueues[queueID], reason, queueID)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("修复中断批量队列状态失败: %w", err)
+		}
+		affected, _ := res.RowsAffected()
+		summary.QueuesRepaired += affected
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("提交中断批量任务修复失败: %w", err)
+	}
+	return summary, nil
+}
+
+func (db *DB) recordInterruptedBatchConversationTx(tx *sql.Tx, conversationID, reason string, now time.Time) error {
+	var messageID, content string
+	err := tx.QueryRow(`
+		SELECT id, content
+		FROM messages
+		WHERE conversation_id = ? AND role = 'assistant'
+		ORDER BY created_at DESC, rowid DESC
+		LIMIT 1
+	`, conversationID).Scan(&messageID, &content)
+	if err == sql.ErrNoRows {
+		messageID = uuid.New().String()
+		if _, err := tx.Exec(`
+			INSERT INTO messages (id, conversation_id, role, content, reasoning_content, mcp_execution_ids, created_at, updated_at)
+			VALUES (?, ?, 'assistant', ?, '', '', ?, ?)
+		`, messageID, conversationID, reason, now, now); err != nil {
+			return fmt.Errorf("写入中断批量任务助手消息失败: %w", err)
+		}
+	} else if err != nil {
+		return fmt.Errorf("查询中断批量任务助手消息失败: %w", err)
+	} else {
+		nextContent := strings.TrimSpace(content)
+		if nextContent == "" || nextContent == "处理中..." {
+			nextContent = reason
+		} else if !strings.Contains(nextContent, reason) {
+			nextContent += "\n\n" + reason
+		}
+		if nextContent != content {
+			if _, err := tx.Exec(
+				`UPDATE messages SET content = ?, updated_at = ? WHERE id = ?`,
+				nextContent, now, messageID,
+			); err != nil {
+				return fmt.Errorf("更新中断批量任务助手消息失败: %w", err)
+			}
+		}
+	}
+
+	detailID := uuid.New().String()
+	if _, err := tx.Exec(`
+		INSERT INTO process_details (id, message_id, conversation_id, event_type, message, data, created_at)
+		VALUES (?, ?, ?, 'error', ?, '', ?)
+	`, detailID, messageID, conversationID, reason, now); err != nil {
+		return fmt.Errorf("写入中断批量任务过程详情失败: %w", err)
+	}
+	_, _ = tx.Exec(`UPDATE conversations SET updated_at = ? WHERE id = ?`, now, conversationID)
+	return nil
 }
 
 // CreateBatchQueue 创建批量任务队列

--- a/internal/database/batch_task_repair_test.go
+++ b/internal/database/batch_task_repair_test.go
@@ -1,0 +1,155 @@
+package database
+
+import (
+	"path/filepath"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+func TestRepairInterruptedBatchRunsPausesQueueAndFailsRunningTask(t *testing.T) {
+	db, err := NewDB(filepath.Join(t.TempDir(), "batch-repair.db"), zap.NewNop())
+	if err != nil {
+		t.Fatalf("NewDB: %v", err)
+	}
+	defer db.Close()
+
+	queueID := "queue-with-pending"
+	runningTaskID := "task-running"
+	pendingTaskID := "task-pending"
+	if err := db.CreateBatchQueue(queueID, "repair test", "", "eino_single", "manual", "", nil, "", []map[string]interface{}{
+		{"id": runningTaskID, "message": "running task"},
+		{"id": pendingTaskID, "message": "pending task"},
+	}); err != nil {
+		t.Fatalf("CreateBatchQueue: %v", err)
+	}
+
+	conv, err := db.CreateConversation("interrupted batch", ConversationCreateMeta{})
+	if err != nil {
+		t.Fatalf("CreateConversation: %v", err)
+	}
+	assistantMsg, err := db.AddMessage(conv.ID, "assistant", "处理中...", nil)
+	if err != nil {
+		t.Fatalf("AddMessage: %v", err)
+	}
+	if err := db.UpdateBatchTaskStatus(queueID, runningTaskID, "running", conv.ID, "", ""); err != nil {
+		t.Fatalf("UpdateBatchTaskStatus running: %v", err)
+	}
+	if err := db.UpdateBatchQueueStatus(queueID, "running"); err != nil {
+		t.Fatalf("UpdateBatchQueueStatus running: %v", err)
+	}
+
+	const reason = "服务重启导致批量任务中断，已自动标记当前子任务失败"
+	summary, err := db.RepairInterruptedBatchRuns(reason)
+	if err != nil {
+		t.Fatalf("RepairInterruptedBatchRuns: %v", err)
+	}
+	if summary.TasksFailed != 1 || summary.QueuesRepaired != 1 {
+		t.Fatalf("summary = %+v, want 1 failed task and 1 repaired queue", summary)
+	}
+
+	queue, err := db.GetBatchQueue(queueID)
+	if err != nil {
+		t.Fatalf("GetBatchQueue: %v", err)
+	}
+	if queue.Status != "paused" {
+		t.Fatalf("queue status = %q, want paused", queue.Status)
+	}
+	if !queue.LastRunError.Valid || queue.LastRunError.String != reason {
+		t.Fatalf("last_run_error = %#v, want %q", queue.LastRunError, reason)
+	}
+	if queue.CompletedAt.Valid {
+		t.Fatalf("paused queue completed_at should be empty, got %v", queue.CompletedAt.Time)
+	}
+
+	tasks, err := db.GetBatchTasks(queueID)
+	if err != nil {
+		t.Fatalf("GetBatchTasks: %v", err)
+	}
+	byID := map[string]*BatchTaskRow{}
+	for _, task := range tasks {
+		byID[task.ID] = task
+	}
+	if byID[runningTaskID].Status != "failed" {
+		t.Fatalf("running task status = %q, want failed", byID[runningTaskID].Status)
+	}
+	if !byID[runningTaskID].CompletedAt.Valid {
+		t.Fatal("failed running task should have completed_at")
+	}
+	if !byID[runningTaskID].Error.Valid || byID[runningTaskID].Error.String != reason {
+		t.Fatalf("running task error = %#v, want %q", byID[runningTaskID].Error, reason)
+	}
+	if byID[pendingTaskID].Status != "pending" {
+		t.Fatalf("pending task status = %q, want pending", byID[pendingTaskID].Status)
+	}
+
+	messages, err := db.GetMessages(conv.ID)
+	if err != nil {
+		t.Fatalf("GetMessages: %v", err)
+	}
+	var gotAssistant *Message
+	for i := range messages {
+		if messages[i].ID == assistantMsg.ID {
+			gotAssistant = &messages[i]
+			break
+		}
+	}
+	if gotAssistant == nil {
+		t.Fatal("assistant message not found")
+	}
+	if gotAssistant.Content != reason {
+		t.Fatalf("assistant content = %q, want %q", gotAssistant.Content, reason)
+	}
+	details, err := db.GetProcessDetails(assistantMsg.ID)
+	if err != nil {
+		t.Fatalf("GetProcessDetails: %v", err)
+	}
+	if len(details) != 1 || details[0].EventType != "error" || details[0].Message != reason {
+		t.Fatalf("process details = %+v, want one error detail with reason", details)
+	}
+}
+
+func TestRepairInterruptedBatchRunsCompletesQueueWithoutPendingTasks(t *testing.T) {
+	db, err := NewDB(filepath.Join(t.TempDir(), "batch-repair-complete.db"), zap.NewNop())
+	if err != nil {
+		t.Fatalf("NewDB: %v", err)
+	}
+	defer db.Close()
+
+	queueID := "queue-without-pending"
+	taskID := "task-only"
+	if err := db.CreateBatchQueue(queueID, "repair complete test", "", "eino_single", "manual", "", nil, "", []map[string]interface{}{
+		{"id": taskID, "message": "running task"},
+	}); err != nil {
+		t.Fatalf("CreateBatchQueue: %v", err)
+	}
+	if err := db.UpdateBatchTaskStatus(queueID, taskID, "running", "", "", ""); err != nil {
+		t.Fatalf("UpdateBatchTaskStatus running: %v", err)
+	}
+	if err := db.UpdateBatchQueueStatus(queueID, "running"); err != nil {
+		t.Fatalf("UpdateBatchQueueStatus running: %v", err)
+	}
+
+	const reason = "restart interrupted batch task"
+	summary, err := db.RepairInterruptedBatchRuns(reason)
+	if err != nil {
+		t.Fatalf("RepairInterruptedBatchRuns: %v", err)
+	}
+	if summary.TasksFailed != 1 || summary.QueuesRepaired != 1 {
+		t.Fatalf("summary = %+v, want 1 failed task and 1 repaired queue", summary)
+	}
+
+	queue, err := db.GetBatchQueue(queueID)
+	if err != nil {
+		t.Fatalf("GetBatchQueue: %v", err)
+	}
+	if queue.Status != "completed" {
+		t.Fatalf("queue status = %q, want completed", queue.Status)
+	}
+	if !queue.CompletedAt.Valid {
+		t.Fatal("completed repaired queue should have completed_at")
+	}
+	if !queue.LastRunError.Valid || queue.LastRunError.String != reason {
+		t.Fatalf("last_run_error = %#v, want %q", queue.LastRunError, reason)
+	}
+}

--- a/internal/database/manual_task_repair.go
+++ b/internal/database/manual_task_repair.go
@@ -1,0 +1,109 @@
+package database
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ManualAgentStartupRepairSummary records orphaned manual agent messages fixed during startup.
+type ManualAgentStartupRepairSummary struct {
+	MessagesRepaired int64
+	DetailsInserted  int64
+}
+
+// RepairInterruptedManualAgentMessages closes assistant placeholder messages left by manual agent runs.
+//
+// Manual agent task state is kept in memory. If the process exits while a task is running, the
+// in-memory task disappears but the assistant placeholder message remains in the database. On the
+// next startup, that task cannot still be running in this process, so mark the placeholder as failed.
+func (db *DB) RepairInterruptedManualAgentMessages(reason string) (*ManualAgentStartupRepairSummary, error) {
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		reason = "服务重启导致任务中断，已自动标记失败"
+	}
+	now := time.Now()
+	summary := &ManualAgentStartupRepairSummary{}
+
+	tx, err := db.Begin()
+	if err != nil {
+		return nil, fmt.Errorf("开始事务失败: %w", err)
+	}
+	defer tx.Rollback()
+
+	type placeholderMessage struct {
+		ID             string
+		ConversationID string
+	}
+	var placeholders []placeholderMessage
+	rows, err := tx.Query(`
+		SELECT id, conversation_id
+		FROM messages
+		WHERE role = 'assistant'
+		  AND TRIM(content) = '处理中...'
+		ORDER BY created_at ASC, rowid ASC
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("查询中断手动任务占位消息失败: %w", err)
+	}
+	for rows.Next() {
+		var msg placeholderMessage
+		if err := rows.Scan(&msg.ID, &msg.ConversationID); err != nil {
+			rows.Close()
+			return nil, fmt.Errorf("扫描中断手动任务占位消息失败: %w", err)
+		}
+		placeholders = append(placeholders, msg)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, fmt.Errorf("关闭中断手动任务占位消息游标失败: %w", err)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("遍历中断手动任务占位消息失败: %w", err)
+	}
+
+	for _, msg := range placeholders {
+		res, err := tx.Exec(`
+			UPDATE messages
+			SET content = ?, updated_at = ?
+			WHERE id = ?
+			  AND role = 'assistant'
+			  AND TRIM(content) = '处理中...'
+		`, reason, now, msg.ID)
+		if err != nil {
+			return nil, fmt.Errorf("更新中断手动任务占位消息失败: %w", err)
+		}
+		affected, _ := res.RowsAffected()
+		summary.MessagesRepaired += affected
+
+		var existingDetails int
+		if err := tx.QueryRow(`
+			SELECT COUNT(1)
+			FROM process_details
+			WHERE message_id = ?
+			  AND conversation_id = ?
+			  AND event_type = 'error'
+			  AND COALESCE(message, '') = ?
+		`, msg.ID, msg.ConversationID, reason).Scan(&existingDetails); err != nil {
+			return nil, fmt.Errorf("检查中断手动任务过程详情失败: %w", err)
+		}
+		if existingDetails == 0 {
+			detailID := uuid.New().String()
+			if _, err := tx.Exec(`
+				INSERT INTO process_details (id, message_id, conversation_id, event_type, message, data, created_at)
+				VALUES (?, ?, ?, 'error', ?, '', ?)
+			`, detailID, msg.ID, msg.ConversationID, reason, now); err != nil {
+				return nil, fmt.Errorf("写入中断手动任务过程详情失败: %w", err)
+			}
+			summary.DetailsInserted++
+		}
+
+		_, _ = tx.Exec(`UPDATE conversations SET updated_at = ? WHERE id = ?`, now, msg.ConversationID)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("提交中断手动任务修复失败: %w", err)
+	}
+	return summary, nil
+}

--- a/internal/database/manual_task_repair_test.go
+++ b/internal/database/manual_task_repair_test.go
@@ -1,0 +1,103 @@
+package database
+
+import (
+	"path/filepath"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+func TestRepairInterruptedManualAgentMessagesMarksPlaceholderFailed(t *testing.T) {
+	db, err := NewDB(filepath.Join(t.TempDir(), "manual-repair.db"), zap.NewNop())
+	if err != nil {
+		t.Fatalf("NewDB: %v", err)
+	}
+	defer db.Close()
+
+	conv, err := db.CreateConversation("interrupted manual", ConversationCreateMeta{})
+	if err != nil {
+		t.Fatalf("CreateConversation: %v", err)
+	}
+	assistantMsg, err := db.AddMessage(conv.ID, "assistant", "处理中...", nil)
+	if err != nil {
+		t.Fatalf("AddMessage assistant placeholder: %v", err)
+	}
+	normalMsg, err := db.AddMessage(conv.ID, "assistant", "正常历史回复", nil)
+	if err != nil {
+		t.Fatalf("AddMessage normal assistant: %v", err)
+	}
+
+	const reason = "服务重启导致任务中断，已自动标记失败"
+	summary, err := db.RepairInterruptedManualAgentMessages(reason)
+	if err != nil {
+		t.Fatalf("RepairInterruptedManualAgentMessages: %v", err)
+	}
+	if summary.MessagesRepaired != 1 || summary.DetailsInserted != 1 {
+		t.Fatalf("summary = %+v, want one repaired message and one detail", summary)
+	}
+
+	messages, err := db.GetMessages(conv.ID)
+	if err != nil {
+		t.Fatalf("GetMessages: %v", err)
+	}
+	byID := map[string]Message{}
+	for _, msg := range messages {
+		byID[msg.ID] = msg
+	}
+	if byID[assistantMsg.ID].Content != reason {
+		t.Fatalf("placeholder content = %q, want %q", byID[assistantMsg.ID].Content, reason)
+	}
+	if byID[normalMsg.ID].Content != "正常历史回复" {
+		t.Fatalf("normal assistant content changed to %q", byID[normalMsg.ID].Content)
+	}
+
+	details, err := db.GetProcessDetails(assistantMsg.ID)
+	if err != nil {
+		t.Fatalf("GetProcessDetails placeholder: %v", err)
+	}
+	if len(details) != 1 || details[0].EventType != "error" || details[0].Message != reason {
+		t.Fatalf("process details = %+v, want one error detail with reason", details)
+	}
+}
+
+func TestRepairInterruptedManualAgentMessagesIsIdempotent(t *testing.T) {
+	db, err := NewDB(filepath.Join(t.TempDir(), "manual-repair-idempotent.db"), zap.NewNop())
+	if err != nil {
+		t.Fatalf("NewDB: %v", err)
+	}
+	defer db.Close()
+
+	conv, err := db.CreateConversation("interrupted manual idempotent", ConversationCreateMeta{})
+	if err != nil {
+		t.Fatalf("CreateConversation: %v", err)
+	}
+	assistantMsg, err := db.AddMessage(conv.ID, "assistant", "处理中...", nil)
+	if err != nil {
+		t.Fatalf("AddMessage assistant placeholder: %v", err)
+	}
+
+	const reason = "服务重启导致任务中断，已自动标记失败"
+	first, err := db.RepairInterruptedManualAgentMessages(reason)
+	if err != nil {
+		t.Fatalf("first RepairInterruptedManualAgentMessages: %v", err)
+	}
+	if first.MessagesRepaired != 1 || first.DetailsInserted != 1 {
+		t.Fatalf("first summary = %+v, want one repaired message and one detail", first)
+	}
+
+	second, err := db.RepairInterruptedManualAgentMessages(reason)
+	if err != nil {
+		t.Fatalf("second RepairInterruptedManualAgentMessages: %v", err)
+	}
+	if second.MessagesRepaired != 0 || second.DetailsInserted != 0 {
+		t.Fatalf("second summary = %+v, want no changes", second)
+	}
+
+	details, err := db.GetProcessDetails(assistantMsg.ID)
+	if err != nil {
+		t.Fatalf("GetProcessDetails placeholder: %v", err)
+	}
+	if len(details) != 1 {
+		t.Fatalf("process detail count = %d, want 1: %+v", len(details), details)
+	}
+}

--- a/internal/handler/agent.go
+++ b/internal/handler/agent.go
@@ -204,6 +204,15 @@ func NewAgentHandler(agent *agent.Agent, db *database.DB, cfg *config.Config, lo
 	if err := batchTaskManager.LoadFromDB(); err != nil {
 		logger.Warn("从数据库加载批量任务队列失败", zap.Error(err))
 	}
+	manualInterruptedReason := "服务重启导致任务中断，已自动标记失败"
+	if summary, err := db.RepairInterruptedManualAgentMessages(manualInterruptedReason); err != nil {
+		logger.Warn("修复中断手动任务占位消息失败", zap.Error(err))
+	} else if summary != nil && (summary.MessagesRepaired > 0 || summary.DetailsInserted > 0) {
+		logger.Info("已修复中断手动任务占位消息",
+			zap.Int64("messagesRepaired", summary.MessagesRepaired),
+			zap.Int64("detailsInserted", summary.DetailsInserted),
+		)
+	}
 
 	bus := NewTaskEventBus()
 	tm := NewAgentTaskManager()

--- a/internal/handler/agent.go
+++ b/internal/handler/agent.go
@@ -20,11 +20,11 @@ import (
 	"cyberstrike-ai/internal/audit"
 	"cyberstrike-ai/internal/config"
 	"cyberstrike-ai/internal/database"
-	"cyberstrike-ai/internal/reasoning"
 	"cyberstrike-ai/internal/mcp"
 	"cyberstrike-ai/internal/mcp/builtin"
 	"cyberstrike-ai/internal/multiagent"
 	"cyberstrike-ai/internal/openai"
+	"cyberstrike-ai/internal/reasoning"
 
 	"github.com/gin-gonic/gin"
 	"github.com/robfig/cron/v3"
@@ -279,13 +279,13 @@ type ChatReasoningRequest struct {
 
 // ChatRequest 聊天请求
 type ChatRequest struct {
-	Message              string           `json:"message" binding:"required"`
-	ConversationID       string           `json:"conversationId,omitempty"`
-	ProjectID            string           `json:"projectId,omitempty"` // 新对话绑定的项目（可选；未指定时可用 config.project.default_project_id）
-	Role                 string           `json:"role,omitempty"` // 角色名称
-	Attachments          []ChatAttachment `json:"attachments,omitempty"`
-	WebShellConnectionID string           `json:"webshellConnectionId,omitempty"` // WebShell 管理 - AI 助手：当前选中的连接 ID，仅使用 webshell_* 工具
-	Hitl                 *HITLRequest     `json:"hitl,omitempty"`
+	Message              string                `json:"message" binding:"required"`
+	ConversationID       string                `json:"conversationId,omitempty"`
+	ProjectID            string                `json:"projectId,omitempty"` // 新对话绑定的项目（可选；未指定时可用 config.project.default_project_id）
+	Role                 string                `json:"role,omitempty"`      // 角色名称
+	Attachments          []ChatAttachment      `json:"attachments,omitempty"`
+	WebShellConnectionID string                `json:"webshellConnectionId,omitempty"` // WebShell 管理 - AI 助手：当前选中的连接 ID，仅使用 webshell_* 工具
+	Hitl                 *HITLRequest          `json:"hitl,omitempty"`
 	Reasoning            *ChatReasoningRequest `json:"reasoning,omitempty"`
 	// Orchestration 仅对 /api/multi-agent、/api/multi-agent/stream：deep | plan_execute | supervisor；空则等同 deep。机器人/批量等无请求体时由服务端默认 deep。/api/eino-agent* 不使用此字段。
 	Orchestration string `json:"orchestration,omitempty"`
@@ -1412,10 +1412,10 @@ func (h *AgentHandler) CancelAgentLoop(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{
-		"status":           "cancelling",
-		"conversationId": req.ConversationID,
-		"message":          msg,
-		"continueAfter":    false,
+		"status":            "cancelling",
+		"conversationId":    req.ConversationID,
+		"message":           msg,
+		"continueAfter":     false,
 		"interruptWithNote": false,
 	})
 }
@@ -1729,7 +1729,7 @@ func (h *AgentHandler) PauseBatchQueue(c *gin.Context) {
 	if h.audit != nil {
 		h.audit.RecordOK(c, "task", "pause_queue", "暂停批量任务队列", "batch_queue", queueID, nil)
 	}
-	c.JSON(http.StatusOK, gin.H{"message": "批量任务已暂停"})
+	c.JSON(http.StatusOK, gin.H{"message": "批量任务正在停止当前子任务，停止完成后会进入已暂停状态", "queueId": queueID})
 }
 
 // UpdateBatchQueueMetadata 修改批量任务队列的标题、角色和代理模式
@@ -1959,7 +1959,7 @@ func (h *AgentHandler) nextBatchQueueRunAt(cronExpr string, from time.Time) (*ti
 func (h *AgentHandler) startBatchQueueExecution(queueID string, scheduled bool) (bool, error) {
 	// 先获取执行互斥门，再读取队列状态，避免基于过时快照做判断
 	if !h.markBatchQueueRunning(queueID) {
-		return true, nil
+		return true, fmt.Errorf("当前子任务仍在停止中，请稍后再继续")
 	}
 
 	queue, exists := h.batchTaskManager.GetBatchQueue(queueID)
@@ -1975,7 +1975,7 @@ func (h *AgentHandler) startBatchQueueExecution(queueID string, scheduled bool) 
 			h.batchTaskManager.SetLastScheduleError(queueID, err.Error())
 			return true, err
 		}
-		if queue.Status == "running" || queue.Status == "paused" || queue.Status == "cancelled" {
+		if queue.Status == "running" || queue.Status == "pausing" || queue.Status == "paused" || queue.Status == "cancelled" {
 			h.unmarkBatchQueueRunning(queueID)
 			err := fmt.Errorf("当前队列状态不允许被调度执行")
 			h.batchTaskManager.SetLastScheduleError(queueID, err.Error())
@@ -1988,6 +1988,9 @@ func (h *AgentHandler) startBatchQueueExecution(queueID string, scheduled bool) 
 			return true, err
 		}
 		queue, _ = h.batchTaskManager.GetBatchQueue(queueID)
+	} else if queue.Status == "pausing" {
+		h.unmarkBatchQueueRunning(queueID)
+		return true, fmt.Errorf("当前子任务仍在停止中，请稍后再继续")
 	} else if queue.Status != "pending" && queue.Status != "paused" {
 		h.unmarkBatchQueueRunning(queueID)
 		return true, fmt.Errorf("队列状态不允许启动")
@@ -2024,7 +2027,7 @@ func (h *AgentHandler) batchQueueSchedulerLoop() {
 		queues := h.batchTaskManager.GetLoadedQueues()
 		now := time.Now()
 		for _, queue := range queues {
-			if queue == nil || queue.ScheduleMode != "cron" || !queue.ScheduleEnabled || queue.Status == "cancelled" || queue.Status == "running" || queue.Status == "paused" {
+			if queue == nil || queue.ScheduleMode != "cron" || !queue.ScheduleEnabled || queue.Status == "cancelled" || queue.Status == "running" || queue.Status == "pausing" || queue.Status == "paused" {
 				continue
 			}
 			nextRunAt := queue.NextRunAt
@@ -2054,7 +2057,7 @@ func (h *AgentHandler) executeBatchQueue(queueID string) {
 	for {
 		// 检查队列状态
 		queue, exists := h.batchTaskManager.GetBatchQueue(queueID)
-		if !exists || queue.Status == "cancelled" || queue.Status == "completed" || queue.Status == "paused" {
+		if !exists || queue.Status == "cancelled" || queue.Status == "completed" || queue.Status == "pausing" || queue.Status == "paused" {
 			break
 		}
 
@@ -2200,8 +2203,15 @@ func (h *AgentHandler) executeBatchQueue(queueID string) {
 				return
 			}
 			registered = true
-			// 存储取消函数：暂停队列时取消子任务 context（与原先语义一致）
-			h.batchTaskManager.SetTaskCancel(queueID, timeoutCancel)
+			// 存储取消函数：暂停队列时通过任务管理器进入 cancelling，并用明确原因取消运行上下文。
+			h.batchTaskManager.SetTaskCancel(queueID, func() {
+				if ok, err := h.tasks.CancelTask(conversationID, ErrTaskCancelled); err != nil {
+					h.logger.Warn("批量队列子任务取消失败", zap.String("queueId", queueID), zap.String("taskId", task.ID), zap.String("conversationId", conversationID), zap.Error(err))
+				} else if !ok {
+					cancelWithCause(ErrTaskCancelled)
+				}
+				timeoutCancel()
+			})
 
 			// 创建进度回调函数：写 DB + 镜像到 task-events，支持刷新后继续流式展示。
 			progressCallback = h.createProgressCallback(taskCtx, cancelWithCause, conversationID, assistantMessageID, sendEvent)
@@ -2261,86 +2271,86 @@ func (h *AgentHandler) executeBatchQueue(queueID string) {
 				}
 
 				if isCancelled {
-				h.logger.Info("批量任务被取消", zap.String("queueId", queueID), zap.String("taskId", task.ID), zap.String("conversationId", conversationID))
-				cancelMsg := "任务已被用户取消，后续操作已停止。"
-				// 如果执行结果中有更具体的取消消息，使用它
-				if partialResp != "" && (strings.Contains(partialResp, "任务已被取消") || strings.Contains(partialResp, "任务执行中断")) {
-					cancelMsg = partialResp
+					h.logger.Info("批量任务被取消", zap.String("queueId", queueID), zap.String("taskId", task.ID), zap.String("conversationId", conversationID))
+					cancelMsg := "任务已被用户取消，后续操作已停止。"
+					// 如果执行结果中有更具体的取消消息，使用它
+					if partialResp != "" && (strings.Contains(partialResp, "任务已被取消") || strings.Contains(partialResp, "任务执行中断")) {
+						cancelMsg = partialResp
+					}
+					// 更新助手消息内容
+					if assistantMessageID != "" {
+						if updateErr := h.appendAssistantMessageNotice(assistantMessageID, cancelMsg); updateErr != nil {
+							h.logger.Warn("更新取消后的助手消息失败", zap.String("queueId", queueID), zap.String("taskId", task.ID), zap.Error(updateErr))
+						}
+						// 保存取消详情到数据库
+						if err := h.db.AddProcessDetail(assistantMessageID, conversationID, "cancelled", cancelMsg, nil); err != nil {
+							h.logger.Warn("保存取消详情失败", zap.String("queueId", queueID), zap.String("taskId", task.ID), zap.Error(err))
+						}
+					} else {
+						// 如果没有预先创建的助手消息，创建一个新的
+						_, errMsg := h.db.AddMessage(conversationID, "assistant", cancelMsg, nil)
+						if errMsg != nil {
+							h.logger.Warn("保存取消消息失败", zap.String("queueId", queueID), zap.String("taskId", task.ID), zap.Error(errMsg))
+						}
+					}
+					h.batchTaskManager.UpdateTaskStatusWithConversationID(queueID, task.ID, "cancelled", cancelMsg, "", conversationID)
+				} else {
+					h.logger.Error("批量任务执行失败", zap.String("queueId", queueID), zap.String("taskId", task.ID), zap.String("conversationId", conversationID), zap.Error(runErr))
+					errorMsg := "执行失败: " + runErr.Error()
+					// 更新助手消息内容
+					if assistantMessageID != "" {
+						if _, updateErr := h.db.Exec(
+							"UPDATE messages SET content = ?, updated_at = ? WHERE id = ?",
+							errorMsg,
+							time.Now(), assistantMessageID,
+						); updateErr != nil {
+							h.logger.Warn("更新失败后的助手消息失败", zap.String("queueId", queueID), zap.String("taskId", task.ID), zap.Error(updateErr))
+						}
+						// 保存错误详情到数据库
+						if err := h.db.AddProcessDetail(assistantMessageID, conversationID, "error", errorMsg, nil); err != nil {
+							h.logger.Warn("保存错误详情失败", zap.String("queueId", queueID), zap.String("taskId", task.ID), zap.Error(err))
+						}
+					}
+					h.batchTaskManager.UpdateTaskStatus(queueID, task.ID, "failed", "", runErr.Error())
 				}
+			} else {
+				h.logger.Info("批量任务执行成功", zap.String("queueId", queueID), zap.String("taskId", task.ID), zap.String("conversationId", conversationID))
+
+				resText := resultMA.Response
+				mcpIDs := resultMA.MCPExecutionIDs
+				lastIn := resultMA.LastAgentTraceInput
+				lastOut := resultMA.LastAgentTraceOutput
+
 				// 更新助手消息内容
 				if assistantMessageID != "" {
-					if updateErr := h.appendAssistantMessageNotice(assistantMessageID, cancelMsg); updateErr != nil {
-						h.logger.Warn("更新取消后的助手消息失败", zap.String("queueId", queueID), zap.String("taskId", task.ID), zap.Error(updateErr))
-					}
-					// 保存取消详情到数据库
-					if err := h.db.AddProcessDetail(assistantMessageID, conversationID, "cancelled", cancelMsg, nil); err != nil {
-						h.logger.Warn("保存取消详情失败", zap.String("queueId", queueID), zap.String("taskId", task.ID), zap.Error(err))
+					if updateErr := h.db.UpdateAssistantMessageFinalize(assistantMessageID, resText, mcpIDs, multiagent.AggregatedReasoningFromTraceJSON(lastIn)); updateErr != nil {
+						h.logger.Warn("更新助手消息失败", zap.String("queueId", queueID), zap.String("taskId", task.ID), zap.Error(updateErr))
+						// 如果更新失败，尝试创建新消息
+						_, err = h.db.AddMessage(conversationID, "assistant", resText, mcpIDs)
+						if err != nil {
+							h.logger.Error("保存助手消息失败", zap.String("queueId", queueID), zap.String("taskId", task.ID), zap.String("conversationId", conversationID), zap.Error(err))
+						}
 					}
 				} else {
 					// 如果没有预先创建的助手消息，创建一个新的
-					_, errMsg := h.db.AddMessage(conversationID, "assistant", cancelMsg, nil)
-					if errMsg != nil {
-						h.logger.Warn("保存取消消息失败", zap.String("queueId", queueID), zap.String("taskId", task.ID), zap.Error(errMsg))
-					}
-				}
-				h.batchTaskManager.UpdateTaskStatusWithConversationID(queueID, task.ID, "cancelled", cancelMsg, "", conversationID)
-			} else {
-				h.logger.Error("批量任务执行失败", zap.String("queueId", queueID), zap.String("taskId", task.ID), zap.String("conversationId", conversationID), zap.Error(runErr))
-				errorMsg := "执行失败: " + runErr.Error()
-				// 更新助手消息内容
-				if assistantMessageID != "" {
-					if _, updateErr := h.db.Exec(
-						"UPDATE messages SET content = ?, updated_at = ? WHERE id = ?",
-						errorMsg,
-						time.Now(), assistantMessageID,
-					); updateErr != nil {
-						h.logger.Warn("更新失败后的助手消息失败", zap.String("queueId", queueID), zap.String("taskId", task.ID), zap.Error(updateErr))
-					}
-					// 保存错误详情到数据库
-					if err := h.db.AddProcessDetail(assistantMessageID, conversationID, "error", errorMsg, nil); err != nil {
-						h.logger.Warn("保存错误详情失败", zap.String("queueId", queueID), zap.String("taskId", task.ID), zap.Error(err))
-					}
-				}
-				h.batchTaskManager.UpdateTaskStatus(queueID, task.ID, "failed", "", runErr.Error())
-			}
-		} else {
-			h.logger.Info("批量任务执行成功", zap.String("queueId", queueID), zap.String("taskId", task.ID), zap.String("conversationId", conversationID))
-
-			resText := resultMA.Response
-			mcpIDs := resultMA.MCPExecutionIDs
-			lastIn := resultMA.LastAgentTraceInput
-			lastOut := resultMA.LastAgentTraceOutput
-
-			// 更新助手消息内容
-			if assistantMessageID != "" {
-				if updateErr := h.db.UpdateAssistantMessageFinalize(assistantMessageID, resText, mcpIDs, multiagent.AggregatedReasoningFromTraceJSON(lastIn)); updateErr != nil {
-					h.logger.Warn("更新助手消息失败", zap.String("queueId", queueID), zap.String("taskId", task.ID), zap.Error(updateErr))
-					// 如果更新失败，尝试创建新消息
 					_, err = h.db.AddMessage(conversationID, "assistant", resText, mcpIDs)
 					if err != nil {
 						h.logger.Error("保存助手消息失败", zap.String("queueId", queueID), zap.String("taskId", task.ID), zap.String("conversationId", conversationID), zap.Error(err))
 					}
 				}
-			} else {
-				// 如果没有预先创建的助手消息，创建一个新的
-				_, err = h.db.AddMessage(conversationID, "assistant", resText, mcpIDs)
-				if err != nil {
-					h.logger.Error("保存助手消息失败", zap.String("queueId", queueID), zap.String("taskId", task.ID), zap.String("conversationId", conversationID), zap.Error(err))
-				}
-			}
 
-			// 保存代理轨迹
-			if lastIn != "" || lastOut != "" {
-				if err := h.db.SaveAgentTrace(conversationID, lastIn, lastOut); err != nil {
-					h.logger.Warn("保存代理轨迹失败", zap.String("queueId", queueID), zap.String("taskId", task.ID), zap.Error(err))
-				} else {
-					h.logger.Info("已保存代理轨迹", zap.String("queueId", queueID), zap.String("taskId", task.ID), zap.String("conversationId", conversationID))
+				// 保存代理轨迹
+				if lastIn != "" || lastOut != "" {
+					if err := h.db.SaveAgentTrace(conversationID, lastIn, lastOut); err != nil {
+						h.logger.Warn("保存代理轨迹失败", zap.String("queueId", queueID), zap.String("taskId", task.ID), zap.Error(err))
+					} else {
+						h.logger.Info("已保存代理轨迹", zap.String("queueId", queueID), zap.String("taskId", task.ID), zap.String("conversationId", conversationID))
+					}
 				}
-			}
 
-			// 保存结果
-			h.batchTaskManager.UpdateTaskStatusWithConversationID(queueID, task.ID, "completed", resText, "", conversationID)
-		}
+				// 保存结果
+				h.batchTaskManager.UpdateTaskStatusWithConversationID(queueID, task.ID, "completed", resText, "", conversationID)
+			}
 		}()
 
 		// 移动到下一个任务
@@ -2348,6 +2358,10 @@ func (h *AgentHandler) executeBatchQueue(queueID string) {
 
 		// 检查是否被取消或暂停
 		queue, _ = h.batchTaskManager.GetBatchQueue(queueID)
+		if queue.Status == "pausing" {
+			h.batchTaskManager.CompletePause(queueID)
+			break
+		}
 		if queue.Status == "cancelled" || queue.Status == "paused" {
 			break
 		}

--- a/internal/handler/batch_task_manager.go
+++ b/internal/handler/batch_task_manager.go
@@ -21,6 +21,7 @@ import (
 const (
 	BatchQueueStatusPending   = "pending"
 	BatchQueueStatusRunning   = "running"
+	BatchQueueStatusPausing   = "pausing"
 	BatchQueueStatusPaused    = "paused"
 	BatchQueueStatusCompleted = "completed"
 	BatchQueueStatusCancelled = "cancelled"
@@ -68,7 +69,7 @@ type BatchTaskQueue struct {
 	LastRunError          string       `json:"lastRunError,omitempty"`
 	ProjectID             string       `json:"projectId,omitempty"`
 	Tasks                 []*BatchTask `json:"tasks"`
-	Status                string       `json:"status"` // pending, running, paused, completed, cancelled
+	Status                string       `json:"status"` // pending, running, pausing, paused, completed, cancelled
 	CreatedAt             time.Time    `json:"createdAt"`
 	StartedAt             *time.Time   `json:"startedAt,omitempty"`
 	CompletedAt           *time.Time   `json:"completedAt,omitempty"`
@@ -997,7 +998,7 @@ func (m *BatchTaskManager) SetTaskCancel(queueID string, cancel context.CancelFu
 	}
 }
 
-// PauseQueue 暂停队列
+// PauseQueue requests a running queue to stop after cancelling the current task.
 func (m *BatchTaskManager) PauseQueue(queueID string) bool {
 	var cancelFunc context.CancelFunc
 
@@ -1015,7 +1016,7 @@ func (m *BatchTaskManager) PauseQueue(queueID string) bool {
 
 	// DB 优先：先持久化，成功后再更新内存
 	if m.db != nil {
-		if err := m.db.UpdateBatchQueueStatus(queueID, BatchQueueStatusPaused); err != nil {
+		if err := m.db.UpdateBatchQueueStatus(queueID, BatchQueueStatusPausing); err != nil {
 			m.logger.Warn("batch queue DB pause update failed, skipping memory update",
 				zap.String("queueId", queueID), zap.Error(err))
 			m.mu.Unlock()
@@ -1023,7 +1024,7 @@ func (m *BatchTaskManager) PauseQueue(queueID string) bool {
 		}
 	}
 
-	queue.Status = BatchQueueStatusPaused
+	queue.Status = BatchQueueStatusPausing
 
 	// 取消当前正在执行的任务（通过取消context）
 	if cancel, ok := m.taskCancels[queueID]; ok {
@@ -1037,6 +1038,28 @@ func (m *BatchTaskManager) PauseQueue(queueID string) bool {
 		cancelFunc()
 	}
 
+	return true
+}
+
+// CompletePause transitions a queue from pausing to paused after the active task has stopped.
+func (m *BatchTaskManager) CompletePause(queueID string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	queue, exists := m.queues[queueID]
+	if !exists || queue.Status != BatchQueueStatusPausing {
+		return false
+	}
+
+	if m.db != nil {
+		if err := m.db.UpdateBatchQueueStatus(queueID, BatchQueueStatusPaused); err != nil {
+			m.logger.Warn("batch queue DB complete pause update failed, skipping memory update",
+				zap.String("queueId", queueID), zap.Error(err))
+			return false
+		}
+	}
+
+	queue.Status = BatchQueueStatusPaused
 	return true
 }
 

--- a/internal/handler/batch_task_manager.go
+++ b/internal/handler/batch_task_manager.go
@@ -445,6 +445,15 @@ func (m *BatchTaskManager) LoadFromDB() error {
 		return nil
 	}
 
+	const interruptedReason = "服务重启导致批量任务中断，已自动标记当前子任务失败"
+	if summary, err := m.db.RepairInterruptedBatchRuns(interruptedReason); err != nil {
+		m.logger.Warn("repair interrupted batch runs failed", zap.Error(err))
+	} else if summary != nil && (summary.QueuesRepaired > 0 || summary.TasksFailed > 0) {
+		m.logger.Info("repaired interrupted batch runs on startup",
+			zap.Int64("queues", summary.QueuesRepaired),
+			zap.Int64("tasks", summary.TasksFailed))
+	}
+
 	queueRows, err := m.db.GetAllBatchQueues()
 	if err != nil {
 		return err

--- a/internal/handler/batch_task_mcp.go
+++ b/internal/handler/batch_task_mcp.go
@@ -35,8 +35,8 @@ func RegisterBatchTaskMCPTools(mcpServer *mcp.Server, h *AgentHandler, logger *z
 			"properties": map[string]interface{}{
 				"status": map[string]interface{}{
 					"type":        "string",
-					"description": "筛选状态：all（默认）、pending、running、paused、completed、cancelled",
-					"enum":        []string{"all", "pending", "running", "paused", "completed", "cancelled"},
+					"description": "筛选状态：all（默认）、pending、running、pausing、paused、completed、cancelled",
+					"enum":        []string{"all", "pending", "running", "pausing", "paused", "completed", "cancelled"},
 				},
 				"keyword": map[string]interface{}{
 					"type":        "string",
@@ -342,7 +342,7 @@ func RegisterBatchTaskMCPTools(mcpServer *mcp.Server, h *AgentHandler, logger *z
 			return batchMCPTextResult("无法暂停：队列不存在或当前非 running 状态", true), nil
 		}
 		logger.Info("MCP batch_task_pause", zap.String("queueId", qid))
-		return batchMCPTextResult("队列已暂停。", false), nil
+		return batchMCPTextResult("队列正在停止当前子任务，停止完成后会进入已暂停状态。", false), nil
 	})
 
 	// --- delete queue ---

--- a/internal/handler/openapi.go
+++ b/internal/handler/openapi.go
@@ -455,7 +455,7 @@ func (h *OpenAPIHandler) GetOpenAPISpec(c *gin.Context) {
 						"status": map[string]interface{}{
 							"type":        "string",
 							"description": "队列状态",
-							"enum":        []string{"pending", "running", "paused", "completed", "failed"},
+							"enum":        []string{"pending", "running", "pausing", "paused", "completed", "cancelled"},
 						},
 						"tasks": map[string]interface{}{
 							"type":        "array",
@@ -798,18 +798,18 @@ func (h *OpenAPIHandler) GetOpenAPISpec(c *gin.Context) {
 					"type":        "object",
 					"description": "视觉分析（analyze_image MCP 工具）；enabled 且 model 非空时注册工具",
 					"properties": map[string]interface{}{
-						"enabled":                      map[string]interface{}{"type": "boolean", "description": "是否启用 analyze_image"},
-						"model":                        map[string]interface{}{"type": "string", "description": "视觉模型名（必填）", "example": "qwen-vl-max"},
-						"api_key":                      map[string]interface{}{"type": "string", "description": "API Key；留空复用 openai.api_key"},
-						"base_url":                     map[string]interface{}{"type": "string", "description": "Base URL；留空复用 openai.base_url"},
-						"provider":                     map[string]interface{}{"type": "string", "description": "提供商；留空复用 openai.provider"},
-						"timeout_seconds":              map[string]interface{}{"type": "integer", "description": "VL 调用超时（秒）"},
-						"max_image_bytes":              map[string]interface{}{"type": "integer", "description": "原始文件大小上限（字节）"},
-						"max_dimension":                map[string]interface{}{"type": "integer", "description": "长边缩放像素"},
-						"jpeg_quality":                 map[string]interface{}{"type": "integer", "description": "JPEG 质量 60-100"},
-						"max_payload_bytes":            map[string]interface{}{"type": "integer", "description": "送 API 体积上限（字节）"},
-						"skip_preprocess_below_bytes":  map[string]interface{}{"type": "integer", "description": "低于该字节且尺寸合规时可原图直传；0=始终压缩"},
-						"detail": map[string]interface{}{"type": "string", "enum": []string{"low", "high", "auto"}, "description": "OpenAI 兼容 image detail"},
+						"enabled":                     map[string]interface{}{"type": "boolean", "description": "是否启用 analyze_image"},
+						"model":                       map[string]interface{}{"type": "string", "description": "视觉模型名（必填）", "example": "qwen-vl-max"},
+						"api_key":                     map[string]interface{}{"type": "string", "description": "API Key；留空复用 openai.api_key"},
+						"base_url":                    map[string]interface{}{"type": "string", "description": "Base URL；留空复用 openai.base_url"},
+						"provider":                    map[string]interface{}{"type": "string", "description": "提供商；留空复用 openai.provider"},
+						"timeout_seconds":             map[string]interface{}{"type": "integer", "description": "VL 调用超时（秒）"},
+						"max_image_bytes":             map[string]interface{}{"type": "integer", "description": "原始文件大小上限（字节）"},
+						"max_dimension":               map[string]interface{}{"type": "integer", "description": "长边缩放像素"},
+						"jpeg_quality":                map[string]interface{}{"type": "integer", "description": "JPEG 质量 60-100"},
+						"max_payload_bytes":           map[string]interface{}{"type": "integer", "description": "送 API 体积上限（字节）"},
+						"skip_preprocess_below_bytes": map[string]interface{}{"type": "integer", "description": "低于该字节且尺寸合规时可原图直传；0=始终压缩"},
+						"detail":                      map[string]interface{}{"type": "string", "enum": []string{"low", "high", "auto"}, "description": "OpenAI 兼容 image detail"},
 					},
 				},
 				"AnalyzeImageToolCall": map[string]interface{}{
@@ -1397,7 +1397,7 @@ func (h *OpenAPIHandler) GetOpenAPISpec(c *gin.Context) {
 						{
 							"name": "id", "in": "path", "required": true,
 							"description": "对话ID",
-							"schema": map[string]interface{}{"type": "string"},
+							"schema":      map[string]interface{}{"type": "string"},
 						},
 					},
 					"requestBody": map[string]interface{}{

--- a/internal/multiagent/eino_execute_streaming_wrap.go
+++ b/internal/multiagent/eino_execute_streaming_wrap.go
@@ -5,7 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os/exec"
+	"runtime"
 	"strings"
+	"sync"
 	"time"
 
 	"cyberstrike-ai/internal/einomcp"
@@ -57,10 +60,10 @@ type einoStreamingShellWrap struct {
 }
 
 func (w *einoStreamingShellWrap) ExecuteStreaming(ctx context.Context, input *filesystem.ExecuteRequest) (*schema.StreamReader[*filesystem.ExecuteResponse], error) {
-	if w.inner == nil {
-		return nil, fmt.Errorf("einoStreamingShellWrap: inner shell is nil")
-	}
 	if input == nil {
+		if w.inner == nil {
+			return nil, fmt.Errorf("einoStreamingShellWrap: inner shell is nil")
+		}
 		return w.inner.ExecuteStreaming(ctx, nil)
 	}
 	req := *input
@@ -78,7 +81,7 @@ func (w *einoStreamingShellWrap) ExecuteStreaming(ctx context.Context, input *fi
 		execCtx, execCancel = context.WithTimeout(ctx, time.Duration(w.toolTimeoutMinutes)*time.Minute)
 	}
 
-	sr, err := w.inner.ExecuteStreaming(execCtx, &req)
+	sr, err := executeManagedStreamingShell(execCtx, &req)
 	if err != nil {
 		if execCancel != nil {
 			execCancel()
@@ -183,4 +186,170 @@ func (w *einoStreamingShellWrap) ExecuteStreaming(ctx context.Context, input *fi
 	}(sr, userCmd, execCancel, execCtx)
 
 	return outR, nil
+}
+
+func executeManagedStreamingShell(ctx context.Context, input *filesystem.ExecuteRequest) (*schema.StreamReader[*filesystem.ExecuteResponse], error) {
+	if input == nil || strings.TrimSpace(input.Command) == "" {
+		return nil, fmt.Errorf("command is required")
+	}
+
+	cmd := managedShellCommand(ctx, input.Command)
+	if err := security.PrepareShellCmdSession(cmd); err != nil {
+		return nil, err
+	}
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create stdout pipe: %w", err)
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		_ = stdout.Close()
+		return nil, fmt.Errorf("failed to create stderr pipe: %w", err)
+	}
+
+	sr, w := schema.Pipe[*filesystem.ExecuteResponse](100)
+	if err := cmd.Start(); err != nil {
+		_ = stdout.Close()
+		_ = stderr.Close()
+		go sendManagedShellError(w, fmt.Errorf("failed to start command: %w", err))
+		return sr, nil
+	}
+
+	if input.RunInBackendGround {
+		runManagedShellInBackground(ctx, cmd, stdout, stderr, w)
+		return sr, nil
+	}
+
+	go streamManagedShellOutput(ctx, cmd, stdout, stderr, w)
+	return sr, nil
+}
+
+func managedShellCommand(ctx context.Context, command string) *exec.Cmd {
+	if runtime.GOOS == "windows" {
+		return exec.CommandContext(ctx, "cmd", "/C", command)
+	}
+	return exec.CommandContext(ctx, "/bin/sh", "-c", command)
+}
+
+func sendManagedShellError(w *schema.StreamWriter[*filesystem.ExecuteResponse], err error) {
+	defer w.Close()
+	w.Send(nil, err)
+}
+
+func runManagedShellInBackground(ctx context.Context, cmd *exec.Cmd, stdout, stderr io.ReadCloser, w *schema.StreamWriter[*filesystem.ExecuteResponse]) {
+	go func() {
+		defer func() {
+			_ = stdout.Close()
+			_ = stderr.Close()
+		}()
+
+		done := make(chan struct{})
+		go func() {
+			drainReaders(stdout, stderr)
+			_ = cmd.Wait()
+			close(done)
+		}()
+
+		select {
+		case <-ctx.Done():
+			security.TerminateCmdTree(cmd)
+		case <-done:
+		}
+	}()
+
+	go func() {
+		defer w.Close()
+		exitCode := 0
+		w.Send(&filesystem.ExecuteResponse{Output: "command started in background\n", ExitCode: &exitCode}, nil)
+	}()
+}
+
+func streamManagedShellOutput(ctx context.Context, cmd *exec.Cmd, stdout, stderr io.ReadCloser, w *schema.StreamWriter[*filesystem.ExecuteResponse]) {
+	defer w.Close()
+	defer func() {
+		_ = stdout.Close()
+		_ = stderr.Close()
+	}()
+
+	stopWatch := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			security.TerminateCmdTree(cmd)
+		case <-stopWatch:
+		}
+	}()
+	defer close(stopWatch)
+
+	chunks := make(chan string, 64)
+	var wg sync.WaitGroup
+	readFn := func(r io.Reader) {
+		defer wg.Done()
+		buf := make([]byte, 8192)
+		for {
+			n, readErr := r.Read(buf)
+			if n > 0 {
+				chunks <- string(buf[:n])
+			}
+			if readErr != nil {
+				return
+			}
+		}
+	}
+	wg.Add(2)
+	go readFn(stdout)
+	go readFn(stderr)
+
+	go func() {
+		wg.Wait()
+		close(chunks)
+	}()
+
+	hasOutput := false
+	for chunk := range chunks {
+		hasOutput = true
+		if w.Send(&filesystem.ExecuteResponse{Output: chunk}, nil) {
+			security.TerminateCmdTree(cmd)
+			return
+		}
+	}
+
+	waitErr := cmd.Wait()
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		w.Send(nil, ctxErr)
+		return
+	}
+	if waitErr != nil {
+		var exitErr *exec.ExitError
+		if errors.As(waitErr, &exitErr) {
+			exitCode := exitErr.ExitCode()
+			w.Send(&filesystem.ExecuteResponse{
+				Output:   fmt.Sprintf("command exited with non-zero code %d", exitCode),
+				ExitCode: &exitCode,
+			}, nil)
+			return
+		}
+		w.Send(nil, fmt.Errorf("command failed: %w", waitErr))
+		return
+	}
+	if !hasOutput {
+		exitCode := 0
+		w.Send(&filesystem.ExecuteResponse{ExitCode: &exitCode}, nil)
+	}
+}
+
+func drainReaders(readers ...io.Reader) {
+	var wg sync.WaitGroup
+	for _, r := range readers {
+		if r == nil {
+			continue
+		}
+		wg.Add(1)
+		go func(reader io.Reader) {
+			defer wg.Done()
+			_, _ = io.Copy(io.Discard, reader)
+		}(r)
+	}
+	wg.Wait()
 }

--- a/internal/security/process_tree.go
+++ b/internal/security/process_tree.go
@@ -1,0 +1,14 @@
+package security
+
+import "os/exec"
+
+// PrepareShellCmdSession prepares a command so TerminateCmdTree can stop its
+// descendant processes as a group on platforms that support it.
+func PrepareShellCmdSession(cmd *exec.Cmd) error {
+	return prepareShellCmdSession(cmd)
+}
+
+// TerminateCmdTree best-effort terminates cmd and child processes spawned by it.
+func TerminateCmdTree(cmd *exec.Cmd) {
+	terminateCmdTree(cmd)
+}

--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -12179,6 +12179,12 @@ tr.mcp-stats-tool-row[data-tool-name]:focus-visible {
     border: 1px solid rgba(0, 123, 255, 0.3);
 }
 
+.batch-queue-status-pausing {
+    background: rgba(255, 193, 7, 0.12);
+    color: #9a6a00;
+    border: 1px solid rgba(255, 193, 7, 0.45);
+}
+
 .batch-queue-cron-active {
     box-shadow: 0 0 0 1px rgba(0, 123, 255, 0.15);
 }

--- a/web/static/i18n/en-US.json
+++ b/web/static/i18n/en-US.json
@@ -670,6 +670,7 @@
     "retryTask": "Retry",
     "conversationIdLabel": "Conversation ID",
     "statusPending": "Pending",
+    "statusPausing": "Stopping...",
     "statusPaused": "Paused",
     "statusCronCycleIdle": "Round done · scheduled loop",
     "statusCronRunning": "Running · cron queue",
@@ -1858,6 +1859,7 @@
   "tasksPage": {
     "statusFilter": "Status filter",
     "statusPending": "Pending",
+    "statusPausing": "Stopping",
     "statusPaused": "Paused",
     "statusCancelled": "Cancelled",
     "searchQueuePlaceholder": "Search queue ID, title or created time",

--- a/web/static/i18n/zh-CN.json
+++ b/web/static/i18n/zh-CN.json
@@ -658,6 +658,7 @@
     "retryTask": "重试",
     "conversationIdLabel": "对话ID",
     "statusPending": "待执行",
+    "statusPausing": "正在停止...",
     "statusPaused": "已暂停",
     "statusCronCycleIdle": "本轮已完成 · 定时循环中",
     "statusCronRunning": "执行中 · 定时队列",
@@ -1846,6 +1847,7 @@
   "tasksPage": {
     "statusFilter": "状态筛选",
     "statusPending": "待执行",
+    "statusPausing": "正在停止",
     "statusPaused": "已暂停",
     "statusCancelled": "已取消",
     "searchQueuePlaceholder": "搜索队列ID、标题或创建时间",

--- a/web/static/js/tasks.js
+++ b/web/static/js/tasks.js
@@ -36,6 +36,7 @@ function getBatchQueueStatusPresentation(queue) {
     const map = {
         pending: { text: _t('tasks.statusPending'), class: 'batch-queue-status-pending' },
         running: { text: _t('tasks.statusRunning'), class: 'batch-queue-status-running' },
+        pausing: { text: _t('tasks.statusPausing'), class: 'batch-queue-status-pausing' },
         paused: { text: _t('tasks.statusPaused'), class: 'batch-queue-status-paused' },
         completed: { text: _t('tasks.statusCompleted'), class: 'batch-queue-status-completed' },
         cancelled: { text: _t('tasks.statusCancelled'), class: 'batch-queue-status-cancelled' }
@@ -77,7 +78,7 @@ function getBatchQueueStatusPresentation(queue) {
 /** 队列是否处于「可改子任务列表/文案」的空闲态（与后端 batch_task_manager.queueAllowsTaskListMutationLocked 对齐） */
 function batchQueueAllowsSubtaskMutation(queue) {
     if (!queue) return false;
-    if (queue.status === 'running') return false;
+    if (queue.status === 'running' || queue.status === 'pausing') return false;
     const hasRunningSubtask = Array.isArray(queue.tasks) && queue.tasks.some(t => t && t.status === 'running');
     if (hasRunningSubtask) return false;
     return queue.status === 'pending' || queue.status === 'paused' || queue.status === 'completed' || queue.status === 'cancelled';
@@ -803,7 +804,7 @@ const batchQueuesState = {
     currentQueueId: null,
     refreshInterval: null,
     // 筛选和分页状态
-    filterStatus: 'all', // 'all', 'pending', 'running', 'paused', 'completed', 'cancelled'
+    filterStatus: 'all', // 'all', 'pending', 'running', 'pausing', 'paused', 'completed', 'cancelled'
     searchKeyword: '',
     currentPage: 1,
     pageSize: 10,
@@ -1384,7 +1385,7 @@ async function showBatchQueueDetail(queueId) {
             addTaskBtn.style.display = allowSubtaskMutation ? 'inline-block' : 'none';
         }
         if (startBtn) {
-            // pending状态显示"开始执行"，paused状态显示"继续执行"
+            // pending状态显示"开始执行"，paused状态显示"继续执行"；pausing 等待当前子任务停止
             startBtn.style.display = (queue.status === 'pending' || queue.status === 'paused') ? 'inline-block' : 'none';
             if (startBtn && queue.status === 'paused') {
                 startBtn.textContent = _t('tasks.resumeExecute');
@@ -1401,7 +1402,7 @@ async function showBatchQueueDetail(queueId) {
             rerunBtn.style.display = (queue.status === 'completed' || queue.status === 'cancelled') ? 'inline-block' : 'none';
         }
         if (pauseBtn) {
-            // running状态显示"暂停队列"
+            // running状态显示"暂停队列"；pausing 已在停止中
             pauseBtn.style.display = queue.status === 'running' ? 'inline-block' : 'none';
         }
         if (deleteBtn) {

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -1994,6 +1994,7 @@
                                         <option value="all" data-i18n="knowledgePage.all">全部</option>
                                         <option value="pending" data-i18n="tasksPage.statusPending">待执行</option>
                                         <option value="running" data-i18n="dashboard.executing">执行中</option>
+                                        <option value="pausing" data-i18n="tasksPage.statusPausing">正在停止</option>
                                         <option value="paused" data-i18n="tasksPage.statusPaused">已暂停</option>
                                         <option value="completed" data-i18n="dashboard.completed">已完成</option>
                                         <option value="cancelled" data-i18n="tasksPage.statusCancelled">已取消</option>


### PR DESCRIPTION
## Summary
- repair batch queues/tasks left in `running` after a server restart by failing the interrupted child task and moving the queue to `paused` or `completed`
- repair manual agent assistant placeholders left as `处理中...` after restart by marking them failed and writing one idempotent `error` process detail
- add database tests for batch restart repair, manual placeholder repair, and idempotency

## Testing
- `go test ./internal/database`
- `go test ./internal/handler`

## Notes
- This PR is based on upstream `main` and only includes the two task restart-state fixes.