### PR TITLE
fix(vulnerability): 记录漏洞前按项目/会话范围自动去重 (#178)

### DIFF
--- a/internal/app/vulnerability_tools.go
+++ b/internal/app/vulnerability_tools.go
@@ -201,7 +201,7 @@ func registerVulnerabilityTools(mcpServer *mcp.Server, db *database.DB, logger *
 func registerRecordVulnerabilityTool(mcpServer *mcp.Server, db *database.DB, logger *zap.Logger) {
 	tool := mcp.Tool{
 		Name:             builtin.ToolRecordVulnerability,
-		Description:      "记录发现的漏洞详情到漏洞管理系统。必须按“仅看本记录即可复现”的标准填写：目标、漏洞类型、触发点、复现步骤、证据/POC、实际影响和修复建议；前置条件与复测方式为推荐填写项。边渗透边记录：每验证出一条可复现漏洞后立即调用，勿等会话结束。记录前可先 list_vulnerabilities 避免重复。",
+		Description:      "记录发现的漏洞详情到漏洞管理系统。必须按“仅看本记录即可复现”的标准填写：目标、漏洞类型、触发点、复现步骤、证据/POC、实际影响和修复建议；前置条件与复测方式为推荐填写项。边渗透边记录：每验证出一条可复现漏洞后立即调用，勿等会话结束。系统会在当前项目/会话范围内按“目标+类型+标题”自动去重：若已存在相同且未闭环的漏洞将跳过并返回已有记录，无需重复记录。",
 		ShortDescription: "记录可复现的漏洞详情到漏洞管理系统",
 		InputSchema: map[string]interface{}{
 			"type": "object",
@@ -290,6 +290,33 @@ func registerRecordVulnerabilityTool(mcpServer *mcp.Server, db *database.DB, log
 			projectID = strings.TrimSpace(pid)
 		}
 
+		target := strings.TrimSpace(strArg(args, "target"))
+		vulnType := strings.TrimSpace(strArg(args, "vulnerability_type"))
+		scopeDesc := "当前会话"
+		if projectID != "" {
+			scopeDesc = "当前项目"
+		}
+
+		// 记录前去重：同一范围（项目优先，否则会话）内已存在相同且未闭环的漏洞时跳过创建，
+		// 避免多会话/重复扫描或 AI 重复挖掘同一路径产生大量重复条目。
+		dup, related, derr := db.FindDuplicateVulnerability(projectID, conversationID, target, vulnType, title)
+		if derr != nil {
+			if logger != nil {
+				logger.Warn("漏洞去重检查失败，按正常流程创建", zap.Error(derr))
+			}
+		} else if dup != nil {
+			if logger != nil {
+				logger.Info("record_vulnerability 命中重复漏洞，已跳过创建",
+					zap.String("existing_id", dup.ID),
+					zap.String("conversation_id", conversationID),
+					zap.String("project_id", projectID),
+				)
+			}
+			return textResult(fmt.Sprintf(
+				"检测到重复漏洞，已跳过记录（%s内已存在相同且未闭环的漏洞）。\n\n已存在漏洞ID: %s\n标题: %s\n严重程度: %s\n状态: %s\n\n若本次有新证据需补充，请先 get_vulnerability(%s) 查看后再更新该条；若确为不同问题，请调整 title/target/vulnerability_type 使其可区分后重试。",
+				scopeDesc, dup.ID, dup.Title, dup.Severity, dup.Status, dup.ID), false), nil
+		}
+
 		vuln := &database.Vulnerability{
 			ConversationID: conversationID,
 			ProjectID:      projectID,
@@ -297,8 +324,8 @@ func registerRecordVulnerabilityTool(mcpServer *mcp.Server, db *database.DB, log
 			Description:    strArg(args, "description"),
 			Severity:       severity,
 			Status:         "open",
-			Type:           strArg(args, "vulnerability_type"),
-			Target:         strArg(args, "target"),
+			Type:           vulnType,
+			Target:         target,
 			Preconditions:  strArg(args, "preconditions"),
 			ReproSteps:     strArg(args, "reproduction_steps"),
 			Evidence:       strArg(args, "evidence"),
@@ -329,9 +356,25 @@ func registerRecordVulnerabilityTool(mcpServer *mcp.Server, db *database.DB, log
 			)
 		}
 
-		return textResult(fmt.Sprintf("漏洞已成功记录！\n\n漏洞ID: %s\n标题: %s\n严重程度: %s\n状态: %s\n\n可使用 get_vulnerability(id) 查看详情，或 list_vulnerabilities 查看列表。",
-			created.ID, created.Title, created.Severity, created.Status), false), nil
+		return textResult(fmt.Sprintf("漏洞已成功记录！\n\n漏洞ID: %s\n标题: %s\n严重程度: %s\n状态: %s\n\n可使用 get_vulnerability(id) 查看详情，或 list_vulnerabilities 查看列表。%s",
+			created.ID, created.Title, created.Severity, created.Status, formatRelatedVulnHint(scopeDesc, related)), false), nil
 	})
+}
+
+// formatRelatedVulnHint 将“同目标+类型、但标题不同或已闭环”的关联漏洞拼成提示，促使 AI 自行判断是否属于同一问题以减少重复。无关联项时返回空串。
+func formatRelatedVulnHint(scopeDesc string, related []*database.VulnerabilityDedupMatch) string {
+	if len(related) == 0 {
+		return ""
+	}
+	ids := make([]string, 0, 3)
+	for _, r := range related {
+		if len(ids) >= 3 {
+			break
+		}
+		ids = append(ids, r.ID)
+	}
+	return fmt.Sprintf("\n\n提示：%s内已有 %d 条相同目标+类型的漏洞（如 %s）。若与本条实为同一问题，请考虑合并去重；若确为不同问题可忽略本提示。",
+		scopeDesc, len(related), strings.Join(ids, "、"))
 }
 
 func registerListVulnerabilitiesTool(mcpServer *mcp.Server, db *database.DB, logger *zap.Logger) {

--- a/internal/database/vulnerability.go
+++ b/internal/database/vulnerability.go
@@ -35,6 +35,25 @@ func escapeVulnerabilityLikePattern(s string) string {
 	return "%" + s + "%"
 }
 
+// normalizeVulnSignatureField 归一化用于漏洞去重比对的字段：
+// 去首尾空白、把内部连续空白折叠为单个空格、统一转小写。
+// 使机器多次产出的“同一漏洞”（大小写/空白差异）能被判定为重复。
+func normalizeVulnSignatureField(s string) string {
+	return strings.ToLower(strings.Join(strings.Fields(s), " "))
+}
+
+// vulnStatusIsActive 判断漏洞状态是否为“未闭环”（open/confirmed）。
+// 只有未闭环的同一漏洞才视为真正的重复；已修复/误报/忽略的同名漏洞再次出现
+// 可能是回归或重新确认，允许重新记录，仅作为关联项提示。
+func vulnStatusIsActive(status string) bool {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "open", "confirmed", "":
+		return true
+	default:
+		return false
+	}
+}
+
 func (f VulnerabilityListFilter) appendWhere(query string, args []interface{}) (string, []interface{}) {
 	if f.ID != "" {
 		query += " AND id = ?"
@@ -192,6 +211,94 @@ func (db *DB) CreateVulnerability(vuln *Vulnerability) (*Vulnerability, error) {
 		return nil, fmt.Errorf("创建漏洞失败: %w", err)
 	}
 	return vuln, nil
+}
+
+// VulnerabilityDedupMatch 去重比对命中的精简漏洞信息。
+type VulnerabilityDedupMatch struct {
+	ID       string
+	Title    string
+	Severity string
+	Status   string
+	Type     string
+	Target   string
+}
+
+// FindDuplicateVulnerability 在同一范围内查找重复漏洞，用于 record_vulnerability 记录前去重。
+// 范围规则：绑定项目时按 project_id，否则按 conversation_id（跨会话重复主要发生在同一项目下）。
+// 返回值：
+//   - dup：target+vulnerability_type+title 归一化后完全一致、且状态仍未闭环（open/confirmed）的漏洞，
+//     视为真正的重复，调用方应跳过创建；无匹配时为 nil。
+//   - related：目标+类型相同但标题不同、或已闭环（fixed/false_positive/ignored）的同名漏洞，
+//     作为“可能近似重复/可能回归”的提示返回，不阻止创建。
+//
+// 本方法只读，不修改任何数据。
+func (db *DB) FindDuplicateVulnerability(projectID, conversationID, target, vulnType, title string) (*VulnerabilityDedupMatch, []*VulnerabilityDedupMatch, error) {
+	projectID = strings.TrimSpace(projectID)
+	conversationID = strings.TrimSpace(conversationID)
+
+	// 无目标无法可靠去重，交由调用方正常创建。
+	looseTarget := strings.ToLower(strings.TrimSpace(target))
+	if looseTarget == "" {
+		return nil, nil, nil
+	}
+
+	// 先用 SQL 按范围 + 归一化目标粗筛，再在 Go 中做完整归一化精确比对，兼容历史数据（无需迁移/回填）。
+	query := `
+		SELECT id, COALESCE(title,''), COALESCE(severity,''), COALESCE(status,''),
+		       COALESCE(vulnerability_type,''), COALESCE(target,'')
+		FROM vulnerabilities
+		WHERE LOWER(TRIM(COALESCE(target,''))) = ?`
+	args := []interface{}{looseTarget}
+	switch {
+	case projectID != "":
+		query += " AND project_id = ?"
+		args = append(args, projectID)
+	case conversationID != "":
+		query += " AND conversation_id = ?"
+		args = append(args, conversationID)
+	default:
+		return nil, nil, nil
+	}
+	query += " ORDER BY created_at ASC"
+
+	rows, err := db.Query(query, args...)
+	if err != nil {
+		return nil, nil, fmt.Errorf("查询重复漏洞失败: %w", err)
+	}
+	defer rows.Close()
+
+	wantTarget := normalizeVulnSignatureField(target)
+	wantType := normalizeVulnSignatureField(vulnType)
+	wantTitle := normalizeVulnSignatureField(title)
+
+	var dup *VulnerabilityDedupMatch
+	related := make([]*VulnerabilityDedupMatch, 0)
+	for rows.Next() {
+		m := &VulnerabilityDedupMatch{}
+		if err := rows.Scan(&m.ID, &m.Title, &m.Severity, &m.Status, &m.Type, &m.Target); err != nil {
+			db.logger.Warn("扫描重复漏洞候选失败", zap.Error(err))
+			continue
+		}
+		// 目标/类型必须一致，否则不是同一漏洞。
+		if normalizeVulnSignatureField(m.Target) != wantTarget || normalizeVulnSignatureField(m.Type) != wantType {
+			continue
+		}
+		sameTitle := normalizeVulnSignatureField(m.Title) == wantTitle
+		if sameTitle && vulnStatusIsActive(m.Status) {
+			if dup == nil {
+				dup = m
+			}
+			continue
+		}
+		// 同目标+类型，但标题不同或已闭环：作为关联项提示（最多保留若干条）。
+		if len(related) < 10 {
+			related = append(related, m)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, nil, fmt.Errorf("遍历重复漏洞失败: %w", err)
+	}
+	return dup, related, nil
 }
 
 // GetVulnerability 获取漏洞

--- a/internal/database/vulnerability_dedup_test.go
+++ b/internal/database/vulnerability_dedup_test.go
@@ -1,0 +1,171 @@
+package database
+
+import (
+	"path/filepath"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+// setupDedupDB 创建临时库、一个项目和两个绑定到该项目的会话，用于漏洞去重测试。
+func setupDedupDB(t *testing.T) (db *DB, projectID, convA, convB string) {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "vuln-dedup.db")
+	var err error
+	db, err = NewDB(dbPath, zap.NewNop())
+	if err != nil {
+		t.Fatalf("NewDB: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	proj, err := db.CreateProject(&Project{Name: "dedup-proj"})
+	if err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+	projectID = proj.ID
+
+	for _, name := range []string{"conv-a", "conv-b"} {
+		conv, cerr := db.CreateConversation(name, ConversationCreateMeta{})
+		if cerr != nil {
+			t.Fatalf("CreateConversation(%s): %v", name, cerr)
+		}
+		if serr := db.SetConversationProjectID(conv.ID, projectID); serr != nil {
+			t.Fatalf("SetConversationProjectID(%s): %v", name, serr)
+		}
+		if name == "conv-a" {
+			convA = conv.ID
+		} else {
+			convB = conv.ID
+		}
+	}
+	return db, projectID, convA, convB
+}
+
+// TestFindDuplicateVulnerability_ProjectScope 验证跨会话（同项目）能识别出重复漏洞，
+// 且大小写/空白差异经归一化后仍判定为同一漏洞。
+func TestFindDuplicateVulnerability_ProjectScope(t *testing.T) {
+	db, projectID, convA, convB := setupDedupDB(t)
+
+	created, err := db.CreateVulnerability(&Vulnerability{
+		ConversationID: convA,
+		Title:          "/api/login 存在 SQL 注入",
+		Severity:       "high",
+		Type:           "SQL注入",
+		Target:         "https://x/api/login",
+	})
+	if err != nil {
+		t.Fatalf("CreateVulnerability: %v", err)
+	}
+
+	// 会话 B（同项目）以带大小写与多余空白的等价签名查询，应命中同一漏洞。
+	dup, related, err := db.FindDuplicateVulnerability(projectID, convB,
+		"  HTTPS://X/api/login ", "sql注入", "/api/login   存在  SQL 注入")
+	if err != nil {
+		t.Fatalf("FindDuplicateVulnerability: %v", err)
+	}
+	if dup == nil {
+		t.Fatal("期望命中重复漏洞，实际为 nil")
+	}
+	if dup.ID != created.ID {
+		t.Fatalf("dup.ID = %q, want %q", dup.ID, created.ID)
+	}
+	if len(related) != 0 {
+		t.Fatalf("related 应为空，实际 %d 条", len(related))
+	}
+}
+
+// TestFindDuplicateVulnerability_DifferentTitleIsRelated 验证同目标+类型但标题不同时
+// 不视为重复（保留独立发现），而是作为 related 提示。
+func TestFindDuplicateVulnerability_DifferentTitleIsRelated(t *testing.T) {
+	db, projectID, convA, convB := setupDedupDB(t)
+
+	created, err := db.CreateVulnerability(&Vulnerability{
+		ConversationID: convA,
+		Title:          "/api/login 存在 SQL 注入",
+		Severity:       "high",
+		Type:           "SQL注入",
+		Target:         "https://x/api/login",
+	})
+	if err != nil {
+		t.Fatalf("CreateVulnerability: %v", err)
+	}
+
+	dup, related, err := db.FindDuplicateVulnerability(projectID, convB,
+		"https://x/api/login", "SQL注入", "登录接口注入（另一处参数）")
+	if err != nil {
+		t.Fatalf("FindDuplicateVulnerability: %v", err)
+	}
+	if dup != nil {
+		t.Fatalf("标题不同不应判为重复，实际命中 %q", dup.ID)
+	}
+	if len(related) != 1 || related[0].ID != created.ID {
+		t.Fatalf("期望 1 条 related 指向 %q，实际 %+v", created.ID, related)
+	}
+}
+
+// TestFindDuplicateVulnerability_ResolvedNotDuplicate 验证已闭环（fixed）的同名漏洞
+// 不阻止再次记录（可能是回归），但会作为 related 提示返回。
+func TestFindDuplicateVulnerability_ResolvedNotDuplicate(t *testing.T) {
+	db, projectID, convA, convB := setupDedupDB(t)
+
+	created, err := db.CreateVulnerability(&Vulnerability{
+		ConversationID: convA,
+		Title:          "/api/login 存在 SQL 注入",
+		Severity:       "high",
+		Status:         "fixed",
+		Type:           "SQL注入",
+		Target:         "https://x/api/login",
+	})
+	if err != nil {
+		t.Fatalf("CreateVulnerability: %v", err)
+	}
+
+	dup, related, err := db.FindDuplicateVulnerability(projectID, convB,
+		"https://x/api/login", "SQL注入", "/api/login 存在 SQL 注入")
+	if err != nil {
+		t.Fatalf("FindDuplicateVulnerability: %v", err)
+	}
+	if dup != nil {
+		t.Fatalf("已修复漏洞不应判为重复，实际命中 %q", dup.ID)
+	}
+	if len(related) != 1 || related[0].ID != created.ID {
+		t.Fatalf("期望 1 条 related 指向 %q，实际 %+v", created.ID, related)
+	}
+}
+
+// TestFindDuplicateVulnerability_ScopeIsolation 验证不同项目之间互不去重。
+func TestFindDuplicateVulnerability_ScopeIsolation(t *testing.T) {
+	db, projectID, convA, _ := setupDedupDB(t)
+
+	if _, err := db.CreateVulnerability(&Vulnerability{
+		ConversationID: convA,
+		Title:          "/api/login 存在 SQL 注入",
+		Severity:       "high",
+		Type:           "SQL注入",
+		Target:         "https://x/api/login",
+	}); err != nil {
+		t.Fatalf("CreateVulnerability: %v", err)
+	}
+
+	other, err := db.CreateProject(&Project{Name: "other-proj"})
+	if err != nil {
+		t.Fatalf("CreateProject(other): %v", err)
+	}
+	convC, err := db.CreateConversation("conv-c", ConversationCreateMeta{})
+	if err != nil {
+		t.Fatalf("CreateConversation(conv-c): %v", err)
+	}
+	if err := db.SetConversationProjectID(convC.ID, other.ID); err != nil {
+		t.Fatalf("SetConversationProjectID(conv-c): %v", err)
+	}
+
+	dup, related, err := db.FindDuplicateVulnerability(other.ID, convC.ID,
+		"https://x/api/login", "SQL注入", "/api/login 存在 SQL 注入")
+	if err != nil {
+		t.Fatalf("FindDuplicateVulnerability: %v", err)
+	}
+	if dup != nil || len(related) != 0 {
+		t.Fatalf("跨项目不应命中任何记录，dup=%v related=%d", dup, len(related))
+	}
+	_ = projectID
+}


### PR DESCRIPTION
record_vulnerability 此前无条件插入新记录，工具描述仅"建议"先 list_vulnerabilities， 没有强制去重。多会话/多次扫描同一批目标，或 AI 忘记已挖掘方向、基于相同事实重复挖掘
同一路径时，会产出大量相同漏洞。

- 新增 DB 只读方法 FindDuplicateVulnerability：按 target + 漏洞类型 + 标题 的归一化 签名（转小写、折叠空白），在同一范围（绑定项目时按 project_id，否则按 conversation_id）内查找重复，正好覆盖"跨会话重复"这一主因。
- 状态区分：仅 open/confirmed 视为真正重复并跳过；fixed/false_positive/ignored 的 同名漏洞再次出现可能是回归，允许重新记录，仅作为关联项提示。
- record_vulnerability 记录前去重：命中相同且未闭环漏洞则跳过创建并返回已有记录； 对"同目标+类型但标题不同"的关联项在成功消息中提示 AI 考虑合并。
- 直接查询现有列，无需数据库迁移/回填，对历史数据即时生效；手动 UI 创建路径不受影响。
- 新增 4 个单元测试：跨会话去重+归一化、标题不同不误判、已修复不拦截、跨项目隔离。

Closes #178