### PR TITLE
fix: 修复 KnowledgeHandler 方法调用错误

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1071,7 +1071,7 @@ func setupRoutes(
 					})
 					return
 				}
-				app.knowledgeHandler.RebuildIndex(c)
+				app.knowledgeHandler.StartIndex(c)
 			})
 			knowledgeRoutes.POST("/scan", func(c *gin.Context) {
 				if app.knowledgeHandler == nil {


### PR DESCRIPTION
## 问题背景
我在使用`run.sh`脚本构建时报错
```ℹ️  Build error details:
    # cyberstrike-ai/internal/app
    internal/app/app.go:1074:26: app.knowledgeHandler.RebuildIndex undefined (type *"cyberstrike-ai/internal/handler".KnowledgeHandler has no field or method RebuildIndex)
```
## 问题描述

在最近的提交（62fafbf）中，`KnowledgeHandler.RebuildIndex` 方法被重命名为 `StartIndex`，但 `internal/app/app.go` 中的调用点未同步更新，导致编译失败。

## 修复内容

- 将 `app.go:1074` 中的 `RebuildIndex(c)` 调用改为 `StartIndex(c)`
- 修复后可正常编译运行

## 编译错误信息

cyberstrike-ai/internal/app

internal/app/app.go:1074:26: app.knowledgeHandler.RebuildIndex undefined
(type *"cyberstrike-ai/internal/handler".KnowledgeHandler has no field or method RebuildIndex)

## 相关变更

在提交 62fafbf 中，`internal/handler/knowledge.go` 的变更：
- ❌ 移除：`RebuildIndex` 方法
- ✅ 新增：`StartIndex` 方法（支持 `mode=missing|full` 参数）

## 测试

- [x] 编译通过
- [x] 方法签名匹配
- [x] 路由调用正确

## 影响范围

仅影响 `/api/knowledge/index` 端点的后端调用，不涉及功能变更。