### PR TITLE
fix(asset): composite dedup key to prevent false merges

### DIFF
--- a/internal/database/asset.go
+++ b/internal/database/asset.go
@@ -273,14 +273,13 @@ func validAssetDomain(domain string) bool {
 }
 
 func assetDedupKey(a *Asset) string {
-	target := a.Domain
-	if target == "" {
-		target = a.IP
-	}
-	if target == "" {
-		target = strings.ToLower(a.Host)
-	}
-	return strings.Join([]string{target, strconv.Itoa(a.Port), a.Protocol}, "|")
+	return strings.Join([]string{
+		strings.ToLower(a.IP),
+		strings.ToLower(a.Domain),
+		strings.ToLower(a.Host),
+		strconv.Itoa(a.Port),
+		a.Protocol,
+	}, "|")
 }
 
 func appendAssetAccess(query string, args []interface{}, access RBACListAccess, alias string) (string, []interface{}) {

--- a/internal/database/asset.go
+++ b/internal/database/asset.go
@@ -97,7 +97,7 @@ type AssetImportResult struct {
 
 func normalizeAsset(a *Asset) {
 	a.Host = strings.TrimSpace(a.Host)
-	a.IP = strings.ToLower(strings.TrimSpace(a.IP))
+	a.IP = strings.ToLower(strings.Trim(strings.TrimSpace(a.IP), "[]"))
 	a.Domain = strings.ToLower(strings.TrimSpace(a.Domain))
 	a.Protocol = strings.ToLower(strings.TrimSpace(a.Protocol))
 	a.Title = strings.TrimSpace(a.Title)

--- a/internal/database/asset_test.go
+++ b/internal/database/asset_test.go
@@ -490,3 +490,19 @@ func TestAssetDedupCompositeKey(t *testing.T) {
 		t.Fatalf("expected 7 distinct assets, got total=%d err=%v", total, err)
 	}
 }
+
+func TestAssetDedupIPv6BracketNormalization(t *testing.T) {
+	db, err := NewDB(filepath.Join(t.TempDir(), "asset-ipv6-dedup.db"), zap.NewNop())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	// [::1] 和 ::1 应视为同一资产：normalizeAsset 去括号后 dedup key 一致
+	result, err := db.UpsertAssets([]*Asset{
+		{IP: "[::1]", Port: 443, Protocol: "https"},
+		{IP: "::1", Port: 443, Protocol: "https"},
+	}, "", true)
+	if err != nil || result.Created != 1 || result.Updated != 1 {
+		t.Fatalf("bracketed vs bare IPv6 should dedup: result=%#v err=%v", result, err)
+	}
+}

--- a/internal/database/asset_test.go
+++ b/internal/database/asset_test.go
@@ -98,7 +98,7 @@ func TestAssetUpsertDeduplicatesAndUpdates(t *testing.T) {
 	if err != nil || result.Created != 1 || result.Updated != 0 {
 		t.Fatalf("first upsert = %#v, %v", result, err)
 	}
-	second := &Asset{Domain: "example.com", Port: 443, Protocol: "https", Title: "New", Server: "nginx", Source: "fofa"}
+	second := &Asset{Host: "https://example.com", Domain: "example.com", Port: 443, Protocol: "https", Title: "New", Server: "nginx", Source: "fofa"}
 	result, err = db.UpsertAssets([]*Asset{second}, "user-a")
 	if err != nil || result.Created != 0 || result.Updated != 1 {
 		t.Fatalf("second upsert = %#v, %v", result, err)
@@ -445,5 +445,48 @@ func TestAssetListFlexibleFiltersAndOldestScanPagination(t *testing.T) {
 	filtered, total, err := db.ListAssets(20, 0, AssetListFilter{Source: "fofa", Port: &port, LastScanBefore: &recent}, access)
 	if err != nil || total != 1 || len(filtered) != 1 || filtered[0].ID != assets[0].ID {
 		t.Fatalf("structured filters: total=%d assets=%#v err=%v", total, filtered, err)
+	}
+}
+
+func TestAssetDedupCompositeKey(t *testing.T) {
+	db, err := NewDB(filepath.Join(t.TempDir(), "asset-composite-dedup.db"), zap.NewNop())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	// 同 domain 同 port 不同 ip → 两条
+	if _, err := db.UpsertAssets([]*Asset{
+		{IP: "1.1.1.1", Domain: "example.com", Port: 443, Protocol: "https"},
+		{IP: "2.2.2.2", Domain: "example.com", Port: 443, Protocol: "https"},
+	}, "", true); err != nil {
+		t.Fatal(err)
+	}
+	// 同 ip 同 port 不同 domain → 两条（vhost/SNI 保留）
+	if _, err := db.UpsertAssets([]*Asset{
+		{IP: "3.3.3.3", Domain: "app1.example.com", Port: 443, Protocol: "https"},
+		{IP: "3.3.3.3", Domain: "app2.example.com", Port: 443, Protocol: "https"},
+	}, "", true); err != nil {
+		t.Fatal(err)
+	}
+	// 同 ip 同 domain 不同 port → 两条
+	if _, err := db.UpsertAssets([]*Asset{
+		{IP: "4.4.4.4", Domain: "example.com", Port: 80, Protocol: "http"},
+		{IP: "4.4.4.4", Domain: "example.com", Port: 443, Protocol: "https"},
+	}, "", true); err != nil {
+		t.Fatal(err)
+	}
+	// 完全相同 → 合并（created=1, updated=1）
+	result, err := db.UpsertAssets([]*Asset{
+		{IP: "5.5.5.5", Domain: "example.com", Port: 8443, Protocol: "https"},
+		{IP: "5.5.5.5", Domain: "example.com", Port: 8443, Protocol: "https"},
+	}, "", true)
+	if err != nil || result.Created != 1 || result.Updated != 1 {
+		t.Fatalf("identical assets should merge: result=%#v err=%v", result, err)
+	}
+
+	_, total, err := db.ListAssets(100, 0, AssetListFilter{}, RBACListAccess{Scope: RBACScopeAll})
+	if err != nil || total != 7 {
+		t.Fatalf("expected 7 distinct assets, got total=%d err=%v", total, err)
 	}
 }

--- a/web/static/i18n/en-US.json
+++ b/web/static/i18n/en-US.json
@@ -1126,6 +1126,7 @@
     "templateGuideRequired": "Required: target, or at least one of host / ip / domain",
     "templateGuideTarget": "target examples: https://example.com:443, example.com, 1.1.1.1:22",
     "templateGuideProject": "project accepts an existing project name or ID; leave blank for no project",
+    "templateGuideDomain": "domain is the asset's own hostname (e.g. app.example.com), not the root domain; auto-parsed from target if empty",
     "templateGuideTags": "Separate tags with commas; at most 30 tags",
     "templateGuideStatus": "status accepts active / inactive and defaults to active",
     "templateGuideLimit": "Enter data in the Assets sheet; up to 100,000 rows",

--- a/web/static/i18n/en-US.json
+++ b/web/static/i18n/en-US.json
@@ -1126,7 +1126,7 @@
     "templateGuideRequired": "Required: target, or at least one of host / ip / domain",
     "templateGuideTarget": "target examples: https://example.com:443, example.com, 1.1.1.1:22",
     "templateGuideProject": "project accepts an existing project name or ID; leave blank for no project",
-    "templateGuideDomain": "domain is the asset's own hostname (e.g. app.example.com), not the root domain; auto-parsed from target if empty",
+    "templateGuideDomain": "domain accepts a root or sub-domain; auto-parsed from target if empty",
     "templateGuideTags": "Separate tags with commas; at most 30 tags",
     "templateGuideStatus": "status accepts active / inactive and defaults to active",
     "templateGuideLimit": "Enter data in the Assets sheet; up to 100,000 rows",

--- a/web/static/i18n/zh-CN.json
+++ b/web/static/i18n/zh-CN.json
@@ -1114,7 +1114,7 @@
     "templateGuideRequired": "必填：target，或 host / ip / domain 中至少一项",
     "templateGuideTarget": "target 示例：https://example.com:443、example.com、1.1.1.1:22",
     "templateGuideProject": "project 填写系统中已有的项目名称或项目 ID，留空表示不绑定",
-    "templateGuideDomain": "domain 填资产自身域名（如 app.example.com），勿填根域名；留空时从 target 自动解析",
+    "templateGuideDomain": "domain 可填根域名或子域名；留空时从 target 自动解析",
     "templateGuideTags": "tags 使用逗号分隔，最多 30 个",
     "templateGuideStatus": "status 仅支持 active / inactive，留空默认为 active",
     "templateGuideLimit": "请在“Assets”工作表中填写，最多 100000 行",

--- a/web/static/i18n/zh-CN.json
+++ b/web/static/i18n/zh-CN.json
@@ -1114,6 +1114,7 @@
     "templateGuideRequired": "必填：target，或 host / ip / domain 中至少一项",
     "templateGuideTarget": "target 示例：https://example.com:443、example.com、1.1.1.1:22",
     "templateGuideProject": "project 填写系统中已有的项目名称或项目 ID，留空表示不绑定",
+    "templateGuideDomain": "domain 填资产自身域名（如 app.example.com），勿填根域名；留空时从 target 自动解析",
     "templateGuideTags": "tags 使用逗号分隔，最多 30 个",
     "templateGuideStatus": "status 仅支持 active / inactive，留空默认为 active",
     "templateGuideLimit": "请在“Assets”工作表中填写，最多 100000 行",

--- a/web/static/js/assets.js
+++ b/web/static/js/assets.js
@@ -137,6 +137,7 @@ function downloadAssetTemplate(format) {
         [assetT('assets.templateGuideRequired', '必填：target，或 host / ip / domain 中至少一项')],
         [assetT('assets.templateGuideTarget', 'target 示例：https://example.com:443、example.com、1.1.1.1:22')],
         [assetT('assets.templateGuideProject', 'project 填写系统中已有的项目名称或项目 ID，留空表示不绑定')],
+        [assetT('assets.templateGuideDomain', 'domain 填资产自身域名（如 app.example.com），勿填根域名；留空时从 target 自动解析')],
         [assetT('assets.templateGuideTags', 'tags 使用逗号分隔，最多 30 个')],
         [assetT('assets.templateGuideStatus', 'status 仅支持 active / inactive，留空默认为 active')],
         [assetT('assets.templateGuideLimit', '请在“Assets”工作表中填写，最多 100000 行')]
@@ -272,7 +273,7 @@ function parseAssetImportMatrix(matrix, fileName) {
         const parsed = assetImportRecord(values, index + 2);
         if (!parsed.error) {
             const asset = parsed.asset;
-            const key = `${String(asset.domain || asset.ip || asset.host).toLowerCase()}|${asset.port || 0}|${asset.protocol || ''}`;
+            const key = [asset.ip, asset.domain, asset.host, asset.port || 0, asset.protocol || ''].map(v => String(v || '').toLowerCase()).join('|');
             if (seen.has(key)) parsed.error = assetT('assets.duplicateFileRow', `与第 ${seen.get(key)} 行重复`, { row: seen.get(key) });
             else seen.set(key, parsed.rowNumber);
         }
@@ -322,7 +323,7 @@ function assetImportRecord(values, rowNumber) {
     const tags = String(values.tags || '').split(/[,，;；|]/).map(tag => tag.trim()).filter(Boolean);
     if (tags.length > 30 || tags.some(tag => Array.from(tag).length > 64)) return fail(assetT('assets.importTagsInvalid', '标签最多 30 个，单个标签最多 64 个字符'));
     const asset = {
-        host: values.host || parsed.host || '', ip, domain, port, protocol,
+        host: values.host || parsed.host || target || '', ip, domain, port, protocol,
         title: values.title || '', server: values.server || '', country: values.country || '',
         province: values.province || '', city: values.city || '', responsible_person: values.responsible_person || '',
         department: values.department || '', business_system: values.business_system || '', environment, criticality, status, tags,

--- a/web/static/js/assets.js
+++ b/web/static/js/assets.js
@@ -137,7 +137,7 @@ function downloadAssetTemplate(format) {
         [assetT('assets.templateGuideRequired', '必填：target，或 host / ip / domain 中至少一项')],
         [assetT('assets.templateGuideTarget', 'target 示例：https://example.com:443、example.com、1.1.1.1:22')],
         [assetT('assets.templateGuideProject', 'project 填写系统中已有的项目名称或项目 ID，留空表示不绑定')],
-        [assetT('assets.templateGuideDomain', 'domain 填资产自身域名（如 app.example.com），勿填根域名；留空时从 target 自动解析')],
+        [assetT('assets.templateGuideDomain', 'domain 可填根域名或子域名；留空时从 target 自动解析')],
         [assetT('assets.templateGuideTags', 'tags 使用逗号分隔，最多 30 个')],
         [assetT('assets.templateGuideStatus', 'status 仅支持 active / inactive，留空默认为 active')],
         [assetT('assets.templateGuideLimit', '请在“Assets”工作表中填写，最多 100000 行')]


### PR DESCRIPTION
## Problem

Batch asset import incorrectly merges distinct assets when the `domain` column holds a root domain (as exported by recon platforms like FOFA/Hunter/Quake).

Reproduction: importing an xlsx where each row is a distinct `subdomain:port` / IP, but `domain` is uniformly a root domain (e.g. `jdl.com`). The preview reports most rows as duplicates; on upsert the backend merges them into a few records, losing data.

## Root cause

The dedup key used a single target with **domain priority**: `domain ‖ ip ‖ host | port | protocol`. When `domain` is a coarse root domain, all rows sharing root domain + port + protocol collapse into one key → false merge.

## Fix

- `assetDedupKey`: composite key `ip + domain + host + port + protocol` — any differing field yields a distinct asset.
- `assets.js:275`: import preview dedup uses the same composite key.
- `assets.js:325`: backfill `host` from the target string when empty, so imports without a `host` column (and targets without a scheme) still populate `host` and remain distinguishable (covers reverse-proxy/vhost and root-domain exports).
- `normalizeAsset`: strip IPv6 brackets from `ip` so `[::1]` and `::1` produce the same dedup key (validation already accepted both forms via `strings.Trim(ip,"[]")`).
- template guide + i18n: note `domain` accepts root or sub-domain, auto-parsed from target if empty.

## Why composite over ip-priority

An ip-priority single-target key would merge reverse-proxy/vhost assets (same IP:port, different domains). The composite key does not falsely merge in any explicit scenario:

| scenario (same port/protocol) | composite key |
|---|---|
| different IP, same domain (root) | not merged ✓ |
| same IP, different domain (vhost) | not merged ✓ |
| same IP+domain, different port | not merged ✓ |
| all fields identical | merged ✓ |

## Breaking change / migration

`assets.dedup_key` is a `UNIQUE` persisted column. This PR changes the key format from `single-target|port|protocol` to `ip|domain|host|port|protocol`. Existing rows keep the legacy key, so after deploy `UpsertAssets` will not match them and may create duplicates until a one-time backfill rewrites the keys:

```sql
ALTER TABLE assets ADD COLUMN new_dedup_key TEXT NOT NULL DEFAULT '';
UPDATE assets SET new_dedup_key =
  LOWER(TRIM(ip,'[]')) || '|' || LOWER(domain) || '|' || LOWER(host) || '|' || port || '|' || protocol;
-- inspect collisions (dedup_key is UNIQUE):
-- SELECT new_dedup_key, COUNT(*) FROM assets GROUP BY new_dedup_key HAVING COUNT(*)>1;
-- resolve collisions: keep newest updated_at, migrate rbac_resource_assignments(resource_type='asset'), then:
UPDATE assets SET dedup_key = new_dedup_key;
ALTER TABLE assets DROP COLUMN new_dedup_key;  -- SQLite 3.35+
```

A Go migration helper can be added if maintainers prefer it over raw SQL.

## Tests

- Updated `TestAssetUpsertDeduplicatesAndUpdates` (both records carry the same `host`).
- Added `TestAssetDedupCompositeKey` (same-domain/diff-IP, same-IP/diff-domain, diff-port, identical-merge).
- Added `TestAssetDedupIPv6BracketNormalization` (`[::1]` vs `::1` dedup).
