### PR TITLE
fix(multiagent): guard MCPExecutionBinder map with RWMutex (concurrent tool callback race)

### DIFF
--- a/internal/multiagent/mcp_execution_binder.go
+++ b/internal/multiagent/mcp_execution_binder.go
@@ -1,9 +1,13 @@
 package multiagent
 
-import "strings"
+import (
+	"strings"
+	"sync"
+)
 
 // MCPExecutionBinder maps ADK toolCallID → MCP monitor execution ID for a single agent run.
 type MCPExecutionBinder struct {
+	mu         sync.RWMutex
 	byToolCall map[string]string
 }
 
@@ -20,12 +24,17 @@ func (b *MCPExecutionBinder) Bind(toolCallID, executionID string) {
 	if tid == "" || eid == "" {
 		return
 	}
+	b.mu.Lock()
 	b.byToolCall[tid] = eid
+	b.mu.Unlock()
 }
 
 func (b *MCPExecutionBinder) ExecutionID(toolCallID string) string {
 	if b == nil {
 		return ""
 	}
-	return b.byToolCall[strings.TrimSpace(toolCallID)]
+	tid := strings.TrimSpace(toolCallID)
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return b.byToolCall[tid]
 }


### PR DESCRIPTION
## Bug

`internal/multiagent.MCPExecutionBinder` 用一个裸 `map[string]string` 持久化
`toolCallID -> executionID` 映射，而 `Bind/ExecutionID` 在 eino_adk_run_loop
的工具回调、与 MCP 监控 goroutine 中是**并发**触发的。上游已经存在
`TestMCPExecutionBinder_ConcurrentBind`，注释也明示「回归并行 tool 回调
不得 concurrent map panic」，但当前实现在 `-race` 下百分百 panic。

## Repro

```bash
go test -race -run MCPExecutionBinder ./internal/multiagent/...
# 上游当前实现: FAIL — fatal error: concurrent map read and map write
```

## Fix

把 `map` 用 `sync.RWMutex` 保护起来：
- `Bind` 写锁
- `ExecutionID` 读锁
- `strings.TrimSpace` 移出临界区（廉价，但保持惯用法）

行为对齐原作者给出的版本：

```go
type MCPExecutionBinder struct {
    mu         sync.RWMutex
    byToolCall map[string]string
}
```

## Verification

```
$ go vet ./internal/multiagent/...
$ go test -race -run MCPExecutionBinder ./internal/multiagent/... -count=1 -v
=== RUN   TestMCPExecutionBinder
--- PASS: TestMCPExecutionBinder (0.00s)
=== RUN   TestMCPExecutionBinder_ConcurrentBind
--- PASS: TestMCPExecutionBinder_ConcurrentBind (0.00s)
PASS
ok      cyberstrike-ai/internal/multiagent      1.979s
```

## Scope

仅改 `internal/multiagent/mcp_execution_binder.go` 一个文件，11 insertions, 2 deletions。
未触碰上游的 `_test.go`（其语义已与新实装一致），也未改公开 API。
