### PR TITLE
fix(project): 允许 fact_key 驼峰命名并澄清未绑定项目授权报错 (#200)

### DIFF
--- a/internal/app/mcp_authorization.go
+++ b/internal/app/mcp_authorization.go
@@ -382,7 +382,13 @@ func authorizeProjectTool(ctx context.Context, principal authctx.Principal, db *
 		return fmt.Errorf("no access to conversation %s", conversationID)
 	}
 	projectID, err := db.GetConversationProjectID(conversationID)
-	if err != nil || strings.TrimSpace(projectID) == "" || !db.UserCanAccessResource(principal.UserID, principal.ScopeFor(permission), "project", projectID) {
+	if err != nil {
+		return fmt.Errorf("no access to project: %w", err)
+	}
+	if strings.TrimSpace(projectID) == "" {
+		return fmt.Errorf("当前对话未绑定项目，无法使用项目黑板工具，请先在对话中选择项目或创建带项目的对话")
+	}
+	if !db.UserCanAccessResource(principal.UserID, principal.ScopeFor(permission), "project", projectID) {
 		return fmt.Errorf("no access to project %s", projectID)
 	}
 	return nil

--- a/internal/database/project.go
+++ b/internal/database/project.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/uuid"
 )
 
-var factKeyPattern = regexp.MustCompile(`^[a-z0-9][a-z0-9._/-]*$`)
+var factKeyPattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._/-]*$`)
 
 // ValidateFactKey 校验事实 key（项目内唯一标识）。
 func ValidateFactKey(key string) error {
@@ -22,7 +22,7 @@ func ValidateFactKey(key string) error {
 		return fmt.Errorf("fact_key 过长（最多 128 字符）")
 	}
 	if !factKeyPattern.MatchString(key) {
-		return fmt.Errorf("fact_key 格式无效，仅允许小写字母、数字及 . _ / -，且须以小写字母或数字开头")
+		return fmt.Errorf("fact_key 格式无效，仅允许字母、数字及 . _ / -，且须以字母或数字开头（支持驼峰命名）")
 	}
 	return nil
 }

--- a/internal/project/fact_body_links.go
+++ b/internal/project/fact_body_links.go
@@ -9,8 +9,8 @@ import (
 )
 
 var (
-	bodyDepFactLine   = regexp.MustCompile(`(?im)^[\s\-*]*依赖事实\s*[:：]\s*([a-z0-9][a-z0-9._/-]*)`)
-	bodyRelFactLine   = regexp.MustCompile(`(?im)^[\s\-*]*相关\s*fact_key\s*[:：]\s*([a-z0-9][a-z0-9._/-]*)`)
+	bodyDepFactLine   = regexp.MustCompile(`(?im)^[\s\-*]*依赖事实\s*[:：]\s*([a-zA-Z0-9][a-zA-Z0-9._/-]*)`)
+	bodyRelFactLine   = regexp.MustCompile(`(?im)^[\s\-*]*相关\s*fact_key\s*[:：]\s*([a-zA-Z0-9][a-zA-Z0-9._/-]*)`)
 	bodyAssocSection  = regexp.MustCompile(`(?im)^##\s*关联\s*$`)
 	bodySyncLinksHead = "结构化关系边（自动同步）"
 )


### PR DESCRIPTION
## 背景（Closes #200）
`upsert_project_fact` 存在两个问题：
1. `fact_key` 含大写字母（驼峰，如 `finding/info-disclosure-messageBundle`）被拒，AI 反复重试浪费 token。
2. 报错 `tool authorization denied: no access to project`（projectID 为空）含义不清、有误导性。

## 改动
### 1. fact_key 支持驼峰命名
- `internal/database/project.go`：校验正则 `^[a-z0-9][a-z0-9._/-]*$` → `^[a-zA-Z0-9][a-zA-Z0-9._/-]*$`，并更新错误提示。
- `internal/project/fact_body_links.go`：body 中「依赖事实 / 相关 fact_key」两个解析正则同步放开大写，避免驼峰 key 被截断解析。
- 已核实：`fact_key` 在存储/查找/图节点 ID/关系边引用中始终保持原始大小写且一致；`ToLower` 仅用于按前缀（如 `finding/`）分类/排序，不影响存储与查找，放开大写不破坏黑板图/边系统。

### 2. 澄清未绑定项目的授权报错
- `internal/app/mcp_authorization.go`：`authorizeProjectTool` 将「查询出错 / 未绑定项目 / 真实无权限」三种情况分开。未绑定项目时返回明确可执行提示，真实无权限仍保留 `no access to project <id>`。
- 根因：conversation 未绑定 project（发起对话未传 projectID 且 `config.Project.DefaultProjectID` 为空），并非多代理会话 ID 传播问题。

## 验证
- `go build ./...` 通过
- `go test ./internal/project/... ./internal/database/... ./internal/app/...` 全部通过